### PR TITLE
feat(ink): surface detailed workflow progress

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,6 +99,7 @@ venv.bak/
 
 # Project specific
 .serena/
+.worktrees/
 test-
 .kcmt/last_run.json
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install install-dev format ruff-fix lint test test-verbose test-strict coverage check typecheck clean clean-build clean-cache clean-pyc clean-test build version bump-patch bump-minor bump-major release release-test dev-setup dev-check quick-patch quick-minor quick-major
+.PHONY: help install install-dev format ruff-fix lint test test-ink test-verbose test-strict coverage check typecheck clean clean-build clean-cache clean-pyc clean-test build version bump-patch bump-minor bump-major release release-test dev-setup dev-check quick-patch quick-minor quick-major
 # Default target
 help:
 	@echo "Available targets:"
@@ -68,6 +68,9 @@ ruff-fix:
 test:
 	$(PYTEST) -q
 
+test-ink:
+	npm --prefix kcmt/ui/ink test
+
 test-verbose:
 	$(PYTEST) -v
 
@@ -83,7 +86,7 @@ typecheck:
 	$(UV) run mypy ./$(PACKAGE_NAME)
 
 # All checks
-check: ruff-fix format lint typecheck test-strict
+check: ruff-fix format lint typecheck test-strict test-ink
 	@echo "All checks passed!"
 
 # Cleaning

--- a/kcmt/ink_backend.py
+++ b/kcmt/ink_backend.py
@@ -273,7 +273,7 @@ class InkWorkflow(KlingonCMTWorkflow):
         self._emitter = emitter
         # Maintain a compact per-file state map for the Ink UI without printing
         # to stdout. Keys mirror the legacy renderer but avoid terminal output.
-        self._file_states: dict[str, dict[str, str]] = {}
+        self._file_states: dict[str, dict[str, Any]] = {}
 
     def _clear_progress_line(self) -> None:  # pragma: no cover - disabled
         return
@@ -324,24 +324,78 @@ class InkWorkflow(KlingonCMTWorkflow):
             self._emitter("log", {"message": leftover})
         return result
 
+    def _ensure_file_state(
+        self, file_path: str, *, now: float | None = None
+    ) -> dict[str, Any]:
+        current_now = time.time() if now is None else now
+        return self._file_states.setdefault(
+            file_path,
+            {
+                "diff": "-",
+                "req": "-",
+                "res": "-",
+                "batch": "-",
+                "commit": "-",
+                "current_stage": "pending",
+                "active_label": "pending",
+                "stage_started_at": current_now,
+                "last_update_at": current_now,
+            },
+        )
+
+    def _mark_file_stage(
+        self,
+        file_path: str,
+        *,
+        stage: str | None = None,
+        label: str | None = None,
+        now: float | None = None,
+    ) -> dict[str, Any]:
+        current_now = time.time() if now is None else now
+        entry = self._ensure_file_state(file_path, now=current_now)
+        if stage is not None and entry.get("current_stage") != stage:
+            entry["stage_started_at"] = current_now
+        if stage is not None:
+            entry["current_stage"] = stage
+        if label is not None:
+            entry["active_label"] = label
+        entry["last_update_at"] = current_now
+        return entry
+
     def _progress_event(self, kind: str, **info: object) -> None:
         # Update our in-memory file state map without writing to stdout.
         file_path = str(info.get("file") or "")
         if file_path:
-            entry = self._file_states.setdefault(
-                file_path,
-                {"diff": "-", "req": "-", "res": "-", "batch": "-", "commit": "-"},
-            )
+            event_now = time.time()
+            entry = self._ensure_file_state(file_path, now=event_now)
             if kind == "diff-ready":
                 entry["diff"] = "yes"
+                self._mark_file_stage(
+                    file_path,
+                    stage="diff",
+                    label="collecting diff",
+                    now=event_now,
+                )
             elif kind == "request-sent":
                 entry["req"] = "sent"
                 entry["batch"] = "validating"
+                self._mark_file_stage(
+                    file_path,
+                    stage="llm_wait",
+                    label="waiting for LLM response",
+                    now=event_now,
+                )
             elif kind == "response":
                 entry["res"] = "ok"
                 # For non-batch flows, response implies ready
                 if entry.get("batch", "-") == "-":
                     entry["batch"] = "completed"
+                self._mark_file_stage(
+                    file_path,
+                    stage="prepared",
+                    label="message prepared",
+                    now=event_now,
+                )
             elif kind == "llm" and info.get("detail"):
                 detail = str(info.get("detail") or "").strip().lower()
                 label = detail
@@ -358,12 +412,44 @@ class InkWorkflow(KlingonCMTWorkflow):
                     entry["batch"] = "completed"
                 elif label:
                     entry["batch"] = label[:12]
+                if label == "completed":
+                    self._mark_file_stage(
+                        file_path,
+                        stage="prepared",
+                        label="message prepared",
+                        now=event_now,
+                    )
+                else:
+                    self._mark_file_stage(
+                        file_path,
+                        stage="llm_wait",
+                        label="waiting for LLM response",
+                        now=event_now,
+                    )
             elif kind == "commit-start":
                 entry["commit"] = "running"
+                self._mark_file_stage(
+                    file_path,
+                    stage="commit",
+                    label="writing commit",
+                    now=event_now,
+                )
             elif kind == "commit-done":
                 entry["commit"] = "ok"
+                self._mark_file_stage(
+                    file_path,
+                    stage="done",
+                    label="commit complete",
+                    now=event_now,
+                )
             elif kind == "commit-error":
                 entry["commit"] = "err"
+                self._mark_file_stage(
+                    file_path,
+                    stage="failed",
+                    label="commit failed",
+                    now=event_now,
+                )
 
         message = self._format_progress_message(kind, info)
         if not message:
@@ -371,7 +457,7 @@ class InkWorkflow(KlingonCMTWorkflow):
         payload = {"message": message, "stage": kind, **info}
         self._emitter("status", payload)
 
-    def file_states_snapshot(self) -> dict[str, dict[str, str]]:
+    def file_states_snapshot(self) -> dict[str, dict[str, Any]]:
         # Return a shallow copy safe for JSON serialisation
         return {k: dict(v) for k, v in self._file_states.items()}
 
@@ -756,11 +842,15 @@ def _action_workflow(repo_path: str, payload: dict[str, Any]) -> int:
     except (TypeError, ValueError):
         workers_value = None
 
-    stage_tracker = {"value": "prepare"}
+    stage_tracker = {"value": "diff"}
 
     def _emitter(event: str, info: Dict[str, Any]) -> None:
         if event == "progress" and isinstance(info, dict):
             stage_tracker["value"] = str(info.get("stage", stage_tracker["value"]))
+        elif event == "status" and isinstance(info, dict):
+            event_stage = str(info.get("stage", "")).lower()
+            if event_stage == "push-start":
+                stage_tracker["value"] = "push"
         _emit(event, info)
 
     workflow = InkWorkflow(

--- a/kcmt/ink_backend.py
+++ b/kcmt/ink_backend.py
@@ -883,7 +883,7 @@ def _action_workflow(repo_path: str, payload: dict[str, Any]) -> int:
     while thread.is_alive():
         snapshot = workflow.stats_snapshot()
         if snapshot != last_sent:
-            files_snapshot: dict[str, dict[str, str]] = {}
+            files_snapshot: dict[str, dict[str, Any]] = {}
             try:
                 files_snapshot = workflow.file_states_snapshot()
             except Exception:  # pragma: no cover - best-effort UI telemetry
@@ -912,7 +912,7 @@ def _action_workflow(repo_path: str, payload: dict[str, Any]) -> int:
             metrics_summary = str(metrics_obj.summary())
         except Exception:  # pragma: no cover - defensive
             metrics_summary = None
-    files: dict[str, dict[str, str]] = {}
+    files: dict[str, dict[str, Any]] = {}
     try:
         files = workflow.file_states_snapshot()
     except Exception:  # pragma: no cover - defensive

--- a/kcmt/ui/ink/package.json
+++ b/kcmt/ui/ink/package.json
@@ -4,6 +4,9 @@
   "type": "module",
   "version": "0.1.0",
   "description": "Ink-based interactive UI for kcmt",
+  "scripts": {
+    "test": "node --test src/components/workflow-progress-model.test.mjs"
+  },
   "dependencies": {
     "chalk": "^5.3.0",
     "gradient-string": "^2.0.2",

--- a/kcmt/ui/ink/src/components/workflow-progress-model.mjs
+++ b/kcmt/ui/ink/src/components/workflow-progress-model.mjs
@@ -268,8 +268,9 @@ function buildFooterStatus({
     }
     return 'Run complete';
   }
-  if (currentPhaseLabel === 'PREPARE' && stats.requests > 0) {
-    return `Waiting on ${stats.requests} LLM requests`;
+  const pendingRequests = Math.max(0, stats.requests - stats.responses);
+  if (currentPhaseLabel === 'PREPARE' && pendingRequests > 0) {
+    return `Waiting on ${pendingRequests} LLM requests`;
   }
   if (currentPhaseLabel === 'COMMIT' && commitsInProgress > 0) {
     return `Writing ${commitsInProgress} commits`;

--- a/kcmt/ui/ink/src/components/workflow-progress-model.mjs
+++ b/kcmt/ui/ink/src/components/workflow-progress-model.mjs
@@ -1,0 +1,377 @@
+const ACTIVE_STAGES = new Set(['diff', 'llm_wait', 'prepared', 'commit']);
+const DONE_STAGES = new Set(['done', 'failed']);
+
+const PHASE_LABELS = {
+  diff: 'DIFF',
+  prepare: 'PREPARE',
+  commit: 'COMMIT',
+  push: 'PUSH',
+  done: 'COMPLETE',
+};
+
+const STAGE_PROGRESS = {
+  pending: 0,
+  diff: 20,
+  llm_wait: 45,
+  prepared: 80,
+  commit: 90,
+  done: 100,
+  failed: 100,
+};
+
+const STAGE_LABELS = {
+  pending: 'pending',
+  diff: 'collecting diff',
+  llm_wait: 'waiting for LLM response',
+  prepared: 'message prepared',
+  commit: 'writing commit',
+  done: 'commit complete',
+  failed: 'commit failed',
+};
+
+const SLOW_THRESHOLDS_SECONDS = {
+  diff: 5,
+  llm_wait: 10,
+  prepared: 10,
+  commit: 5,
+};
+
+function asNumber(value, fallback = 0) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+export function formatDuration(seconds) {
+  const total = Math.max(0, asNumber(seconds));
+  if (total < 60) {
+    return `${total.toFixed(1)}s`;
+  }
+  const minutes = Math.floor(total / 60);
+  const remaining = total - minutes * 60;
+  if (minutes < 60) {
+    return `${minutes}m ${remaining.toFixed(0).padStart(2, '0')}s`;
+  }
+  const hours = Math.floor(minutes / 60);
+  const leftoverMinutes = minutes % 60;
+  return `${hours}h ${String(leftoverMinutes).padStart(2, '0')}m`;
+}
+
+export function normaliseWorkflowStats(stats = {}) {
+  return {
+    total_files: asNumber(stats?.total_files ?? stats?.total),
+    diffs_built: asNumber(stats?.diffs_built),
+    requests: asNumber(stats?.requests),
+    responses: asNumber(stats?.responses),
+    prepared: asNumber(stats?.prepared ?? stats?.ready),
+    processed: asNumber(stats?.processed ?? stats?.done),
+    successes: asNumber(stats?.successes),
+    failures: asNumber(stats?.failures),
+    elapsed: asNumber(stats?.elapsed),
+    rate: asNumber(stats?.rate),
+  };
+}
+
+function humanizePushState(pushState) {
+  const value = String(pushState || 'idle').toLowerCase();
+  if (value === 'pushing') {
+    return 'Pushing';
+  }
+  if (value === 'done') {
+    return 'Done';
+  }
+  if (value === 'error') {
+    return 'Failed';
+  }
+  return 'Idle';
+}
+
+function deriveStage(entry, meta) {
+  if (meta?.error) {
+    return 'failed';
+  }
+  const currentStage = String(entry?.current_stage || '').trim().toLowerCase();
+  if (currentStage) {
+    return currentStage;
+  }
+  if (entry?.commit === 'err') {
+    return 'failed';
+  }
+  if (entry?.commit === 'ok') {
+    return 'done';
+  }
+  if (entry?.commit === 'running') {
+    return 'commit';
+  }
+  if (entry?.res === 'ok' || entry?.batch === 'completed') {
+    return 'prepared';
+  }
+  if (entry?.req === 'sent' || entry?.batch === 'validating' || entry?.batch === 'in_progress' || entry?.batch === 'finalizing') {
+    return 'llm_wait';
+  }
+  if (entry?.diff === 'yes') {
+    return 'diff';
+  }
+  return 'pending';
+}
+
+function deriveActiveLabel(entry, meta, stage) {
+  if (meta?.error) {
+    return String(meta.error);
+  }
+  const label = String(entry?.active_label || '').trim();
+  if (label) {
+    return label;
+  }
+  return STAGE_LABELS[stage] || 'pending';
+}
+
+function buildFileRecord(path, entry, meta, nowSeconds) {
+  const stage = deriveStage(entry, meta);
+  const stageStartedAt = asNumber(entry?.stage_started_at, asNumber(entry?.last_update_at, nowSeconds));
+  const lastUpdateAt = asNumber(entry?.last_update_at, stageStartedAt);
+  const stageDuration = Math.max(0, nowSeconds - stageStartedAt);
+  const activeLabel = deriveActiveLabel(entry, meta, stage);
+  const isActive = ACTIVE_STAGES.has(stage);
+  const isDone = DONE_STAGES.has(stage);
+  const threshold = SLOW_THRESHOLDS_SECONDS[stage];
+  const isSlow = isActive && Number.isFinite(threshold) && stageDuration >= threshold;
+
+  return {
+    path,
+    entry,
+    stage,
+    activeLabel,
+    stageStartedAt,
+    lastUpdateAt,
+    stageDuration,
+    isActive,
+    isSlow,
+    isDone,
+    isFailed: stage === 'failed',
+    progressPercent: STAGE_PROGRESS[stage] ?? 0,
+    statusText: STAGE_LABELS[stage] || activeLabel || 'pending',
+    subject: meta?.subject ? String(meta.subject) : '',
+    error: meta?.error ? String(meta.error) : '',
+  };
+}
+
+function compareFileRecords(left, right) {
+  const rank = record => {
+    if (record.isSlow) {
+      return 0;
+    }
+    if (record.isActive) {
+      return 1;
+    }
+    if (record.isFailed) {
+      return 2;
+    }
+    if (record.isDone) {
+      return 3;
+    }
+    return 4;
+  };
+
+  const rankDelta = rank(left) - rank(right);
+  if (rankDelta !== 0) {
+    return rankDelta;
+  }
+  if (left.isActive || left.isSlow || right.isActive || right.isSlow) {
+    const durationDelta = right.stageDuration - left.stageDuration;
+    if (durationDelta !== 0) {
+      return durationDelta;
+    }
+  }
+  if (left.isDone || right.isDone || left.isFailed || right.isFailed) {
+    const updateDelta = right.lastUpdateAt - left.lastUpdateAt;
+    if (updateDelta !== 0) {
+      return updateDelta;
+    }
+  }
+  return left.path.localeCompare(right.path);
+}
+
+function buildCurrentPhaseLabel({stage, pushState, status, stats, orderedFiles}) {
+  if (String(pushState || '').toLowerCase() === 'pushing') {
+    return 'PUSH';
+  }
+  if (status === 'completed' && String(pushState || '').toLowerCase() !== 'pushing') {
+    return 'COMPLETE';
+  }
+
+  const totalFiles = Math.max(stats.total_files, orderedFiles.length);
+  const hasPrepareActivity =
+    stats.requests > 0 ||
+    stats.responses > 0 ||
+    stats.prepared > 0 ||
+    orderedFiles.some(record => record.stage === 'llm_wait' || record.stage === 'prepared');
+  const hasCommitActivity =
+    stats.processed > 0 ||
+    orderedFiles.some(record => record.stage === 'commit' || record.stage === 'done' || record.stage === 'failed');
+  const activeStages = orderedFiles.filter(record => record.isActive).map(record => record.stage);
+
+  if (!hasPrepareActivity && !hasCommitActivity && totalFiles > 0 && stats.diffs_built < totalFiles) {
+    return 'DIFF';
+  }
+
+  if (activeStages.includes('commit')) {
+    return 'COMMIT';
+  }
+  if (activeStages.includes('llm_wait') || activeStages.includes('prepared')) {
+    return 'PREPARE';
+  }
+  if (activeStages.includes('diff')) {
+    return 'DIFF';
+  }
+  if (hasCommitActivity) {
+    return 'COMMIT';
+  }
+  if (hasPrepareActivity) {
+    return 'PREPARE';
+  }
+
+  const stageKey = String(stage || '').trim().toLowerCase();
+  if (PHASE_LABELS[stageKey]) {
+    return PHASE_LABELS[stageKey];
+  }
+  return 'DIFF';
+}
+
+function buildSlowAlert(record) {
+  if (!record || !record.isSlow) {
+    return null;
+  }
+  let label = record.activeLabel;
+  if (label.toLowerCase().startsWith('waiting ')) {
+    label = label.slice('waiting '.length);
+  }
+  return `Slow step: waiting ${formatDuration(record.stageDuration)} ${label} on ${record.path}`;
+}
+
+function buildFooterStatus({
+  currentPhaseLabel,
+  pushState,
+  status,
+  stats,
+  commitsInProgress,
+  failureCount,
+}) {
+  if (String(pushState || '').toLowerCase() === 'pushing') {
+    return 'Pushing commits to remote';
+  }
+  if (status === 'completed') {
+    if (String(pushState || '').toLowerCase() === 'error') {
+      return 'Push failed';
+    }
+    if (failureCount > 0) {
+      return `Run completed with ${failureCount} failures`;
+    }
+    return 'Run complete';
+  }
+  if (currentPhaseLabel === 'PREPARE' && stats.requests > 0) {
+    return `Waiting on ${stats.requests} LLM requests`;
+  }
+  if (currentPhaseLabel === 'COMMIT' && commitsInProgress > 0) {
+    return `Writing ${commitsInProgress} commits`;
+  }
+  if (currentPhaseLabel === 'DIFF' && stats.total_files > stats.diffs_built) {
+    return `Collecting diffs for ${stats.total_files - stats.diffs_built} files`;
+  }
+  return 'Waiting for workflow activity';
+}
+
+function buildOverallProgressPct(stats, pushState, status, commitsInProgress) {
+  const total = Math.max(0, stats.total_files);
+  if (!total) {
+    return 0;
+  }
+
+  let progressPct = 0;
+  progressPct += (Math.min(stats.diffs_built, total) / total) * 20;
+  progressPct += (Math.min(stats.prepared, total) / total) * 40;
+  progressPct += (Math.min(stats.successes + commitsInProgress, total) / total) * 35;
+  if (String(pushState || '').toLowerCase() === 'pushing') {
+    progressPct += 2.5;
+  } else if (
+    String(pushState || '').toLowerCase() === 'done' ||
+    (status === 'completed' && stats.successes + stats.failures >= total)
+  ) {
+    progressPct += 5;
+  }
+  if (status === 'completed' && String(pushState || '').toLowerCase() !== 'pushing') {
+    return 100;
+  }
+  return Math.max(0, Math.min(100, progressPct));
+}
+
+export function buildWorkflowViewModel({
+  stage = 'diff',
+  status = 'running',
+  stats,
+  fileStates = {},
+  fileMeta = {},
+  now,
+  viewportCount = 0,
+  pushState = 'idle',
+}) {
+  const snapshot = normaliseWorkflowStats(stats);
+  const nowSeconds = asNumber(now, Date.now() / 1000);
+  const fileKeys = new Set([
+    ...Object.keys(fileStates || {}),
+    ...Object.keys(fileMeta || {}),
+  ]);
+
+  const orderedFiles = [...fileKeys]
+    .map(path => buildFileRecord(path, fileStates?.[path] || {}, fileMeta?.[path] || {}, nowSeconds))
+    .sort(compareFileRecords);
+
+  const totalFiles = Math.max(snapshot.total_files, orderedFiles.length);
+  const commitsInProgress = orderedFiles.filter(record => record.stage === 'commit').length;
+  const failureCount = Math.max(
+    snapshot.failures,
+    orderedFiles.filter(record => record.isFailed).length,
+  );
+  const currentPhaseLabel = buildCurrentPhaseLabel({
+    stage,
+    pushState,
+    status,
+    stats: snapshot,
+    orderedFiles,
+  });
+  const activeRecord = orderedFiles.find(record => record.isSlow) || orderedFiles.find(record => record.isActive) || null;
+  const visibleCount = Math.min(Math.max(0, viewportCount), totalFiles);
+  const startedCount = orderedFiles.filter(record => record.stage !== 'pending').length;
+  const notStartedCount = Math.max(0, totalFiles - startedCount);
+
+  return {
+    currentPhaseLabel,
+    totalElapsedLabel: formatDuration(snapshot.elapsed),
+    stageCounters: [
+      {label: 'Files discovered', value: totalFiles},
+      {label: 'Diffs collected', value: snapshot.diffs_built},
+      {label: 'LLM requests sent', value: snapshot.requests},
+      {label: 'LLM responses received', value: snapshot.responses},
+      {label: 'Messages prepared', value: snapshot.prepared},
+      {label: 'Commits in progress', value: commitsInProgress},
+      {label: 'Commits completed', value: snapshot.successes},
+      {label: 'Failures', value: failureCount},
+      {label: 'Push', value: humanizePushState(pushState)},
+    ],
+    activeNow: activeRecord
+      ? `Active now: ${activeRecord.activeLabel} on ${activeRecord.path}`
+      : null,
+    slowAlert: buildSlowAlert(activeRecord),
+    viewportSummary: totalFiles ? `Visible ${visibleCount} of ${totalFiles} files` : null,
+    notStartedCount,
+    orderedFiles,
+    footerStatus: buildFooterStatus({
+      currentPhaseLabel,
+      pushState,
+      status,
+      stats: snapshot,
+      commitsInProgress,
+      failureCount,
+    }),
+    overallProgressPct: buildOverallProgressPct(snapshot, pushState, status, commitsInProgress),
+  };
+}

--- a/kcmt/ui/ink/src/components/workflow-progress-model.test.mjs
+++ b/kcmt/ui/ink/src/components/workflow-progress-model.test.mjs
@@ -189,5 +189,5 @@ test('buildWorkflowViewModel emits a clear footer sentence for in-flight work', 
     pushState: 'idle',
   });
 
-  assert.match(model.footerStatus, /waiting on 18 LLM requests/i);
+  assert.match(model.footerStatus, /waiting on 7 LLM requests/i);
 });

--- a/kcmt/ui/ink/src/components/workflow-progress-model.test.mjs
+++ b/kcmt/ui/ink/src/components/workflow-progress-model.test.mjs
@@ -1,0 +1,193 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {buildWorkflowViewModel} from './workflow-progress-model.mjs';
+
+test('buildWorkflowViewModel exposes full-text stage counters and current phase labels', () => {
+  const model = buildWorkflowViewModel({
+    stage: 'prepare',
+    status: 'running',
+    stats: {
+      total_files: 694,
+      diffs_built: 212,
+      requests: 18,
+      responses: 11,
+      prepared: 11,
+      processed: 9,
+      successes: 9,
+      failures: 0,
+      elapsed: 12.4,
+    },
+    fileStates: {
+      'README.md': {
+        current_stage: 'llm_wait',
+        active_label: 'waiting for LLM response',
+        stage_started_at: 1,
+        last_update_at: 12,
+      },
+    },
+    now: 12,
+    viewportCount: 20,
+    pushState: 'idle',
+  });
+
+  assert.deepEqual(
+    model.stageCounters.map(item => item.label),
+    [
+      'Files discovered',
+      'Diffs collected',
+      'LLM requests sent',
+      'LLM responses received',
+      'Messages prepared',
+      'Commits in progress',
+      'Commits completed',
+      'Failures',
+      'Push',
+    ],
+  );
+  assert.equal(model.currentPhaseLabel, 'PREPARE');
+  assert.equal(model.totalElapsedLabel, '12.4s');
+});
+
+test('buildWorkflowViewModel surfaces active work and slow-step warnings', () => {
+  const model = buildWorkflowViewModel({
+    stage: 'prepare',
+    status: 'running',
+    stats: {
+      total_files: 694,
+      diffs_built: 694,
+      requests: 1,
+      responses: 0,
+      prepared: 0,
+      processed: 0,
+      successes: 0,
+      failures: 0,
+      elapsed: 12,
+    },
+    fileStates: {
+      '.gitignore': {
+        current_stage: 'llm_wait',
+        active_label: 'waiting for LLM response',
+        stage_started_at: 0,
+        last_update_at: 12,
+      },
+    },
+    now: 12,
+    viewportCount: 20,
+    pushState: 'idle',
+  });
+
+  assert.match(model.activeNow, /waiting for LLM response on \.gitignore/i);
+  assert.match(model.slowAlert, /Slow step: waiting 12\.0s for LLM response on \.gitignore/i);
+});
+
+test('buildWorkflowViewModel prefers active file telemetry over a stale diff stage', () => {
+  const model = buildWorkflowViewModel({
+    stage: 'diff',
+    status: 'running',
+    stats: {
+      total_files: 1,
+      diffs_built: 1,
+      requests: 1,
+      responses: 0,
+      prepared: 0,
+      processed: 0,
+      successes: 0,
+      failures: 0,
+      elapsed: 3,
+    },
+    fileStates: {
+      '.gitignore': {
+        current_stage: 'llm_wait',
+        active_label: 'waiting for LLM response',
+        stage_started_at: 0,
+        last_update_at: 3,
+      },
+    },
+    now: 3,
+    viewportCount: 20,
+    pushState: 'idle',
+  });
+
+  assert.equal(model.currentPhaseLabel, 'PREPARE');
+});
+
+test('buildWorkflowViewModel reports viewport, pending counts, and active-first ordering', () => {
+  const fileStates = Object.fromEntries([
+    [
+      '.gitignore',
+      {
+        current_stage: 'llm_wait',
+        active_label: 'waiting for LLM response',
+        stage_started_at: 0,
+        last_update_at: 12,
+      },
+    ],
+    ...Array.from({length: 693}, (_, index) => [
+      `file-${String(index + 1).padStart(3, '0')}.txt`,
+      {
+        current_stage: index < 211 ? 'diff' : 'pending',
+        active_label: index < 211 ? 'collecting diff' : 'pending',
+        stage_started_at: 0,
+        last_update_at: 0,
+      },
+    ]),
+  ]);
+
+  const model = buildWorkflowViewModel({
+    stage: 'prepare',
+    status: 'running',
+    stats: {
+      total_files: 694,
+      diffs_built: 212,
+      requests: 18,
+      responses: 11,
+      prepared: 11,
+      processed: 9,
+      successes: 9,
+      failures: 0,
+      elapsed: 12,
+    },
+    fileStates,
+    now: 12,
+    viewportCount: 20,
+    pushState: 'idle',
+  });
+
+  assert.equal(model.viewportSummary, 'Visible 20 of 694 files');
+  assert.equal(model.notStartedCount, 482);
+  assert.equal(model.orderedFiles[0].path, '.gitignore');
+});
+
+test('buildWorkflowViewModel emits a clear footer sentence for in-flight work', () => {
+  const fileStates = {
+    '.gitignore': {
+      current_stage: 'llm_wait',
+      active_label: 'waiting for LLM response',
+      stage_started_at: 0,
+      last_update_at: 12,
+    },
+  };
+
+  const model = buildWorkflowViewModel({
+    stage: 'prepare',
+    status: 'running',
+    stats: {
+      total_files: 694,
+      diffs_built: 694,
+      requests: 18,
+      responses: 11,
+      prepared: 11,
+      processed: 9,
+      successes: 9,
+      failures: 0,
+      elapsed: 12,
+    },
+    fileStates,
+    now: 12,
+    viewportCount: 20,
+    pushState: 'idle',
+  });
+
+  assert.match(model.footerStatus, /waiting on 18 LLM requests/i);
+});

--- a/kcmt/ui/ink/src/components/workflow-view.mjs
+++ b/kcmt/ui/ink/src/components/workflow-view.mjs
@@ -1,11 +1,9 @@
 import React, {useCallback, useContext, useEffect, useMemo, useRef, useState} from 'react';
 import {Box, Text, useInput, useStdout} from 'ink';
-import Spinner from 'ink-spinner';
 import chalk from 'chalk';
 import {AppContext} from '../app-context.mjs';
+import {buildWorkflowViewModel} from './workflow-progress-model.mjs';
 const h = React.createElement;
-
-const STAGE_ORDER = ['prepare', 'commit', 'done'];
 
 function ellipsize(text, maxLength) {
   const value = text == null ? '' : String(text);
@@ -40,54 +38,8 @@ function normaliseStats(stats = {}) {
     diffs_built: stats.diffs_built ?? 0,
     requests: stats.requests ?? 0,
     responses: stats.responses ?? 0,
+    elapsed: stats.elapsed ?? 0,
   };
-}
-
-function buildProgressLine(stage, stats, maxWidth) {
-  const snapshot = normaliseStats(stats);
-  const total = Math.max(0, snapshot.total_files);
-  const diffs = Math.max(0, Math.min(snapshot.diffs_built, total));
-  const requests = Math.max(0, snapshot.requests);
-  const responses = Math.max(0, snapshot.responses);
-  const processed = Math.max(0, Math.min(snapshot.processed, total));
-  const prepared = Math.max(0, Math.min(snapshot.prepared, total));
-  const success = Math.max(0, snapshot.successes);
-  const failures = Math.max(0, snapshot.failures);
-  const rate = Number.isFinite(snapshot.rate) ? snapshot.rate : 0;
-
-  const stageStyles = {
-    prepare: {icon: '🧠', color: chalk.cyan},
-    commit: {icon: '🚀', color: chalk.green},
-    done: {icon: '🏁', color: chalk.yellow},
-  };
-  const {icon, color} = stageStyles[stage] || stageStyles.prepare;
-  const stageLabel = (stage || 'progress').toUpperCase().padEnd(7);
-
-  const diffStr = String(diffs).padStart(3);
-  const processedStr = String(processed).padStart(3);
-  const totalStr = String(total).padStart(3);
-  const preparedStr = String(prepared).padStart(3);
-  const reqStr = String(requests).padStart(3);
-  const resStr = String(responses).padStart(3);
-  const successStr = String(success).padStart(3);
-  const failureStr = String(failures).padStart(3);
-  const rateStr = rate.toFixed(2).padStart(5);
-
-  const line = (
-    `${chalk.bold(`${icon} kcmt`)} ` +
-    `${color(stageLabel)} │ ` +
-    `${chalk.dim(`Δ ${diffStr}`)}/${totalStr} │ ` +
-    `${chalk.cyan(`req ${reqStr}`)}/${chalk.cyan(`${resStr} res`)} │ ` +
-    `${chalk.green(`${preparedStr}/${totalStr} ready`)} │ ` +
-    `${chalk.green(`✓ ${successStr}`)} │ ` +
-    `${chalk.red(`✗ ${failureStr}`)} │ ` +
-    `${chalk.dim(`${rateStr} commits/s`)}`
-  );
-
-  if (!maxWidth) {
-    return line;
-  }
-  return ellipsize(line, maxWidth);
 }
 
 function useMessageLog() {
@@ -120,6 +72,14 @@ function useMessageLog() {
   return [messages, append];
 }
 
+function chunkItems(items, size) {
+  const chunks = [];
+  for (let index = 0; index < items.length; index += size) {
+    chunks.push(items.slice(index, index + size));
+  }
+  return chunks;
+}
+
 export default function WorkflowView({onBack} = {}) {
   const {backend, bootstrap, argv} = useContext(AppContext);
   const {stdout} = useStdout();
@@ -127,8 +87,8 @@ export default function WorkflowView({onBack} = {}) {
   const stdoutCols = stdout && stdout.columns ? Number(stdout.columns) : undefined;
   const lineWidth = stdoutCols ? Math.max(40, stdoutCols - 2) : undefined;
 
-  const HEADER_ROWS = 7;
-  const FOOTER_ROWS = 2;
+  const HEADER_ROWS = 13;
+  const FOOTER_ROWS = 3;
   const FILE_ROWS = 2;
   const COMPLETION_EXIT_DELAY_MS = 1000;
 
@@ -141,12 +101,6 @@ export default function WorkflowView({onBack} = {}) {
   const [stage, setStage] = useState('prepare');
   const [stats, setStats] = useState(normaliseStats());
   const [status, setStatus] = useState('running');
-  const [summary, setSummary] = useState(null);
-  const [errors, setErrors] = useState([]);
-  const [progressSnapshots, setProgressSnapshots] = useState({});
-  const [currentProgressLine, setCurrentProgressLine] = useState('');
-  const [commitSubjects, setCommitSubjects] = useState([]);
-  const [metricsSummary, setMetricsSummary] = useState('');
   const [messages, appendMessages] = useMessageLog();
   const emitterRef = useRef(null);
   const stageRef = useRef('prepare');
@@ -192,9 +146,6 @@ export default function WorkflowView({onBack} = {}) {
         stageRef.current = nextStage;
         setStats(nextStats);
         setStage(nextStage);
-        const line = buildProgressLine(nextStage, nextStats, lineWidth);
-        setCurrentProgressLine(line);
-        setProgressSnapshots(prev => ({...prev, [nextStage]: line}));
         if (data?.files && typeof data.files === 'object') {
           setFileStates(data.files);
         }
@@ -249,7 +200,6 @@ export default function WorkflowView({onBack} = {}) {
           detail,
           '',
         ]);
-        setErrors(prev => [...prev, data?.error || `Skipped ${file}`]);
         if (data?.file && data?.error) {
           setFileMeta(prev => ({
             ...prev,
@@ -258,21 +208,11 @@ export default function WorkflowView({onBack} = {}) {
         }
       }
       if (event === 'complete') {
-        setSummary(data);
         setStatus('completed');
         if (data?.files && typeof data.files === 'object') {
           setFileStates(data.files);
         }
-        if (Array.isArray(data?.commit_subjects)) {
-          setCommitSubjects(data.commit_subjects.map(item => String(item))); // already serialised
-        }
-        if (data?.metrics_summary) {
-          setMetricsSummary(String(data.metrics_summary));
-        }
         const doneStats = normaliseStats(data?.stats || statsRef.current);
-        const doneLine = buildProgressLine('done', doneStats, lineWidth);
-        setProgressSnapshots(prev => ({...prev, done: doneLine}));
-        setCurrentProgressLine('');
         stageRef.current = 'done';
         statsRef.current = doneStats;
         setStage('done');
@@ -280,14 +220,12 @@ export default function WorkflowView({onBack} = {}) {
       if (event === 'error') {
         const messageText = data?.message || 'Workflow failed';
         setStatus('error');
-        setErrors(prev => [...prev, messageText]);
         appendMessages(chalk.red(`✖ ${messageText}`));
       }
     });
 
       emitter.on('error', err => {
         setStatus('error');
-        setErrors(prev => [...prev, err.message]);
       });
 
     emitter.on('done', () => {
@@ -362,55 +300,103 @@ export default function WorkflowView({onBack} = {}) {
   const endpoint = ellipsize(bootstrap?.config?.llm_endpoint || '', lineWidth ? lineWidth - 12 : undefined);
   const maxRetries = argv['max-retries'] || bootstrap?.config?.max_retries || 3;
 
+  const viewportFiles = getFileViewportCount();
+  const viewModel = useMemo(
+    () =>
+      buildWorkflowViewModel({
+        stage,
+        status,
+        stats,
+        fileStates,
+        fileMeta,
+        now: Date.now() / 1000,
+        viewportCount: viewportFiles,
+        pushState,
+      }),
+    [stage, status, stats, fileStates, fileMeta, viewportFiles, pushState],
+  );
+
+  function formatStageCounter(counter) {
+    const label = chalk.bold(counter.label);
+    if (counter.label === 'Commits completed') {
+      return `${label}: ${chalk.green(counter.value)}`;
+    }
+    if (counter.label === 'Commits in progress') {
+      return `${label}: ${chalk.yellow(counter.value)}`;
+    }
+    if (counter.label === 'Failures') {
+      return `${label}: ${chalk.red(counter.value)}`;
+    }
+    if (counter.label === 'Push') {
+      const pushValue = String(counter.value || '');
+      let painter = chalk.dim;
+      if (pushValue === 'Pushing') {
+        painter = chalk.yellow;
+      } else if (pushValue === 'Done') {
+        painter = chalk.green;
+      } else if (pushValue === 'Failed') {
+        painter = chalk.red;
+      }
+      return `${label}: ${painter(pushValue)}`;
+    }
+    if (counter.label.startsWith('LLM')) {
+      return `${label}: ${chalk.cyan(counter.value)}`;
+    }
+    return `${label}: ${counter.value}`;
+  }
+
   const headerElements = [
     h(Text, {key: 'hdr-banner'}, chalk.bold.cyan(`kcmt :: provider ${provider} :: repo ${repo}`)),
     h(Text, {key: 'hdr-provider'}, `Provider: ${provider}`),
     h(Text, {key: 'hdr-model'}, `Model: ${model}`),
     h(Text, {key: 'hdr-endpoint'}, `Endpoint: ${endpoint}`),
     h(Text, {key: 'hdr-retries'}, `Max retries: ${maxRetries}`),
-    h(Text, {key: 'hdr-hint', dimColor: true}, viewMode === 'files' ? 'j/k, PgUp/PgDn to scroll • m to toggle messages • ESC to exit' : 'm to toggle files • ESC to exit'),
-    h(Text, {key: 'hdr-gap'}, ''),
+    h(
+      Text,
+      {key: 'hdr-phase'},
+      `${chalk.bold('Phase')}: ${chalk.yellow(viewModel.currentPhaseLabel)} │ ${chalk.bold('Elapsed')}: ${viewModel.totalElapsedLabel}`,
+    ),
+    ...chunkItems(viewModel.stageCounters, 3).map((group, index) =>
+      h(
+        Text,
+        {key: `hdr-counters-${index}`, wrap: 'truncate'},
+        group.map(formatStageCounter).join(' │ '),
+      ),
+    ),
   ];
-  // Build file list view
-  const filesArray = useMemo(() => {
-    const map = fileStates || {};
-    const paths = Object.keys(map);
-    paths.sort((a, b) => a.localeCompare(b));
-    return paths.map(p => ({
-      path: p,
-      state: map[p] || {},
-    }));
-  }, [fileStates]);
 
-  function computeProgress(entry) {
-    const s = entry?.state || {};
-    let pct = 0;
-    if (s.diff === 'yes') pct = Math.max(pct, 20);
-    if (s.req === 'sent') pct = Math.max(pct, 40);
-    if (s.res === 'ok') pct = Math.max(pct, 60);
-    if (s.batch === 'completed') pct = Math.max(pct, 80);
-    if (s.commit === 'running') pct = Math.max(pct, 85);
-    if (s.commit === 'ok') pct = 100;
-    if (s.commit === 'err') pct = 100;
-    return pct;
+  if (viewModel.activeNow) {
+    headerElements.push(
+      h(Text, {key: 'hdr-active', wrap: 'truncate'}, chalk.cyan(viewModel.activeNow)),
+    );
   }
-
-  function computeStatus(entry) {
-    const s = entry?.state || {};
-    const meta = fileMeta[entry.path] || {};
-    
-    // Detailed workflow states - show each step clearly
-    if (meta.error) return chalk.red('error');
-    if (s.commit === 'err') return chalk.red('commit failed');
-    if (s.commit === 'ok') return chalk.green('committed');
-    if (s.commit === 'running') return chalk.yellow('committing');
-    if (meta.subject) return chalk.cyan('ready to commit');
-    if (s.res === 'ok' && s.req === 'sent') return chalk.cyan('generating message');
-    if (s.res === 'ok') return chalk.cyan('response received');
-    if (s.req === 'sent') return chalk.magenta('awaiting response');
-    if (s.diff === 'yes') return chalk.blue('diff collected');
-    return chalk.dim('pending');
+  if (viewModel.slowAlert) {
+    headerElements.push(
+      h(Text, {key: 'hdr-slow', wrap: 'truncate'}, chalk.yellow(viewModel.slowAlert)),
+    );
   }
+  const orientationParts = [];
+  if (viewModel.viewportSummary) {
+    orientationParts.push(viewModel.viewportSummary);
+  }
+  if (viewModel.notStartedCount > 0) {
+    orientationParts.push(`${viewModel.notStartedCount} not started`);
+  }
+  if (orientationParts.length) {
+    headerElements.push(
+      h(Text, {key: 'hdr-orientation', wrap: 'truncate'}, chalk.dim(orientationParts.join(' │ '))),
+    );
+  }
+  headerElements.push(
+    h(
+      Text,
+      {key: 'hdr-hint', dimColor: true},
+      viewMode === 'files'
+        ? 'j/k, PgUp/PgDn to scroll • m to toggle messages • ESC to exit'
+        : 'm to toggle files • ESC to exit',
+    ),
+  );
+  headerElements.push(h(Text, {key: 'hdr-gap'}, ''));
 
   function renderBar(pct, width) {
     const w = Math.max(10, Math.min(30, width || 20));
@@ -419,19 +405,17 @@ export default function WorkflowView({onBack} = {}) {
     return `${chalk.green('█'.repeat(filled))}${chalk.dim('░'.repeat(empty))}`;
   }
 
-  const viewportFiles = getFileViewportCount();
+  const filesArray = viewModel.orderedFiles;
   const start = Math.max(0, Math.min(scroll, Math.max(0, filesArray.length - viewportFiles)));
   const end = Math.min(filesArray.length, start + viewportFiles);
   const visibleFiles = filesArray.slice(start, end);
 
   const fileElements = visibleFiles.length
     ? visibleFiles.flatMap((item, idx) => {
-        const pct = computeProgress(item);
+        const pct = item.progressPercent;
         const bar = renderBar(pct, 20);
-        const statusLabel = computeStatus(item);
         const pathMax = Math.max(10, (lineWidth || 80) - 40);
         const shownPath = ellipsize(item.path, pathMax);
-        const meta = fileMeta[item.path] || {};
         const lines = [];
         lines.push(
           h(
@@ -440,30 +424,42 @@ export default function WorkflowView({onBack} = {}) {
             `${shownPath.padEnd(pathMax)}  ${bar} ${String(pct).padStart(3)}%`,
           ),
         );
-        if (meta.subject) {
+        if (item.subject) {
           const subMax = Math.max(10, (lineWidth || 80) - 4);
           lines.push(
             h(
               Text,
               {key: `file-${start + idx}-row2`, wrap: 'truncate'},
-              chalk.greenBright(ellipsize(meta.subject, subMax)),
+              chalk.greenBright(ellipsize(item.subject, subMax)),
             ),
           );
-        } else if (meta.error) {
+        } else if (item.error) {
           const errMax = Math.max(10, (lineWidth || 80) - 4);
           lines.push(
             h(
               Text,
               {key: `file-${start + idx}-row2-err`, wrap: 'truncate'},
-              chalk.red(ellipsize(meta.error, errMax)),
+              chalk.red(ellipsize(item.error, errMax)),
             ),
           );
         } else {
+          let statusColor = chalk.dim;
+          if (item.stage === 'done') {
+            statusColor = chalk.green;
+          } else if (item.stage === 'failed') {
+            statusColor = chalk.red;
+          } else if (item.stage === 'commit') {
+            statusColor = chalk.yellow;
+          } else if (item.stage === 'llm_wait' || item.stage === 'prepared') {
+            statusColor = chalk.cyan;
+          } else if (item.stage === 'diff') {
+            statusColor = chalk.blue;
+          }
           lines.push(
             h(
               Text,
               {key: `file-${start + idx}-status`, wrap: 'truncate'},
-              chalk.dim(statusLabel),
+              statusColor(item.statusText),
             ),
           );
         }
@@ -479,116 +475,20 @@ export default function WorkflowView({onBack} = {}) {
     messageElements.push(h(Text, {key: 'msg-placeholder', dimColor: true}, 'Waiting for workflow activity…'));
   }
 
-  function buildAggregateParts() {
-    const snapshot = normaliseStats(statsRef.current || stats);
-    const totalFromFiles = Object.keys(fileStates || {}).length;
-    const total = Math.max(snapshot.total_files || 0, totalFromFiles);
-
-    let diffed = 0;
-    let req = 0;
-    let res = 0;
-    let batchValidating = 0;
-    let batchInProgress = 0;
-    let batchFinalizing = 0;
-    let batchCompleted = 0;
-    let committing = 0;
-    let committed = 0;
-    let commitErr = 0;
-    let metaErr = 0;
-    const meta = fileMeta || {};
-    const fmap = fileStates || {};
-    for (const p of Object.keys(fmap)) {
-      const s = fmap[p] || {};
-      if (s.diff === 'yes') diffed += 1;
-      if (s.req === 'sent') req += 1;
-      if (s.res === 'ok') res += 1;
-      if (s.batch === 'validating' || s.batch === 'queued') batchValidating += 1;
-      if (s.batch === 'in_progress' || s.batch === 'running' || s.batch === 'in-progress') batchInProgress += 1;
-      if (s.batch === 'finalizing') batchFinalizing += 1;
-      if (s.batch === 'completed') batchCompleted += 1;
-      if (s.commit === 'running') committing += 1;
-      if (s.commit === 'ok') committed += 1;
-      if (s.commit === 'err') commitErr += 1;
-      if (meta[p]?.error) metaErr += 1;
-    }
-    const errors = commitErr + metaErr;
-    const hasBatchActivity = batchValidating + batchInProgress + batchFinalizing + batchCompleted > 0;
-
-    const leftParts = [
-      `${chalk.bold('files')} ${String(total).padStart(3)}`,
-      `${chalk.dim('Δ')} ${String(diffed).padStart(3)}`,
-      `${chalk.cyan('req')} ${String(req).padStart(3)}`,
-      `${chalk.cyan('res')} ${String(res).padStart(3)}`,
-    ];
-
-    // Only show batch stats if there's actual batch activity
-    if (hasBatchActivity) {
-      leftParts.push(
-        `${chalk.magenta('batch')} ${String(batchValidating + batchInProgress + batchFinalizing).padStart(2)}/${String(batchCompleted).padStart(2)}`
-      );
-    }
-
-    const rightParts = [
-      `${chalk.yellow('committing')} ${String(committing).padStart(3)}`,
-      `${chalk.green('✓')} ${String(committed).padStart(3)}`,
-      `${chalk.red('✗')} ${String(errors).padStart(3)}`
-    ];
-
-    return {
-      left: leftParts.join(' │ '),
-      right: rightParts.join(' │ '),
-    };
-  }
-
   function buildOverallProgressParts() {
-    const snapshot = normaliseStats(statsRef.current || stats);
-    const total = Math.max(snapshot.total_files || 0, Object.keys(fileStates || {}).length);
-    
+    const total = Number(viewModel.stageCounters[0]?.value || 0);
     if (total === 0) {
       return '';
     }
-
-    // Calculate overall progress: diff → prepare → commit → push
-    // Weight each stage: diff 20%, prepare 40%, commit 35%, push 5%
-    const committed = snapshot.successes || 0;
-    const prepared = snapshot.prepared || 0;
-    const diffed = snapshot.diffs_built || 0;
-    
-    let progressPct = 0;
-    progressPct += (diffed / total) * 20;      // Diff stage: 20%
-    progressPct += (prepared / total) * 40;    // Prepare stage: 40%
-    progressPct += (committed / total) * 35;   // Commit stage: 35%
-    
-    // Push adds final 5%
-    if (pushState === 'pushing') {
-      progressPct += 2.5; // Half of push
-    } else if (pushState === 'done') {
-      progressPct += 5;   // Full push
-    } else if (status === 'completed' && committed === total) {
-      progressPct += 5;   // Assume push done if all committed and completed
-    }
-
-    if (status === 'completed' && pushState !== 'pushing') {
-      progressPct = 100;
-    }
-    
-    progressPct = Math.min(100, Math.max(0, progressPct));
-    
+    const progressPct = Math.min(100, Math.max(0, viewModel.overallProgressPct));
     const pctStr = String(Math.round(progressPct)).padStart(3);
-    
-    let statusLabel = 'In progress';
-    if (pushState === 'pushing') {
-      statusLabel = 'Pushing';
-    } else if (pushState === 'done' || (status === 'completed' && progressPct >= 100)) {
-      statusLabel = 'Complete';
-    } else if (committed > 0 && committed === total) {
-      statusLabel = 'Committing complete';
-    }
 
+    const statusLabel =
+      status === 'completed' && pushState !== 'pushing'
+        ? 'Complete'
+        : viewModel.currentPhaseLabel;
     const rightPlain = `${pctStr}% ${statusLabel}`;
     const right = `${pctStr}% ${chalk.dim(statusLabel)}`;
-
-    // Fill the remaining terminal width with the bar itself.
     const barWidth = Math.max(10, (lineWidth || 80) - rightPlain.length - 1);
     const filled = Math.round((progressPct / 100) * barWidth);
     const empty = Math.max(0, barWidth - filled);
@@ -598,51 +498,20 @@ export default function WorkflowView({onBack} = {}) {
   }
 
   const footerElements = [];
-  if (status === 'running') {
-    const overall = buildOverallProgressParts();
-    if (overall) {
-      footerElements.push(
-        h(
-          Box,
-          {key: 'overall-progress', width: '100%'},
-          h(Box, {flexGrow: 1, flexShrink: 1}, h(Text, {wrap: 'truncate'}, overall.bar)),
-          h(Box, {flexShrink: 0}, h(Text, {wrap: 'truncate'}, ` ${overall.right}`)),
-        ),
-      );
-    }
-
-    const agg = buildAggregateParts();
+  const overall = buildOverallProgressParts();
+  if (overall) {
     footerElements.push(
       h(
         Box,
-        {key: 'aggregate-live', width: '100%'},
-        h(Box, {flexGrow: 1, flexShrink: 1}, h(Text, {wrap: 'truncate'}, agg.left)),
-        h(Box, {flexShrink: 0}, h(Text, {wrap: 'truncate'}, agg.right)),
+        {key: 'overall-progress', width: '100%'},
+        h(Box, {flexGrow: 1, flexShrink: 1}, h(Text, {wrap: 'truncate'}, overall.bar)),
+        h(Box, {flexShrink: 0}, h(Text, {wrap: 'truncate'}, ` ${overall.right}`)),
       ),
     );
   }
-
-  if (status !== 'running') {
-    const overall = buildOverallProgressParts();
-    if (overall) {
-      footerElements.push(
-        h(
-          Box,
-          {key: 'overall-progress-done', width: '100%'},
-          h(Box, {flexGrow: 1, flexShrink: 1}, h(Text, {wrap: 'truncate'}, overall.bar)),
-          h(Box, {flexShrink: 0}, h(Text, {wrap: 'truncate'}, ` ${overall.right}`)),
-        ),
-      );
-    }
-
-    const agg = buildAggregateParts();
+  if (viewModel.footerStatus) {
     footerElements.push(
-      h(
-        Box,
-        {key: 'aggregate-done', width: '100%'},
-        h(Box, {flexGrow: 1, flexShrink: 1}, h(Text, {wrap: 'truncate'}, agg.left)),
-        h(Box, {flexShrink: 0}, h(Text, {wrap: 'truncate'}, agg.right)),
-      ),
+      h(Text, {key: 'footer-status', wrap: 'truncate'}, chalk.dim(viewModel.footerStatus)),
     );
   }
 

--- a/kcmt/ui/ink/src/components/workflow-view.mjs
+++ b/kcmt/ui/ink/src/components/workflow-view.mjs
@@ -87,16 +87,9 @@ export default function WorkflowView({onBack} = {}) {
   const stdoutCols = stdout && stdout.columns ? Number(stdout.columns) : undefined;
   const lineWidth = stdoutCols ? Math.max(40, stdoutCols - 2) : undefined;
 
-  const HEADER_ROWS = 13;
-  const FOOTER_ROWS = 3;
+  const BASE_HEADER_ROWS = 6;
   const FILE_ROWS = 2;
   const COMPLETION_EXIT_DELAY_MS = 1000;
-
-  function getFileViewportCount() {
-    const rows = stdoutRows || 30;
-    const bodyRows = Math.max(0, rows - HEADER_ROWS - FOOTER_ROWS);
-    return Math.max(1, Math.floor(bodyRows / FILE_ROWS));
-  }
 
   const [stage, setStage] = useState('prepare');
   const [stats, setStats] = useState(normaliseStats());
@@ -215,6 +208,7 @@ export default function WorkflowView({onBack} = {}) {
         const doneStats = normaliseStats(data?.stats || statsRef.current);
         stageRef.current = 'done';
         statsRef.current = doneStats;
+        setStats(doneStats);
         setStage('done');
       }
       if (event === 'error') {
@@ -236,44 +230,6 @@ export default function WorkflowView({onBack} = {}) {
       emitter.cancel?.();
     };
   }, [appendMessages, backend, bootstrap, overrides, argv]);
-
-  useInput((input, key) => {
-    const char = (input || '').toLowerCase();
-    if (key.escape || (key.ctrl && char === 'c') || char === 'q') {
-      if (emitterRef.current && typeof emitterRef.current.cancel === 'function') {
-        emitterRef.current.cancel();
-      }
-      emitterRef.current = null;
-      if (status !== 'running') {
-        const exitCode = status === 'error' ? 1 : 0;
-        process.exit(exitCode);
-        return;
-      }
-      onBack();
-    }
-    // Toggle file/messages view
-    if (char === 'm') {
-      setViewMode(prev => (prev === 'files' ? 'messages' : 'files'));
-    }
-    // Scrolling controls for file list view
-    if (viewMode === 'files') {
-      const fileCount = Object.keys(fileStates || {}).length;
-      const viewport = getFileViewportCount();
-      if (key.downArrow || char === 'j') {
-        setScroll(prev => Math.min(Math.max(0, fileCount - viewport), prev + 1));
-      } else if (key.upArrow || char === 'k') {
-        setScroll(prev => Math.max(0, prev - 1));
-      } else if (key.pageDown) {
-        setScroll(prev => Math.min(Math.max(0, fileCount - viewport), prev + viewport));
-      } else if (key.pageUp) {
-        setScroll(prev => Math.max(0, prev - viewport));
-      } else if (char === 'g' && !key.shift) {
-        setScroll(0);
-      } else if (char === 'g' && key.shift) {
-        setScroll(Math.max(0, fileCount - viewport));
-      }
-    }
-  });
 
   useEffect(() => {
     if (status === 'running') {
@@ -300,7 +256,40 @@ export default function WorkflowView({onBack} = {}) {
   const endpoint = ellipsize(bootstrap?.config?.llm_endpoint || '', lineWidth ? lineWidth - 12 : undefined);
   const maxRetries = argv['max-retries'] || bootstrap?.config?.max_retries || 3;
 
-  const viewportFiles = getFileViewportCount();
+  const provisionalViewModel = useMemo(
+    () =>
+      buildWorkflowViewModel({
+        stage,
+        status,
+        stats,
+        fileStates,
+        fileMeta,
+        now: Date.now() / 1000,
+        viewportCount: 0,
+        pushState,
+      }),
+    [stage, status, stats, fileStates, fileMeta, pushState],
+  );
+
+  const viewportFiles = useMemo(() => {
+    const rows = stdoutRows || 30;
+    const stageCounterRows = Math.max(
+      1,
+      Math.ceil(provisionalViewModel.stageCounters.length / 3),
+    );
+    const extraHeaderRows =
+      (provisionalViewModel.activeNow ? 1 : 0) +
+      (provisionalViewModel.slowAlert ? 1 : 0) +
+      (provisionalViewModel.viewportSummary || provisionalViewModel.notStartedCount > 0 ? 1 : 0) +
+      2;
+    const headerRows = BASE_HEADER_ROWS + stageCounterRows + extraHeaderRows;
+    const footerRows =
+      (provisionalViewModel.overallProgressPct > 0 ? 1 : 0) +
+      (provisionalViewModel.footerStatus ? 1 : 0);
+    const bodyRows = Math.max(0, rows - headerRows - footerRows);
+    return Math.max(1, Math.floor(bodyRows / FILE_ROWS));
+  }, [stdoutRows, provisionalViewModel]);
+
   const viewModel = useMemo(
     () =>
       buildWorkflowViewModel({
@@ -315,6 +304,53 @@ export default function WorkflowView({onBack} = {}) {
       }),
     [stage, status, stats, fileStates, fileMeta, viewportFiles, pushState],
   );
+
+  const filesArray = viewModel.orderedFiles;
+  const maxScroll = Math.max(0, filesArray.length - viewportFiles);
+
+  useEffect(() => {
+    setScroll(prev => Math.min(prev, maxScroll));
+  }, [maxScroll]);
+
+  useInput((input, key) => {
+    const char = (input || '').toLowerCase();
+    if (key.escape || (key.ctrl && char === 'c') || char === 'q') {
+      if (emitterRef.current && typeof emitterRef.current.cancel === 'function') {
+        emitterRef.current.cancel();
+      }
+      emitterRef.current = null;
+      if (status !== 'running') {
+        const exitCode = status === 'error' ? 1 : 0;
+        process.exit(exitCode);
+        return;
+      }
+      onBack();
+      return;
+    }
+
+    if (char === 'm') {
+      setViewMode(prev => (prev === 'files' ? 'messages' : 'files'));
+      return;
+    }
+
+    if (viewMode !== 'files') {
+      return;
+    }
+
+    if (key.downArrow || char === 'j') {
+      setScroll(prev => Math.min(maxScroll, prev + 1));
+    } else if (key.upArrow || char === 'k') {
+      setScroll(prev => Math.max(0, prev - 1));
+    } else if (key.pageDown) {
+      setScroll(prev => Math.min(maxScroll, prev + viewportFiles));
+    } else if (key.pageUp) {
+      setScroll(prev => Math.max(0, prev - viewportFiles));
+    } else if (char === 'g' && !key.shift) {
+      setScroll(0);
+    } else if (char === 'g' && key.shift) {
+      setScroll(maxScroll);
+    }
+  });
 
   function formatStageCounter(counter) {
     const label = chalk.bold(counter.label);
@@ -405,8 +441,8 @@ export default function WorkflowView({onBack} = {}) {
     return `${chalk.green('█'.repeat(filled))}${chalk.dim('░'.repeat(empty))}`;
   }
 
-  const filesArray = viewModel.orderedFiles;
-  const start = Math.max(0, Math.min(scroll, Math.max(0, filesArray.length - viewportFiles)));
+  const clampedScroll = Math.max(0, Math.min(scroll, maxScroll));
+  const start = clampedScroll;
   const end = Math.min(filesArray.length, start + viewportFiles);
   const visibleFiles = filesArray.slice(start, end);
 

--- a/specs/004-ink-progress-telemetry/plan.md
+++ b/specs/004-ink-progress-telemetry/plan.md
@@ -1,0 +1,541 @@
+# Ink Workflow Progress Telemetry Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add clear Ink progress telemetry for large repository runs, including full-text stage counters, active-work visibility, slow-step warnings, and viewport orientation, without changing legacy CLI behavior.
+
+**Architecture:** Extend `InkWorkflow` in `kcmt/ink_backend.py` so every file snapshot includes explicit stage and timing metadata. Move the frontend progress math into a new pure helper module consumed by `workflow-view.mjs`, then render the labeled counters, active item, slow warning, and large-run summary from that model. Keep the legacy CLI path untouched and cover the new behavior with Python and Node tests.
+
+**Tech Stack:** Python 3.12, Node ESM, Ink/React, `pytest`, built-in `node:test`
+
+---
+
+**Branch**: `004-ink-progress-telemetry` | **Date**: 2026-04-14 | **Spec**: [`specs/004-ink-progress-telemetry/spec.md`](./spec.md)  
+**Input**: Feature specification from `/specs/004-ink-progress-telemetry/spec.md`
+
+## Summary
+
+The current Ink workflow screen exposes low-signal counters (`req`, `res`) and
+does not make long waits or off-screen work obvious. This plan enriches backend
+telemetry per file, derives a strongly typed workflow view model with
+human-readable labels, and updates the Ink screen to show full-text stage
+counters, current active work, slow-step warnings, and large-run orientation.
+
+## Technical Context
+
+**Language/Version**: Python 3.12, Node ESM, React 18, Ink 4  
+**Primary Dependencies**: Python `pytest`; Ink UI dependencies from
+`kcmt/ui/ink/package.json` (`react`, `ink`, `chalk`, `ink-spinner`)  
+**Storage**: In-memory workflow telemetry only; no persisted state changes  
+**Testing**: `pytest`, built-in `node:test`, existing `make check` with a new Ink
+test target added to the repo gate  
+**Target Platform**: Local macOS/Linux terminal sessions using the Ink UI  
+**Project Type**: Hybrid Python CLI with Node-based Ink frontend  
+**Performance Goals**: Progress telemetry updates must remain responsive during
+large runs of at least 500 files without adding visible workflow lag  
+**Baseline Corpus**: `../kids_movie` for large-run manual validation plus the
+existing Python test suite and new Node unit tests for the view model  
+**Constraints**: Preserve legacy CLI output and flags, avoid adding a browser or
+DOM test harness, keep the Ink component testable through pure helper functions,
+and do not depend on a live provider response to validate stage labels  
+**Scale/Scope**: `kcmt/ink_backend.py`, `kcmt/ui/ink/src/components/workflow-view.mjs`,
+new Ink helper tests, and root quality gate wiring
+
+## Constitution Check
+
+*GATE: Must pass before implementation. Re-check after the plan is executed.*
+
+- [x] Principle I: CLI contract compatibility is preserved or explicitly versioned  
+  Decision: only the Ink view and its telemetry payload change; command flags,
+  exit codes, and legacy CLI behavior remain unchanged.
+- [x] Principle II: Git safety/atomic behavior is preserved with parity strategy  
+  Decision: no git-operation behavior changes are introduced; this feature is UI
+  telemetry only.
+- [x] Principle III: Required tests and strict quality gates are defined  
+  Decision: add `pytest` coverage for backend telemetry and `node:test` coverage
+  for the frontend progress model, then wire the Ink test target into `make check`.
+- [x] Principle IV: Performance claims include baseline corpus and metrics  
+  Decision: validate interactively against `../kids_movie` and keep telemetry
+  derivation in pure helper code to avoid adding runtime overhead.
+- [x] Principle V: Secrets/config precedence/error handling constraints are covered  
+  Decision: no secrets or config precedence changes; provider names can be shown
+  in the active-work line without logging secret values.
+
+No constitution violations identified.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/004-ink-progress-telemetry/
+├── spec.md
+└── plan.md
+```
+
+### Source Code (repository root)
+
+```text
+kcmt/
+├── ink_backend.py
+└── ui/ink/
+    ├── package.json
+    └── src/
+        ├── backend-client.mjs
+        └── components/
+            ├── workflow-view.mjs
+            ├── workflow-progress-model.mjs          # new
+            └── workflow-progress-model.test.mjs     # new
+
+tests/
+└── test_ink_backend.py
+
+Makefile
+```
+
+**Structure Decision**: Keep `workflow-view.mjs` as the Ink renderer but extract
+all counter, timing, sorting, and alert derivation into a new
+`workflow-progress-model.mjs` helper so the UI logic is unit-testable without
+adding a separate frontend testing framework.
+
+## Implementation Tasks
+
+### Task 1: Enrich Backend File Telemetry
+
+**Files:**
+- Modify: `kcmt/ink_backend.py`
+- Test: `tests/test_ink_backend.py`
+
+- [ ] **Step 1: Write the failing backend telemetry test**
+
+```python
+from __future__ import annotations
+
+import kcmt.ink_backend as ink_backend
+
+
+def test_ink_workflow_progress_event_tracks_stage_metadata(monkeypatch):
+    monkeypatch.setattr(
+        ink_backend.KlingonCMTWorkflow,
+        "__init__",
+        lambda self, **_: None,
+    )
+
+    workflow = ink_backend.InkWorkflow(lambda *_: None, repo_path=".")
+    workflow._progress_event("diff-ready", file="alpha.py")
+    first = workflow.file_states_snapshot()["alpha.py"]
+
+    assert first["current_stage"] == "diff"
+    assert first["active_label"] == "collecting diff"
+    assert first["stage_started_at"] > 0
+    assert first["last_update_at"] >= first["stage_started_at"]
+
+    workflow._progress_event("request-sent", file="alpha.py")
+    second = workflow.file_states_snapshot()["alpha.py"]
+
+    assert second["current_stage"] == "llm_wait"
+    assert second["active_label"] == "waiting for LLM response"
+    assert second["stage_started_at"] >= first["last_update_at"]
+```
+
+- [ ] **Step 2: Run the backend test and verify it fails**
+
+Run: `uv run pytest -q tests/test_ink_backend.py -k telemetry`  
+Expected: `FAIL` because the file snapshot only contains the old compact flags
+and no `current_stage`, `active_label`, or timestamp fields.
+
+- [ ] **Step 3: Implement the telemetry metadata in the Ink backend**
+
+```python
+def _mark_file_state(self, file_path: str, *, stage: str, label: str) -> None:
+    now = time.time()
+    entry = self._file_states.setdefault(
+        file_path,
+        {
+            "diff": "-",
+            "req": "-",
+            "res": "-",
+            "batch": "-",
+            "commit": "-",
+            "current_stage": "pending",
+            "active_label": "pending",
+            "stage_started_at": now,
+            "last_update_at": now,
+        },
+    )
+    if entry.get("current_stage") != stage:
+        entry["stage_started_at"] = now
+    entry["current_stage"] = stage
+    entry["active_label"] = label
+    entry["last_update_at"] = now
+```
+
+Update `InkWorkflow._progress_event()` so:
+- `diff-ready` maps to `current_stage="diff"` and `active_label="collecting diff"`
+- `request-sent` maps to `current_stage="llm_wait"` and `active_label="waiting for LLM response"`
+- `response` maps to `current_stage="prepared"` and `active_label="message prepared"`
+- `commit-start` maps to `current_stage="commit"` and `active_label="writing commit"`
+- `commit-done` maps to `current_stage="done"` and `active_label="commit complete"`
+- `commit-error` maps to `current_stage="failed"` and `active_label="commit failed"`
+- `push-start`/`push-done`/`push-error` remain aggregate workflow events, not per-file state
+
+- [ ] **Step 4: Re-run the backend test and verify it passes**
+
+Run: `uv run pytest -q tests/test_ink_backend.py -k telemetry`  
+Expected: `PASS`
+
+- [ ] **Step 5: Commit the backend telemetry change**
+
+```bash
+git add tests/test_ink_backend.py kcmt/ink_backend.py
+git commit -m "feat(ink): enrich workflow telemetry"
+```
+
+### Task 2: Build a Pure Progress View Model with Labeled Stage Counters
+
+**Files:**
+- Create: `kcmt/ui/ink/src/components/workflow-progress-model.mjs`
+- Create: `kcmt/ui/ink/src/components/workflow-progress-model.test.mjs`
+- Modify: `kcmt/ui/ink/package.json`
+
+- [ ] **Step 1: Write the failing Node test for labeled counters**
+
+```javascript
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {buildWorkflowViewModel} from './workflow-progress-model.mjs';
+
+test('buildWorkflowViewModel exposes full-text stage counters', () => {
+  const model = buildWorkflowViewModel({
+    stats: {
+      total_files: 694,
+      diffs_built: 212,
+      requests: 18,
+      responses: 11,
+      prepared: 11,
+      processed: 9,
+      successes: 9,
+      failures: 0,
+    },
+    fileStates: {
+      'README.md': {
+        current_stage: 'llm_wait',
+        active_label: 'waiting for LLM response',
+        stage_started_at: 1,
+        last_update_at: 12,
+      },
+    },
+    now: 12,
+    viewportCount: 20,
+    pushState: 'idle',
+  });
+
+  assert.deepEqual(
+    model.stageCounters.map(item => item.label),
+    [
+      'Files discovered',
+      'Diffs collected',
+      'LLM requests sent',
+      'LLM responses received',
+      'Messages prepared',
+      'Commits in progress',
+      'Commits completed',
+      'Failures',
+      'Push',
+    ],
+  );
+});
+```
+
+- [ ] **Step 2: Run the Node test and verify it fails**
+
+Run: `node --test kcmt/ui/ink/src/components/workflow-progress-model.test.mjs`  
+Expected: `FAIL` because `workflow-progress-model.mjs` does not exist yet.
+
+- [ ] **Step 3: Implement the pure view-model helper**
+
+```javascript
+export function buildWorkflowViewModel({stats, fileStates = {}, fileMeta = {}, now, viewportCount, pushState}) {
+  const totalFiles = Number(stats?.total_files ?? 0);
+  const diffsCollected = Number(stats?.diffs_built ?? 0);
+  const llmRequestsSent = Number(stats?.requests ?? 0);
+  const llmResponsesReceived = Number(stats?.responses ?? 0);
+  const messagesPrepared = Number(stats?.prepared ?? 0);
+  const commitsCompleted = Number(stats?.successes ?? 0);
+  const commitsInProgress = Object.values(fileStates).filter(
+    entry => entry.current_stage === 'commit',
+  ).length;
+  const failures = Number(stats?.failures ?? 0);
+
+  const stageCounters = [
+    {label: 'Files discovered', value: totalFiles},
+    {label: 'Diffs collected', value: diffsCollected},
+    {label: 'LLM requests sent', value: llmRequestsSent},
+    {label: 'LLM responses received', value: llmResponsesReceived},
+    {label: 'Messages prepared', value: messagesPrepared},
+    {label: 'Commits in progress', value: commitsInProgress},
+    {label: 'Commits completed', value: commitsCompleted},
+    {label: 'Failures', value: failures},
+    {label: 'Push', value: pushState},
+  ];
+
+  return {
+    stageCounters,
+    activeNow: null,
+    slowAlert: null,
+    viewportSummary: null,
+    orderedFiles: [],
+  };
+}
+```
+
+Also update `kcmt/ui/ink/package.json`:
+
+```json
+{
+  "scripts": {
+    "test": "node --test src/components/workflow-progress-model.test.mjs"
+  }
+}
+```
+
+- [ ] **Step 4: Re-run the Node test and verify it passes**
+
+Run: `npm --prefix kcmt/ui/ink test`  
+Expected: `PASS`
+
+- [ ] **Step 5: Commit the progress model**
+
+```bash
+git add kcmt/ui/ink/package.json kcmt/ui/ink/src/components/workflow-progress-model.mjs kcmt/ui/ink/src/components/workflow-progress-model.test.mjs
+git commit -m "feat(ink): add labeled progress model"
+```
+
+### Task 3: Add Active-Work, Slow-Step, and Large-Run Orientation Logic
+
+**Files:**
+- Modify: `kcmt/ui/ink/src/components/workflow-progress-model.mjs`
+- Modify: `kcmt/ui/ink/src/components/workflow-progress-model.test.mjs`
+
+- [ ] **Step 1: Write the failing Node tests for slow alerts and viewport summaries**
+
+```javascript
+test('buildWorkflowViewModel surfaces active work and slow-step warnings', () => {
+  const model = buildWorkflowViewModel({
+    stats: {total_files: 694, diffs_built: 694, requests: 1, responses: 0, prepared: 0, processed: 0, successes: 0, failures: 0},
+    fileStates: {
+      '.gitignore': {
+        current_stage: 'llm_wait',
+        active_label: 'waiting for LLM response',
+        stage_started_at: 0,
+        last_update_at: 12,
+      },
+    },
+    now: 12,
+    viewportCount: 20,
+    pushState: 'idle',
+  });
+
+  assert.match(model.activeNow, /waiting for LLM response on \.gitignore/);
+  assert.match(model.slowAlert, /Slow step: waiting for LLM response/);
+});
+
+test('buildWorkflowViewModel reports viewport and pending counts for large runs', () => {
+  const fileStates = Object.fromEntries([
+    [
+      '.gitignore',
+      {
+        current_stage: 'llm_wait',
+        active_label: 'waiting for LLM response',
+        stage_started_at: 0,
+        last_update_at: 12,
+      },
+    ],
+    ...Array.from({length: 693}, (_, index) => [
+      `file-${String(index + 1).padStart(3, '0')}.txt`,
+      {
+        current_stage: index < 211 ? 'diff' : 'pending',
+        active_label: index < 211 ? 'collecting diff' : 'pending',
+        stage_started_at: 0,
+        last_update_at: 0,
+      },
+    ]),
+  ]);
+
+  const model = buildWorkflowViewModel({
+    stats: {total_files: 694, diffs_built: 212, requests: 18, responses: 11, prepared: 11, processed: 9, successes: 9, failures: 0},
+    fileStates,
+    now: 12,
+    viewportCount: 20,
+    pushState: 'idle',
+  });
+
+  assert.equal(model.viewportSummary, 'Visible 20 of 694 files');
+  assert.equal(model.notStartedCount, 482);
+  assert.equal(model.orderedFiles[0].path, '.gitignore');
+});
+```
+
+- [ ] **Step 2: Run the Node test and verify it fails**
+
+Run: `npm --prefix kcmt/ui/ink test`  
+Expected: `FAIL` because `buildWorkflowViewModel()` does not yet produce
+`activeNow`, `slowAlert`, `viewportSummary`, `notStartedCount`, or active-first
+ordering.
+
+- [ ] **Step 3: Implement thresholds, ordering, and orientation output**
+
+```javascript
+const SLOW_THRESHOLDS_SECONDS = {
+  diff: 5,
+  llm_wait: 10,
+  prepared: 10,
+  commit: 5,
+  push: 10,
+};
+
+function rankFile(record) {
+  if (record.isSlow) return 0;
+  if (record.isActive) return 1;
+  if (record.isDone) return 2;
+  return 3;
+}
+```
+
+Extend the helper so it:
+- computes `activeNow` from the slowest active file
+- emits `slowAlert` when `now - stage_started_at` crosses the threshold for the
+  current stage
+- returns `viewportSummary` as `Visible X of Y files`
+- returns `notStartedCount`
+- sorts file rows as slow active, active, recently completed, untouched, then
+  alphabetical for ties
+
+- [ ] **Step 4: Re-run the Node test and verify it passes**
+
+Run: `npm --prefix kcmt/ui/ink test`  
+Expected: `PASS`
+
+- [ ] **Step 5: Commit the alert and ordering logic**
+
+```bash
+git add kcmt/ui/ink/src/components/workflow-progress-model.mjs kcmt/ui/ink/src/components/workflow-progress-model.test.mjs
+git commit -m "feat(ink): add slow-step and viewport summaries"
+```
+
+### Task 4: Render the New Progress Model in the Ink Workflow Screen and Wire the Repo Gate
+
+**Files:**
+- Modify: `kcmt/ui/ink/src/components/workflow-view.mjs`
+- Modify: `Makefile`
+- Test: `tests/test_ink_backend.py`
+- Test: `kcmt/ui/ink/src/components/workflow-progress-model.test.mjs`
+
+- [ ] **Step 1: Write a failing regression in the Node view-model test for the footer sentence**
+
+```javascript
+test('buildWorkflowViewModel emits a clear footer sentence for in-flight work', () => {
+  const fileStates = Object.fromEntries([
+    [
+      '.gitignore',
+      {
+        current_stage: 'llm_wait',
+        active_label: 'waiting for LLM response',
+        stage_started_at: 0,
+        last_update_at: 12,
+      },
+    ],
+    ...Array.from({length: 693}, (_, index) => [
+      `file-${String(index + 1).padStart(3, '0')}.txt`,
+      {
+        current_stage: index < 211 ? 'diff' : 'pending',
+        active_label: index < 211 ? 'collecting diff' : 'pending',
+        stage_started_at: 0,
+        last_update_at: 0,
+      },
+    ]),
+  ]);
+
+  const model = buildWorkflowViewModel({
+    stats: {total_files: 694, diffs_built: 694, requests: 18, responses: 11, prepared: 11, processed: 9, successes: 9, failures: 0},
+    fileStates,
+    now: 12,
+    viewportCount: 20,
+    pushState: 'idle',
+  });
+
+  assert.match(model.footerStatus, /waiting on 18 LLM requests/i);
+});
+```
+
+- [ ] **Step 2: Run the regression tests and verify the new assertion fails**
+
+Run: `npm --prefix kcmt/ui/ink test`  
+Expected: `FAIL` because `footerStatus` is not yet computed.
+
+- [ ] **Step 3: Integrate the helper into `workflow-view.mjs` and add the Ink test gate**
+
+```javascript
+import {buildWorkflowViewModel} from './workflow-progress-model.mjs';
+
+const model = buildWorkflowViewModel({
+  stats,
+  fileStates,
+  fileMeta,
+  now: Date.now() / 1000,
+  viewportCount: getFileViewportCount(),
+  pushState,
+});
+```
+
+Update the component so it:
+- renders the stage counter strip using `model.stageCounters`
+- renders `model.activeNow` and `model.slowAlert` above the file list
+- renders `model.viewportSummary` and `model.notStartedCount`
+- uses `model.orderedFiles` instead of alphabetical-only ordering
+- renders `model.footerStatus` in the footer
+
+Update `Makefile`:
+
+```make
+test-ink:
+	npm --prefix kcmt/ui/ink test
+
+check: ruff-fix format lint typecheck test-strict test-ink
+```
+
+- [ ] **Step 4: Re-run all relevant checks and verify they pass**
+
+Run: `uv run pytest -q tests/test_ink_backend.py`  
+Expected: `PASS`
+
+Run: `npm --prefix kcmt/ui/ink test`  
+Expected: `PASS`
+
+Run: `make check`  
+Expected: Python checks remain green and the new Ink test target passes.
+
+- [ ] **Step 5: Commit the screen integration**
+
+```bash
+git add kcmt/ui/ink/src/components/workflow-view.mjs Makefile kcmt/ui/ink/src/components/workflow-progress-model.mjs kcmt/ui/ink/src/components/workflow-progress-model.test.mjs tests/test_ink_backend.py
+git commit -m "feat(ink): surface detailed workflow progress"
+```
+
+## Spec Coverage Check
+
+- FR-001 through FR-004 are covered by Tasks 2 and 4 via full-text counter labels,
+  explicit phase rendering, and elapsed runtime output in the helper-backed view.
+- FR-005 through FR-008 are covered by Tasks 1, 3, and 4 via active item labels,
+  slow-step warnings, active-first sorting, and viewport summaries.
+- FR-009 is covered by Task 1 through backend telemetry enrichment.
+- FR-010 is covered by scope: only Ink files, tests, and quality gate wiring are
+  changed; no legacy CLI contracts are modified.
+- SC-001 through SC-004 are covered by the Node and Python tests plus `../kids_movie`
+  manual validation in Task 4.
+
+## Complexity Tracking
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| None | N/A | N/A |

--- a/specs/004-ink-progress-telemetry/spec.md
+++ b/specs/004-ink-progress-telemetry/spec.md
@@ -1,0 +1,173 @@
+# Feature Specification: Ink Workflow Progress Telemetry and Slow-Step Visibility
+
+**Feature Branch**: `004-ink-progress-telemetry`  
+**Created**: 2026-04-14  
+**Status**: Draft  
+**Input**: User description: "We need more frontend progress indication especially when there are large numbers of files or a step is running slowly. Option 2 plus we need counters for each stage of the process. Labels need to be clear of what each counter is as well."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Understand Current Workflow Stage at a Glance (Priority: P1)
+
+As a developer running the Ink UI, I can see clearly labeled counters for each
+workflow stage so I know whether kcmt is collecting diffs, waiting on the LLM,
+preparing messages, committing, or pushing.
+
+**Why this priority**: The current UI can look idle even when work is happening,
+which makes the tool feel broken during normal runs.
+
+**Independent Test**: Run `kcmt` on a repository with multiple changed files and
+verify the Ink UI shows full-text counters for each stage, with values changing
+as the workflow progresses.
+
+**Acceptance Scenarios**:
+
+1. **Given** a repository with many changed files, **When** the Ink workflow is
+   running, **Then** the UI displays clear counters for `Files discovered`,
+   `Diffs collected`, `LLM requests sent`, `LLM responses received`,
+   `Messages prepared`, `Commits in progress`, `Commits completed`, `Failures`,
+   and `Push`.
+2. **Given** a user is watching a live run, **When** a stage is active,
+   **Then** the current phase label matches the actual backend stage instead of
+   collapsing everything into a generic in-progress state.
+3. **Given** the workflow completes, **When** the final state is rendered,
+   **Then** the counters remain understandable and reflect the completed run.
+
+---
+
+### User Story 2 - Identify Slow or Stalled Work Quickly (Priority: P2)
+
+As a developer waiting on kcmt, I can see which file or step is currently active
+and whether it is taking unusually long so I can distinguish a slow provider
+response from a hung workflow.
+
+**Why this priority**: The biggest trust issue is not just runtime length; it is
+the inability to tell what kcmt is waiting on.
+
+**Independent Test**: Simulate a long-running diff, LLM, commit, or push step
+and verify the Ink UI shows a pinned active item plus a slow-step warning once a
+threshold is crossed.
+
+**Acceptance Scenarios**:
+
+1. **Given** a file is waiting on an LLM response, **When** the response takes
+   longer than the configured threshold, **Then** the UI shows a highlighted
+   slow-step warning with the file path, stage label, and elapsed time.
+2. **Given** a run is actively processing a file, **When** the user views the
+   screen, **Then** the UI shows an `Active now` line naming the current file and
+   the current stage in plain language.
+3. **Given** no step has crossed a slow threshold, **When** the workflow is
+   progressing normally, **Then** the UI still shows active work without a false
+   slow warning.
+
+---
+
+### User Story 3 - Stay Oriented During Large Repository Runs (Priority: P3)
+
+As a developer running kcmt on a repository with hundreds of files, I can tell
+how many files are visible, how many remain untouched, and which files are most
+important to watch right now.
+
+**Why this priority**: Large runs overflow the visible file list, so work can be
+occurring off-screen even when the visible rows look unchanged.
+
+**Independent Test**: Run the Ink UI against a large fixture or real repository
+with hundreds of files and verify the UI reports visible vs total files, active
+vs pending counts, and sorts active or stalled files to the top during the run.
+
+**Acceptance Scenarios**:
+
+1. **Given** a run has more files than fit in the visible viewport, **When** the
+   Ink UI is rendering, **Then** it shows `Visible X of Y files` and makes it
+   clear that additional files are off-screen.
+2. **Given** some files are active or stalled, **When** the file list is shown,
+   **Then** those files are prioritised above untouched files during the live run.
+3. **Given** most files have not started yet, **When** the run is early in the
+   workflow, **Then** the UI explicitly reports how many files are not yet started.
+
+### Edge Cases
+
+- The run contains only one file, so the counter labels still need to read cleanly.
+- A file fails during prepare or commit, and the failure must appear in both the
+  per-file view and the aggregate stage counters.
+- The backend emits state changes faster than the UI refresh cadence.
+- A push step starts only after all commits are done, so the push state must not
+  be confused with commit progress.
+- A file leaves the visible list due to sorting changes while still being the
+  active or slow item.
+- The workflow is running on a narrow terminal where long labels and paths must
+  still degrade gracefully without hiding meaning.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The Ink workflow view MUST display full-text counters for each
+  major workflow stage instead of abbreviated labels such as `req` or `res`.
+- **FR-002**: The UI MUST show the current workflow phase using the labels
+  `DIFF`, `PREPARE`, `COMMIT`, and `PUSH`, with a completed state after the run.
+- **FR-003**: The UI MUST show `Files discovered`, `Diffs collected`,
+  `LLM requests sent`, `LLM responses received`, `Messages prepared`,
+  `Commits in progress`, `Commits completed`, `Failures`, and `Push`.
+- **FR-004**: The UI MUST show total elapsed runtime for the current run.
+- **FR-005**: The UI MUST show a pinned `Active now` line that identifies the
+  current active file and its current stage label in plain language.
+- **FR-006**: The UI MUST show a highlighted slow-step warning when an active
+  stage exceeds the defined threshold for that stage.
+- **FR-007**: The file list MUST sort stalled active files first, then active
+  files, then recently completed files, then untouched files while a run is live.
+- **FR-008**: The UI MUST show large-run orientation cues, including
+  `Visible X of Y files` and a count of files not yet started.
+- **FR-009**: Backend telemetry emitted to the Ink frontend MUST include enough
+  per-file state to derive clear stage counters, active-item labels, and elapsed
+  timers without requiring the UI to guess from incomplete flags.
+- **FR-010**: The existing legacy CLI path and command-line behavior MUST remain
+  unchanged by this feature.
+
+### Non-Functional Requirements *(mandatory)*
+
+- **NFR-001**: The new progress telemetry MUST preserve existing CLI compatibility
+  and MUST NOT change documented command flags, exit codes, or non-Ink output.
+- **NFR-002**: Aggregate stage counters MUST remain internally consistent with
+  the backend workflow state at every emitted update.
+- **NFR-003**: The Ink UI MUST remain readable on large runs with at least 500
+  files in scope.
+- **NFR-004**: Slow-step warnings MUST avoid false positives during ordinary fast
+  transitions while still surfacing sustained waits quickly enough to be useful.
+- **NFR-005**: Additional progress telemetry MUST NOT introduce significant UI
+  lag or visibly degrade normal workflow throughput.
+
+### Key Entities *(include if feature involves data)*
+
+- **Workflow Stage Summary**: Aggregate counters representing the current totals
+  for each named workflow stage in a live run.
+- **File Progress Record**: Per-file UI telemetry including current stage,
+  stage start time, last update time, active label, and terminal outcome.
+- **Slow Step Alert**: A derived warning for the currently active file when its
+  stage duration exceeds the threshold defined for that stage.
+- **Viewport Summary**: Large-repo orientation metadata describing total files,
+  visible files, and not-yet-started files.
+
+### Dependencies and Assumptions
+
+- The backend progress emitter remains the source of truth for stage transitions.
+- Stage thresholds can be fixed defaults for the first version and do not require
+  user configuration in this feature.
+- Per-file timestamps can be captured in the backend without changing the core
+  git or LLM workflow contracts.
+- The file list may reorder during live runs if that improves clarity for active
+  or stalled work.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: In manual validation on a large repository run, the Ink UI always
+  shows clearly labeled counters for every agreed workflow stage and no counter
+  label relies on abbreviations alone.
+- **SC-002**: In a forced slow-step validation scenario, the UI shows the active
+  file and a slow-step warning within the threshold window for the affected stage.
+- **SC-003**: In a repository run with at least 500 files, the UI reports total
+  files, visible files, and not-yet-started files without hiding off-screen work.
+- **SC-004**: Automated tests cover the backend telemetry transitions and the
+  frontend rendering of stage counters, active-item status, and slow-step alerts.

--- a/specs/004-ink-progress-telemetry/tasks.md
+++ b/specs/004-ink-progress-telemetry/tasks.md
@@ -1,0 +1,173 @@
+# Tasks: Ink Workflow Progress Telemetry and Slow-Step Visibility
+
+**Input**: Design documents from `/specs/004-ink-progress-telemetry/`  
+**Prerequisites**: plan.md, spec.md
+
+**Tests**: Tests are required for this feature because the specification requires
+backend telemetry coverage, frontend rendering coverage, and validation of large-run
+progress visibility.
+
+**Organization**: Tasks are grouped by user story so stage counters, slow-step
+visibility, and large-run orientation can be implemented and validated
+independently.
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Establish the shared Ink test harness and file layout used by all stories.
+
+- [ ] T001 [P] Add Ink frontend test entry wiring in `kcmt/ui/ink/package.json`
+- [ ] T002 [P] Create Node test scaffold for the new progress helper in `kcmt/ui/ink/src/components/workflow-progress-model.test.mjs`
+- [ ] T003 [P] Extend Ink backend test scaffolding for workflow telemetry in `tests/test_ink_backend.py`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Add the telemetry and helper scaffolding that all stories depend on.
+
+**⚠️ CRITICAL**: No user story work should begin until this phase is complete.
+
+- [ ] T004 Create the pure workflow progress helper scaffold in `kcmt/ui/ink/src/components/workflow-progress-model.mjs`
+- [ ] T005 Add per-file stage and timestamp telemetry scaffolding in `kcmt/ink_backend.py`
+- [ ] T006 [P] Import the progress helper into `kcmt/ui/ink/src/components/workflow-view.mjs` without changing displayed behavior yet
+
+**Checkpoint**: Backend snapshots carry explicit per-file stage data, and the Ink
+screen can consume the new helper module.
+
+---
+
+## Phase 3: User Story 1 - Understand Current Workflow Stage at a Glance (Priority: P1) 🎯 MVP
+
+**Goal**: Show clear, full-text workflow counters and phase labels so the Ink UI
+always explains what kcmt is doing.
+
+**Independent Test**: Run the Ink workflow against a repo with multiple changed files
+and verify the screen shows labeled counters for each stage, a current phase label,
+and total elapsed runtime without relying on abbreviations.
+
+### Tests for User Story 1
+
+- [ ] T007 [P] [US1] Add backend assertions for `current_stage`, `active_label`, and snapshot stability in `tests/test_ink_backend.py`
+- [ ] T008 [P] [US1] Add Node tests for full-text stage counters and phase labels in `kcmt/ui/ink/src/components/workflow-progress-model.test.mjs`
+
+### Implementation for User Story 1
+
+- [ ] T009 [US1] Implement labeled stage-counter derivation in `kcmt/ui/ink/src/components/workflow-progress-model.mjs`
+- [ ] T010 [US1] Render the full-text counter strip, current phase label, and total elapsed runtime in `kcmt/ui/ink/src/components/workflow-view.mjs`
+- [ ] T011 [US1] Preserve final-state rendering for completed runs in `kcmt/ui/ink/src/components/workflow-view.mjs` and `kcmt/ink_backend.py`
+
+**Checkpoint**: The Ink UI clearly shows the current phase and each stage counter in
+plain language.
+
+---
+
+## Phase 4: User Story 2 - Identify Slow or Stalled Work Quickly (Priority: P2)
+
+**Goal**: Make the currently active file and slow-running step obvious during a live run.
+
+**Independent Test**: Simulate a slow LLM or commit step and verify the screen shows
+an `Active now` line plus a slow-step warning with stage label and elapsed time.
+
+### Tests for User Story 2
+
+- [ ] T012 [P] [US2] Add backend transition-timing tests in `tests/test_ink_backend.py`
+- [ ] T013 [P] [US2] Add Node tests for active-item selection and slow-step warnings in `kcmt/ui/ink/src/components/workflow-progress-model.test.mjs`
+
+### Implementation for User Story 2
+
+- [ ] T014 [US2] Implement active-item selection and human-readable stage labels in `kcmt/ui/ink/src/components/workflow-progress-model.mjs`
+- [ ] T015 [US2] Implement slow-step threshold logic and alert text in `kcmt/ui/ink/src/components/workflow-progress-model.mjs`
+- [ ] T016 [US2] Render the `Active now`, slow-step, and footer status lines in `kcmt/ui/ink/src/components/workflow-view.mjs`
+
+**Checkpoint**: A user can tell which file is active and whether a slow wait is due
+to diffing, the LLM, commit, or push.
+
+---
+
+## Phase 5: User Story 3 - Stay Oriented During Large Repository Runs (Priority: P3)
+
+**Goal**: Make off-screen work visible and prioritise active or stalled files during
+large runs.
+
+**Independent Test**: Run against a large repository fixture and verify the screen
+shows `Visible X of Y files`, a not-yet-started count, and active-first file ordering.
+
+### Tests for User Story 3
+
+- [ ] T017 [P] [US3] Add Node tests for viewport summaries, not-started counts, and active-first ordering in `kcmt/ui/ink/src/components/workflow-progress-model.test.mjs`
+
+### Implementation for User Story 3
+
+- [ ] T018 [US3] Implement viewport summary and not-started count derivation in `kcmt/ui/ink/src/components/workflow-progress-model.mjs`
+- [ ] T019 [US3] Implement active-first and slow-first file ordering in `kcmt/ui/ink/src/components/workflow-progress-model.mjs`
+- [ ] T020 [US3] Render large-run orientation text and ordered file rows in `kcmt/ui/ink/src/components/workflow-view.mjs`
+
+**Checkpoint**: Large runs remain understandable even when most files are outside the
+visible viewport.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Wire the new test gate into repo checks and validate the end-to-end experience.
+
+- [ ] T021 [P] Add an Ink-specific frontend test target to `Makefile`
+- [ ] T022 Run targeted validation in `tests/test_ink_backend.py` and `kcmt/ui/ink/src/components/workflow-progress-model.test.mjs`
+- [ ] T023 Validate the live Ink workflow against `../kids_movie` using `uv run kcmt --repo-path ../kids_movie --limit 1` and a larger run without `--limit`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1: Setup**: Starts immediately.
+- **Phase 2: Foundational**: Depends on Phase 1 and blocks all user stories.
+- **Phase 3: US1**: Depends on Foundational and delivers the MVP.
+- **Phase 4: US2**: Depends on US1 because slow-step visibility needs the clear
+  stage model and labeled counters to exist first.
+- **Phase 5: US3**: Depends on US1 and US2 because large-run orientation builds on
+  the same enriched progress model and active-item ordering.
+- **Phase 6: Polish**: Depends on all desired stories being complete.
+
+### User Story Dependencies
+
+- **US1**: No dependency beyond Foundational.
+- **US2**: Requires US1’s labeled counters and phase model.
+- **US3**: Requires the shared progress model from US1 and benefits from the active
+  file semantics from US2.
+
+### Parallel Opportunities
+
+- T001-T003 can run in parallel during Setup.
+- T005 and T006 can run in parallel after T004 is established.
+- T007 and T008 can run in parallel inside US1.
+- T012 and T013 can run in parallel inside US2.
+- T017 can run while US2 implementation work is being prepared.
+- T021 and T022 can run in parallel during Polish once implementation is complete.
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup
+2. Complete Phase 2: Foundational
+3. Complete Phase 3: User Story 1
+4. Validate that the Ink UI now clearly explains the workflow stages
+
+### Incremental Delivery
+
+1. Deliver US1 so the workflow stage counters and phase labels become trustworthy
+2. Add US2 so slow or stalled work is visible
+3. Add US3 so large-repo runs remain understandable
+4. Finish with repo-level test wiring and live validation
+
+### Suggested Subagent Sequence
+
+1. Task group T001-T006 to establish the shared progress model and telemetry hooks
+2. Task group T007-T011 to land the MVP counter and phase labeling
+3. Task group T012-T016 to add active-item and slow-step visibility
+4. Task group T017-T020 to finish large-run orientation
+5. Task group T021-T023 to wire validation and perform live checks

--- a/tests/test_ink_backend.py
+++ b/tests/test_ink_backend.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import kcmt.ink_backend as ink_backend
 
 
@@ -55,3 +57,82 @@ def test_action_benchmark_rejects_runtime_specific_options(monkeypatch):
             },
         )
     ]
+
+
+def _build_ink_workflow(monkeypatch):
+    def fake_init(self, **_kwargs):
+        self._config = SimpleNamespace(provider="xai", model="grok-code-fast-1")
+        self._progress_history = []
+
+    monkeypatch.setattr(ink_backend.KlingonCMTWorkflow, "__init__", fake_init)
+
+    events: list[tuple[str, dict[str, str]]] = []
+    workflow = ink_backend.InkWorkflow(
+        lambda event, payload: events.append((event, payload)),
+        repo_path=".",
+    )
+    return workflow, events
+
+
+def test_ink_workflow_tracks_stage_metadata_and_snapshot_stability(monkeypatch):
+    workflow, _events = _build_ink_workflow(monkeypatch)
+
+    times = iter([10.0, 13.5])
+    monkeypatch.setattr(ink_backend.time, "time", lambda: next(times))
+
+    workflow._progress_event("diff-ready", file="alpha.py")
+    first = workflow.file_states_snapshot()["alpha.py"]
+
+    assert first["current_stage"] == "diff"
+    assert first["active_label"] == "collecting diff"
+    assert first["stage_started_at"] == 10.0
+    assert first["last_update_at"] == 10.0
+    assert first["diff"] == "yes"
+
+    first["current_stage"] = "mutated"
+    snapshot = workflow.file_states_snapshot()
+    assert snapshot["alpha.py"]["current_stage"] == "diff"
+
+    workflow._progress_event("request-sent", file="alpha.py")
+    second = workflow.file_states_snapshot()["alpha.py"]
+
+    assert second["current_stage"] == "llm_wait"
+    assert second["active_label"] == "waiting for LLM response"
+    assert second["stage_started_at"] == 13.5
+    assert second["last_update_at"] == 13.5
+    assert second["req"] == "sent"
+    assert second["batch"] == "validating"
+
+
+def test_ink_workflow_tracks_terminal_stage_transitions(monkeypatch):
+    workflow, _events = _build_ink_workflow(monkeypatch)
+
+    times = iter([20.0, 25.0, 30.0, 45.0])
+    monkeypatch.setattr(ink_backend.time, "time", lambda: next(times))
+
+    workflow._progress_event("response", file="alpha.py")
+    response_snapshot = workflow.file_states_snapshot()["alpha.py"]
+    assert response_snapshot["current_stage"] == "prepared"
+    assert response_snapshot["active_label"] == "message prepared"
+    assert response_snapshot["res"] == "ok"
+
+    workflow._progress_event("commit-start", file="alpha.py")
+    commit_snapshot = workflow.file_states_snapshot()["alpha.py"]
+    assert commit_snapshot["current_stage"] == "commit"
+    assert commit_snapshot["active_label"] == "writing commit"
+    assert commit_snapshot["commit"] == "running"
+    assert commit_snapshot["stage_started_at"] == 25.0
+
+    workflow._progress_event("commit-done", file="alpha.py")
+    done_snapshot = workflow.file_states_snapshot()["alpha.py"]
+    assert done_snapshot["current_stage"] == "done"
+    assert done_snapshot["active_label"] == "commit complete"
+    assert done_snapshot["commit"] == "ok"
+    assert done_snapshot["stage_started_at"] == 30.0
+
+    workflow._progress_event("commit-error", file="bravo.py", detail="boom")
+    error_snapshot = workflow.file_states_snapshot()["bravo.py"]
+    assert error_snapshot["current_stage"] == "failed"
+    assert error_snapshot["active_label"] == "commit failed"
+    assert error_snapshot["commit"] == "err"
+    assert error_snapshot["stage_started_at"] == 45.0


### PR DESCRIPTION
## Summary
- add richer Ink workflow telemetry with per-file stages, labels, and timestamps from the Python backend
- introduce a pure progress-model helper for full-text stage counters, phase labels, active and slow status, and large-run ordering/orientation
- update the Ink workflow view and repo test wiring to surface the new progress signals with targeted Node and Python coverage

## Test Plan
- [x] `rtk npm --prefix kcmt/ui/ink test`
- [x] `rtk make test-ink`
- [x] `rtk uv run pytest -q --no-cov tests/test_ink_backend.py`
- [x] `rtk uv run ruff check kcmt/ink_backend.py tests/test_ink_backend.py`
- [x] `rtk node --check kcmt/ui/ink/src/components/workflow-view.mjs`
- [x] live Ink smoke on disposable copies of `../kids_movie` for single-file provider wait-state, phase transition, and elapsed-time verification
- [x] stale-base check against `origin/main` via `git merge-tree` (no conflicts reported)