### PR TITLE
feat(rust): harden live llm provider workflows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install install-dev format ruff-fix lint test test-ink test-rust test-verbose test-strict coverage check quality-gates typecheck clean clean-build clean-cache clean-pyc clean-test build version bump-patch bump-minor bump-major release release-test dev-setup dev-check quick-patch quick-minor quick-major
+.PHONY: help install install-dev format ruff-fix lint test test-ink test-rust test-llm-matrix test-verbose test-strict coverage check quality-gates typecheck clean clean-build clean-cache clean-pyc clean-test build version bump-patch bump-minor bump-major release release-test dev-setup dev-check quick-patch quick-minor quick-major
 # Default target
 help:
 	@echo "Available targets:"
@@ -11,6 +11,7 @@ help:
 	@echo "  lint          Lint code with ruff"
 	@echo "  test          Run tests"
 	@echo "  test-rust     Run Rust workspace tests"
+	@echo "  test-llm-matrix Run live Rust LLM provider matrix"
 	@echo "  test-verbose  Run tests with verbose output"
 	@echo "  coverage      Run tests with coverage report"
 	@echo "  check         Run all fixes and checks (ruff --fix, format, lint, typecheck, test)"
@@ -75,6 +76,9 @@ test-ink:
 
 test-rust:
 	cargo test --manifest-path rust/Cargo.toml --workspace --no-fail-fast
+
+test-llm-matrix:
+	KCMT_LIVE_LLM_MATRIX=1 cargo test --manifest-path rust/Cargo.toml -p kcmt-cli --test live_llm_matrix -- --ignored --nocapture
 
 test-verbose:
 	$(PYTEST) -v

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ test -n "$OPENAI_API_KEY" && \
 
 test -n "$ANTHROPIC_API_KEY" && \
   ./rust/target/release/kcmt --provider anthropic --api-key-env ANTHROPIC_API_KEY \
-    --model claude-3-5-haiku-latest --file path/to/changed-file --no-auto-push --repo-path .
+    --model claude-sonnet-4-20250514 --file path/to/changed-file --no-auto-push --repo-path .
 
 test -n "$OPENAI_API_KEY" && \
   ./rust/target/release/kcmt --provider openai --api-key-env OPENAI_API_KEY \
@@ -186,7 +186,7 @@ test -n "$OPENAI_API_KEY" && \
 | Provider  | Default model             | Default endpoint                         |
 |-----------|---------------------------|------------------------------------------|
 | OpenAI    | `gpt-5-mini-2025-08-07`   | `https://api.openai.com/v1`              |
-| Anthropic | `claude-3-5-haiku-latest` | `https://api.anthropic.com`             |
+| Anthropic | `claude-sonnet-4-20250514` | `https://api.anthropic.com`             |
 | xAI       | `grok-code-fast`          | `https://api.x.ai/v1`                   |
 | GitHub    | `openai/gpt-4.1-mini`     | `https://models.github.ai/inference`    |
 

--- a/README.md
+++ b/README.md
@@ -132,7 +132,54 @@ OpenAI batch mode
 
 - Enable with `--batch` (or via the configure menu) to route commit message generation through the OpenAI Batch API.
 - Pick the batch model interactively; defaults to your OpenAI preferred model. Override on the CLI with `--batch-model`.
-- kcmt shows a spinner while the batch job runs and polls for up to 5 minutes by default (tunable via `--batch-timeout` or `KCMT_BATCH_TIMEOUT`).
+- kcmt polls batch jobs for at least 15 minutes by default (tunable upward via
+  `--batch-timeout` or `KCMT_BATCH_TIMEOUT`).
+- Rust batch mode uploads all file prompts before writing commits, maps responses by
+  `custom_id`, commits valid responses, and reports per-file failures for invalid
+  model/output or provider errors without printing API key values.
+
+### Rust-only install and live smoke
+
+Build the Rust binaries directly from the repo root:
+
+```shell
+cargo build --release --manifest-path rust/Cargo.toml -p kcmt-cli
+```
+
+Run Rust without the Python wrapper:
+
+```shell
+./rust/target/release/kcmt --repo-path .
+./rust/target/release/commit --repo-path .
+./rust/target/release/kc --repo-path .
+```
+
+To make `kcmt` resolve to Rust in a shell session, put the release directory
+before the Python environment on `PATH`:
+
+```shell
+export PATH="$(pwd)/rust/target/release:$PATH"
+kcmt --help
+```
+
+Optional live smoke commands use real provider keys only when the corresponding
+environment variable is already set. They do not print secret values; `status
+--raw` records the env var name, not the key.
+
+```shell
+test -n "$OPENAI_API_KEY" && \
+  ./rust/target/release/kcmt --provider openai --api-key-env OPENAI_API_KEY \
+    --model gpt-5-mini-2025-08-07 --file path/to/changed-file --no-auto-push --repo-path .
+
+test -n "$ANTHROPIC_API_KEY" && \
+  ./rust/target/release/kcmt --provider anthropic --api-key-env ANTHROPIC_API_KEY \
+    --model claude-3-5-haiku-latest --file path/to/changed-file --no-auto-push --repo-path .
+
+test -n "$OPENAI_API_KEY" && \
+  ./rust/target/release/kcmt --provider openai --api-key-env OPENAI_API_KEY \
+    --batch --batch-model gpt-5-mini-2025-08-07 --batch-timeout 900 \
+    --no-auto-push --repo-path .
+```
 
 ### Provider defaults
 

--- a/docs/rust-migration-rollout.md
+++ b/docs/rust-migration-rollout.md
@@ -70,7 +70,7 @@ test -n "$OPENAI_API_KEY" && \
 
 test -n "$ANTHROPIC_API_KEY" && \
   ./rust/target/release/kcmt --provider anthropic --api-key-env ANTHROPIC_API_KEY \
-    --model claude-3-5-haiku-latest --file path/to/changed-file --no-auto-push --repo-path .
+    --model claude-sonnet-4-20250514 --file path/to/changed-file --no-auto-push --repo-path .
 
 test -n "$OPENAI_API_KEY" && \
   ./rust/target/release/kcmt --provider openai --api-key-env OPENAI_API_KEY \

--- a/docs/rust-migration-rollout.md
+++ b/docs/rust-migration-rollout.md
@@ -50,6 +50,47 @@ The runtime report includes one baseline row plus five optimization rows with
 timings, throughput, quality scores, failures, and the next bottleneck label for
 each iteration.
 
+### Rust-Only Live LLM Smoke
+
+Build and run the Rust binary directly when validating production cutover:
+
+```bash
+cargo build --release --manifest-path rust/Cargo.toml -p kcmt-cli
+./rust/target/release/kcmt --help
+```
+
+Run live provider smoke checks only when the relevant key is already present in
+the environment. Keep `--no-auto-push` for smoke runs unless the branch is meant
+to publish commits.
+
+```bash
+test -n "$OPENAI_API_KEY" && \
+  ./rust/target/release/kcmt --provider openai --api-key-env OPENAI_API_KEY \
+    --model gpt-5-mini-2025-08-07 --file path/to/changed-file --no-auto-push --repo-path .
+
+test -n "$ANTHROPIC_API_KEY" && \
+  ./rust/target/release/kcmt --provider anthropic --api-key-env ANTHROPIC_API_KEY \
+    --model claude-3-5-haiku-latest --file path/to/changed-file --no-auto-push --repo-path .
+
+test -n "$OPENAI_API_KEY" && \
+  ./rust/target/release/kcmt --provider openai --api-key-env OPENAI_API_KEY \
+    --batch --batch-model gpt-5-mini-2025-08-07 --batch-timeout 900 \
+    --no-auto-push --repo-path .
+```
+
+Expected production-readiness behavior:
+
+- Direct OpenAI and Anthropic calls fail fast for missing keys, invalid models,
+  malformed provider output, and provider 4xx/5xx responses.
+- OpenAI batch mode uploads every file prompt before committing, maps responses
+  by `custom_id`, commits valid responses, and reports invalid or missing
+  responses per file.
+- Debug/profile output and status snapshots record provider names, model names,
+  endpoints, and API key environment variable names, but not API key values.
+- To make `kcmt`, `commit`, and `kc` point at Rust without the Python wrapper,
+  prepend `$(pwd)/rust/target/release` to `PATH` or install those release
+  binaries into the operator's normal bin directory.
+
 ## Rollback Procedure
 
 1. Set `KCMT_RUNTIME=python` in runtime environment.

--- a/rust/crates/kcmt-cli/src/commands/benchmark.rs
+++ b/rust/crates/kcmt-cli/src/commands/benchmark.rs
@@ -28,8 +28,8 @@ const PROVIDER_DEFAULTS: &[(&str, &str, &str, &str)] = &[
     ),
     (
         "anthropic",
-        "claude-3-5-haiku-latest",
-        "https://api.anthropic.com/v1",
+        "claude-sonnet-4-20250514",
+        "https://api.anthropic.com",
         "ANTHROPIC_API_KEY",
     ),
     (

--- a/rust/crates/kcmt-cli/src/commands/configure.rs
+++ b/rust/crates/kcmt-cli/src/commands/configure.rs
@@ -17,8 +17,8 @@ const PROVIDERS: &[(&str, &str, &str, &str, &str)] = &[
     (
         "anthropic",
         "Anthropic",
-        "claude-3-5-haiku-latest",
-        "https://api.anthropic.com/v1",
+        "claude-sonnet-4-20250514",
+        "https://api.anthropic.com",
         "ANTHROPIC_API_KEY",
     ),
     (

--- a/rust/crates/kcmt-cli/src/commands/workflow.rs
+++ b/rust/crates/kcmt-cli/src/commands/workflow.rs
@@ -2,6 +2,9 @@ use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::mpsc;
+use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
 use std::time::Instant;
@@ -18,6 +21,7 @@ use kcmt_core::message::{build_prompt, sanitize_commit_output};
 use kcmt_provider::clients::{
     AnthropicClient, GitHubModelsClient, OpenAiBatchJob, OpenAiClient, ProviderMessage, XaiClient,
 };
+use kcmt_provider::error_map::normalize_error;
 use kcmt_provider::transport::{AsyncTransport, RetryPolicy};
 use serde_json::json;
 
@@ -116,6 +120,87 @@ struct PreparationResult {
 }
 
 #[derive(Debug, Clone)]
+struct WorkflowProgress {
+    enabled: bool,
+    mode: &'static str,
+    total: usize,
+    queued: Arc<AtomicUsize>,
+    completed: Arc<AtomicUsize>,
+    failed: Arc<AtomicUsize>,
+}
+
+impl WorkflowProgress {
+    fn new(mode: &'static str, total: usize, options: &WorkflowOutputOptions) -> Self {
+        let progress = Self {
+            enabled: progress_enabled(options) && total > 0,
+            mode,
+            total,
+            queued: Arc::new(AtomicUsize::new(0)),
+            completed: Arc::new(AtomicUsize::new(0)),
+            failed: Arc::new(AtomicUsize::new(0)),
+        };
+        progress.summary("start");
+        progress
+    }
+
+    fn queued(&self, stage: &'static str, file_path: &str) {
+        self.queued.fetch_add(1, Ordering::Relaxed);
+        self.render(stage, Some(file_path), None);
+    }
+
+    fn event(&self, stage: &'static str, file_path: &str) {
+        self.render(stage, Some(file_path), None);
+    }
+
+    fn completed(&self, file_path: &str) {
+        self.completed.fetch_add(1, Ordering::Relaxed);
+        self.render("done", Some(file_path), Some("ok"));
+    }
+
+    fn failed(&self, file_path: &str) {
+        self.failed.fetch_add(1, Ordering::Relaxed);
+        self.render("done", Some(file_path), Some("failed"));
+    }
+
+    fn summary(&self, stage: &'static str) {
+        self.render(stage, None, None);
+    }
+
+    fn render(&self, stage: &'static str, file_path: Option<&str>, status: Option<&str>) {
+        if !self.enabled {
+            return;
+        }
+        let queued = self.queued.load(Ordering::Relaxed);
+        let completed = self.completed.load(Ordering::Relaxed);
+        let failed = self.failed.load(Ordering::Relaxed);
+        let pending = self.total.saturating_sub(completed + failed);
+        let mut line = format!(
+            "kcmt progress: mode={} stage={} total={} queued={} pending={} completed={} failed={}",
+            self.mode, stage, self.total, queued, pending, completed, failed
+        );
+        if let Some(status) = status {
+            line.push_str(&format!(" status={status}"));
+        }
+        if let Some(file_path) = file_path {
+            line.push_str(&format!(" file={file_path}"));
+        }
+        eprintln!("{line}");
+    }
+}
+
+struct BatchProgress {
+    stop: mpsc::Sender<()>,
+    handle: thread::JoinHandle<()>,
+}
+
+impl BatchProgress {
+    fn stop(self) {
+        let _ = self.stop.send(());
+        let _ = self.handle.join();
+    }
+}
+
+#[derive(Debug, Clone)]
 struct ProviderCandidate {
     provider: String,
     model: String,
@@ -144,6 +229,7 @@ impl PushOutcome {
 pub struct WorkflowOutputOptions {
     pub compact: bool,
     pub verbose: bool,
+    pub no_progress: bool,
     pub profile_startup: bool,
     pub startup_stages: Vec<WorkflowStageTiming>,
 }
@@ -329,9 +415,21 @@ fn run_entries_workflow(
 
     let prepare_workers = select_prepare_workers(entries.len(), prepare_workers_override);
     telemetry.prepare_workers = prepare_workers;
+    let progress_mode = if should_use_provider_batch(config) {
+        "batch"
+    } else {
+        "direct"
+    };
+    let progress = WorkflowProgress::new(progress_mode, entries.len(), &output_options);
     let wait_start = Instant::now();
-    let preparation =
-        prepare_messages_for_entries(&repo_path, entries, config, max_attempts, prepare_workers)?;
+    let preparation = prepare_messages_for_entries(
+        &repo_path,
+        entries,
+        config,
+        max_attempts,
+        prepare_workers,
+        progress,
+    )?;
     telemetry.record_duration(
         "diff_preparation",
         preparation.telemetry.diff_preparation_ms,
@@ -630,6 +728,40 @@ fn runtime_benchmark_enabled() -> bool {
     env_truthy("KCMT_RUNTIME_BENCHMARK")
 }
 
+fn progress_enabled(options: &WorkflowOutputOptions) -> bool {
+    !runtime_benchmark_enabled() && !options.no_progress && !env_truthy("KCMT_NO_PROGRESS")
+}
+
+fn start_batch_progress(
+    progress: WorkflowProgress,
+    model: &str,
+    timeout: Duration,
+) -> Option<BatchProgress> {
+    if !progress.enabled {
+        return None;
+    }
+    progress.summary("submitted");
+    let (stop, receiver) = mpsc::channel();
+    let model = model.to_string();
+    let handle = thread::spawn(move || {
+        let started = Instant::now();
+        loop {
+            match receiver.recv_timeout(Duration::from_secs(15)) {
+                Ok(()) | Err(mpsc::RecvTimeoutError::Disconnected) => break,
+                Err(mpsc::RecvTimeoutError::Timeout) => {
+                    progress.summary("waiting");
+                    eprintln!(
+                        "kcmt progress detail: mode=batch stage=waiting model={model} timeout={}s elapsed={:.0}s",
+                        timeout.as_secs(),
+                        started.elapsed().as_secs_f64()
+                    );
+                }
+            }
+        }
+    });
+    Some(BatchProgress { stop, handle })
+}
+
 fn env_truthy(key: &str) -> bool {
     env::var(key)
         .map(|value| {
@@ -647,15 +779,17 @@ fn prepare_messages_for_entries(
     config: &kcmt_core::model::WorkflowConfig,
     max_attempts: usize,
     prepare_workers: usize,
+    progress: WorkflowProgress,
 ) -> Result<PreparationResult> {
-    if should_use_openai_batch(config) {
+    if should_use_provider_batch(config) {
         if let Some(api_key) = configured_api_key(config) {
-            return prepare_openai_batch_messages(
+            return prepare_provider_batch_messages(
                 repo_path,
                 entries,
                 config,
                 &api_key,
                 max_attempts,
+                progress,
             );
         }
     }
@@ -663,21 +797,37 @@ fn prepare_messages_for_entries(
     if prepare_workers <= 1 || entries.len() <= 1 {
         let outcomes = entries
             .into_iter()
-            .map(
-                |entry| match commit_message_for_entry(repo_path, &entry, config, max_attempts) {
-                    Ok(message) => Ok(PreparedEntry { entry, message }),
-                    Err(err) => Err(WorkflowFailure::prepare(&entry, err.to_string())),
-                },
-            )
+            .map(|entry| {
+                progress.queued("diff", &entry.path);
+                progress.event("llm", &entry.path);
+                match commit_message_for_entry(repo_path, &entry, config, max_attempts) {
+                    Ok(message) => {
+                        progress.completed(&entry.path);
+                        Ok(PreparedEntry { entry, message })
+                    }
+                    Err(err) => {
+                        progress.failed(&entry.path);
+                        Err(WorkflowFailure::prepare(&entry, err.to_string()))
+                    }
+                }
+            })
             .collect::<Vec<_>>();
+        progress.summary("results");
         return Ok(PreparationResult {
             outcomes,
             telemetry: PreparationTelemetry::default(),
         });
     }
 
-    let outcomes =
-        prepare_messages_in_workers(repo_path, entries, config, max_attempts, prepare_workers)?;
+    let outcomes = prepare_messages_in_workers(
+        repo_path,
+        entries,
+        config,
+        max_attempts,
+        prepare_workers,
+        progress.clone(),
+    )?;
+    progress.summary("results");
     Ok(PreparationResult {
         outcomes,
         telemetry: PreparationTelemetry::default(),
@@ -690,6 +840,7 @@ fn prepare_messages_in_workers(
     config: &kcmt_core::model::WorkflowConfig,
     max_attempts: usize,
     prepare_workers: usize,
+    progress: WorkflowProgress,
 ) -> Result<Vec<PreparedOutcome>> {
     let worker_count = prepare_workers.min(entries.len()).max(1);
     let mut buckets = vec![Vec::<(usize, StatusEntry)>::new(); worker_count];
@@ -703,18 +854,27 @@ fn prepare_messages_in_workers(
         .map(|bucket| {
             let repo_path = repo_path.to_path_buf();
             let config = config.clone();
+            let progress = progress.clone();
             thread::spawn(move || {
                 bucket
                     .into_iter()
                     .map(|(index, entry)| {
+                        progress.queued("diff", &entry.path);
+                        progress.event("llm", &entry.path);
                         let outcome = match commit_message_for_entry(
                             &repo_path,
                             &entry,
                             &config,
                             max_attempts,
                         ) {
-                            Ok(message) => Ok(PreparedEntry { entry, message }),
-                            Err(err) => Err(WorkflowFailure::prepare(&entry, err.to_string())),
+                            Ok(message) => {
+                                progress.completed(&entry.path);
+                                Ok(PreparedEntry { entry, message })
+                            }
+                            Err(err) => {
+                                progress.failed(&entry.path);
+                                Err(WorkflowFailure::prepare(&entry, err.to_string()))
+                            }
                         };
                         (index, outcome)
                     })
@@ -734,35 +894,42 @@ fn prepare_messages_in_workers(
     Ok(indexed.into_iter().map(|(_, entry)| entry).collect())
 }
 
-fn should_use_openai_batch(config: &kcmt_core::model::WorkflowConfig) -> bool {
-    config.provider == "openai" && config.use_batch
+fn should_use_provider_batch(config: &kcmt_core::model::WorkflowConfig) -> bool {
+    matches!(config.provider.as_str(), "openai" | "xai") && config.use_batch
 }
 
-fn prepare_openai_batch_messages(
+const COMMIT_MESSAGE_SYSTEM_PROMPT: &str = "You generate strictly valid Conventional Commit messages. Return only the commit message. Keep the subject <=72 characters. Prefer a single subject line for simple diffs. Use a body only when it materially improves quality; limit body to three concise factual bullets.";
+
+fn prepare_provider_batch_messages(
     repo_path: &Path,
     entries: Vec<StatusEntry>,
     config: &kcmt_core::model::WorkflowConfig,
     api_key: &str,
     max_attempts: usize,
+    progress: WorkflowProgress,
 ) -> Result<PreparationResult> {
     let mut outcomes = Vec::new();
     let mut batch_entries = Vec::new();
     let mut jobs = Vec::new();
     let mut telemetry = PreparationTelemetry::default();
-    let system = "You generate strictly valid Conventional Commit messages.";
+    let system = COMMIT_MESSAGE_SYSTEM_PROMPT;
     for entry in entries {
         if entry.is_deletion() {
             let message = deletion_commit_message(&entry.path, config.max_commit_length);
+            progress.queued("local", &entry.path);
+            progress.completed(&entry.path);
             outcomes.push(Ok(PreparedEntry { entry, message }));
             continue;
         }
 
+        progress.queued("diff", &entry.path);
         let diff_start = Instant::now();
         let diff = match diff_for_entry(repo_path, &entry) {
             Ok(diff) => diff,
             Err(err) => {
                 telemetry.diff_preparation_ms += diff_start.elapsed().as_secs_f64() * 1000.0;
                 telemetry.diff_preparation_items += 1;
+                progress.failed(&entry.path);
                 outcomes.push(Err(WorkflowFailure::prepare(&entry, err.to_string())));
                 continue;
             }
@@ -781,6 +948,7 @@ fn prepare_openai_batch_messages(
         });
         telemetry.llm_enqueue_ms += enqueue_start.elapsed().as_secs_f64() * 1000.0;
         telemetry.llm_enqueue_items += 1;
+        progress.event("queued", &entry.path);
         batch_entries.push(entry);
     }
     if batch_entries.is_empty() {
@@ -854,23 +1022,53 @@ fn prepare_openai_batch_messages(
         .as_deref()
         .filter(|value| !value.trim().is_empty())
         .unwrap_or(&config.model);
-    let results = match runtime.block_on(OpenAiClient::invoke_batch(
-        &transport,
-        &config.llm_endpoint,
-        api_key,
-        batch_model,
-        &jobs,
-        Duration::from_secs(config.batch_timeout_seconds),
-        Duration::from_millis(50),
-    )) {
-        Ok(results) => results,
+    let batch_timeout = Duration::from_secs(config.batch_timeout_seconds);
+    let batch_wait = start_batch_progress(progress.clone(), batch_model, batch_timeout);
+    let batch_output = match runtime.block_on(async {
+        match config.provider.as_str() {
+            "openai" => {
+                OpenAiClient::invoke_batch(
+                    &transport,
+                    &config.llm_endpoint,
+                    api_key,
+                    batch_model,
+                    &jobs,
+                    batch_timeout,
+                    Duration::from_millis(50),
+                )
+                .await
+            }
+            "xai" => {
+                XaiClient::invoke_batch(
+                    &transport,
+                    &config.llm_endpoint,
+                    api_key,
+                    batch_model,
+                    &jobs,
+                    batch_timeout,
+                    Duration::from_millis(5000),
+                )
+                .await
+            }
+            other => Err(anyhow::anyhow!("unsupported batch provider: {other}")),
+        }
+    }) {
+        Ok(output) => {
+            if let Some(batch_wait) = batch_wait {
+                batch_wait.stop();
+            }
+            output
+        }
         Err(err) => {
-            let error = format!("provider batch request failed: {err}");
-            outcomes.extend(
-                batch_entries
-                    .into_iter()
-                    .map(|entry| Err(WorkflowFailure::prepare(&entry, error.clone()))),
-            );
+            if let Some(batch_wait) = batch_wait {
+                batch_wait.stop();
+            }
+            let error = provider_error_message("provider batch request failed", &err.to_string());
+            outcomes.extend(batch_entries.into_iter().map(|entry| {
+                progress.failed(&entry.path);
+                Err(WorkflowFailure::prepare(&entry, error.clone()))
+            }));
+            progress.summary("results");
             return Ok(PreparationResult {
                 outcomes,
                 telemetry,
@@ -879,7 +1077,7 @@ fn prepare_openai_batch_messages(
     };
     let mut messages_by_id = std::collections::BTreeMap::new();
     let mut errors_by_id = std::collections::BTreeMap::new();
-    for result in results {
+    for result in batch_output.results {
         match sanitize_commit_output(&result.content) {
             Ok(message) => {
                 messages_by_id.insert(
@@ -892,19 +1090,29 @@ fn prepare_openai_batch_messages(
             }
         }
     }
+    for failure in batch_output.failures {
+        errors_by_id.insert(
+            failure.custom_id,
+            provider_error_message("provider batch response failed", &failure.error),
+        );
+    }
 
     for entry in batch_entries {
         if let Some(message) = messages_by_id.remove(&entry.path) {
+            progress.completed(&entry.path);
             outcomes.push(Ok(PreparedEntry { entry, message }));
         } else if let Some(error) = errors_by_id.remove(&entry.path) {
+            progress.failed(&entry.path);
             outcomes.push(Err(WorkflowFailure::prepare(&entry, error)));
         } else {
+            progress.failed(&entry.path);
             outcomes.push(Err(WorkflowFailure::prepare(
                 &entry,
                 format!("batch response missing {}", entry.path),
             )));
         }
     }
+    progress.summary("results");
     Ok(PreparationResult {
         outcomes,
         telemetry,
@@ -958,7 +1166,7 @@ fn provider_candidates(config: &kcmt_core::model::WorkflowConfig) -> Vec<Provide
 
 fn default_provider_endpoint(provider: &str) -> &'static str {
     match provider {
-        "anthropic" => "https://api.anthropic.com/v1",
+        "anthropic" => "https://api.anthropic.com",
         "xai" => "https://api.x.ai/v1",
         "github" => "https://models.github.ai/inference",
         _ => "https://api.openai.com/v1",
@@ -1017,7 +1225,7 @@ fn invoke_provider_candidate(
     let diff = diff_for_entry(repo_path, entry)?;
     let context = format!("File: {}", entry.path);
     let prompt = build_prompt(&diff, &context, "conventional");
-    let system = "You generate strictly valid Conventional Commit messages.";
+    let system = COMMIT_MESSAGE_SYSTEM_PROMPT;
     let runtime = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
@@ -1091,7 +1299,26 @@ fn invoke_provider_candidate(
                 other => Err(anyhow::anyhow!("unsupported provider: {other}")),
             }
         })
-        .map_err(|err| KcmtError::Message(format!("provider request failed: {err}")))
+        .map_err(|err| {
+            KcmtError::Message(provider_error_message(
+                "provider request failed",
+                &err.to_string(),
+            ))
+        })
+}
+
+fn provider_error_message(prefix: &str, raw_error: &str) -> String {
+    let normalized = normalize_error(raw_error, provider_status_from_error(raw_error));
+    format!("{prefix}: {}", normalized.message)
+}
+
+fn provider_status_from_error(raw_error: &str) -> Option<u16> {
+    raw_error.split_whitespace().find_map(|part| {
+        part.trim_matches(|ch: char| !ch.is_ascii_digit())
+            .parse::<u16>()
+            .ok()
+            .filter(|status| (400..=599).contains(status))
+    })
 }
 
 fn diff_for_entry(repo_path: &Path, entry: &StatusEntry) -> Result<String> {

--- a/rust/crates/kcmt-cli/src/commands/workflow.rs
+++ b/rust/crates/kcmt-cli/src/commands/workflow.rs
@@ -898,7 +898,11 @@ fn should_use_provider_batch(config: &kcmt_core::model::WorkflowConfig) -> bool 
     matches!(config.provider.as_str(), "openai" | "xai") && config.use_batch
 }
 
-const COMMIT_MESSAGE_SYSTEM_PROMPT: &str = "You generate strictly valid Conventional Commit messages. Return only the commit message. Keep the subject <=72 characters. Prefer a single subject line for simple diffs. Use a body only when it materially improves quality; limit body to three concise factual bullets.";
+fn commit_message_system_prompt(max_commit_length: usize) -> String {
+    format!(
+        "You generate strictly valid Conventional Commit messages. Return only the commit message. Keep the subject <={max_commit_length} characters. Prefer a single subject line for simple diffs. Use a body only when it materially improves quality; limit body to three concise factual bullets."
+    )
+}
 
 fn prepare_provider_batch_messages(
     repo_path: &Path,
@@ -912,7 +916,7 @@ fn prepare_provider_batch_messages(
     let mut batch_entries = Vec::new();
     let mut jobs = Vec::new();
     let mut telemetry = PreparationTelemetry::default();
-    let system = COMMIT_MESSAGE_SYSTEM_PROMPT;
+    let system = commit_message_system_prompt(config.max_commit_length);
     for entry in entries {
         if entry.is_deletion() {
             let message = deletion_commit_message(&entry.path, config.max_commit_length);
@@ -942,7 +946,7 @@ fn prepare_provider_batch_messages(
         jobs.push(OpenAiBatchJob {
             custom_id: entry.path.clone(),
             messages: vec![
-                ProviderMessage::system(system),
+                ProviderMessage::system(system.as_str()),
                 ProviderMessage::user(prompt),
             ],
         });
@@ -1200,12 +1204,19 @@ fn invoke_provider_with_fallback(
         let Some(api_key) = api_key_for_env(&candidate.api_key_env) else {
             continue;
         };
-        match invoke_provider_candidate(repo_path, entry, &candidate, &api_key, max_attempts)
-            .and_then(|raw| {
-                sanitize_commit_output(&raw)
-                    .map(|message| limit_subject(message, config.max_commit_length))
-                    .map_err(KcmtError::Message)
-            }) {
+        match invoke_provider_candidate(
+            repo_path,
+            entry,
+            &candidate,
+            &api_key,
+            max_attempts,
+            config.max_commit_length,
+        )
+        .and_then(|raw| {
+            sanitize_commit_output(&raw)
+                .map(|message| limit_subject(message, config.max_commit_length))
+                .map_err(KcmtError::Message)
+        }) {
             Ok(message) => return Ok(message),
             Err(err) => last_error = Some(err),
         }
@@ -1221,11 +1232,12 @@ fn invoke_provider_candidate(
     candidate: &ProviderCandidate,
     api_key: &str,
     max_attempts: usize,
+    max_commit_length: usize,
 ) -> Result<String> {
     let diff = diff_for_entry(repo_path, entry)?;
     let context = format!("File: {}", entry.path);
     let prompt = build_prompt(&diff, &context, "conventional");
-    let system = COMMIT_MESSAGE_SYSTEM_PROMPT;
+    let system = commit_message_system_prompt(max_commit_length);
     let runtime = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
@@ -1245,7 +1257,7 @@ fn invoke_provider_candidate(
             match candidate.provider.as_str() {
                 "openai" => {
                     let messages = vec![
-                        ProviderMessage::system(system),
+                        ProviderMessage::system(system.as_str()),
                         ProviderMessage::user(prompt),
                     ];
                     OpenAiClient::invoke_chat(
@@ -1259,7 +1271,7 @@ fn invoke_provider_candidate(
                 }
                 "xai" => {
                     let messages = vec![
-                        ProviderMessage::system(system),
+                        ProviderMessage::system(system.as_str()),
                         ProviderMessage::user(prompt),
                     ];
                     XaiClient::invoke_chat(
@@ -1273,7 +1285,7 @@ fn invoke_provider_candidate(
                 }
                 "github" => {
                     let messages = vec![
-                        ProviderMessage::system(system),
+                        ProviderMessage::system(system.as_str()),
                         ProviderMessage::user(prompt),
                     ];
                     GitHubModelsClient::invoke_chat(
@@ -1291,7 +1303,7 @@ fn invoke_provider_candidate(
                         &candidate.endpoint,
                         api_key,
                         &candidate.model,
-                        system,
+                        system.as_str(),
                         &prompt,
                     )
                     .await

--- a/rust/crates/kcmt-cli/src/lib.rs
+++ b/rust/crates/kcmt-cli/src/lib.rs
@@ -51,6 +51,7 @@ fn output_options(args: &CliArgs) -> WorkflowOutputOptions {
     WorkflowOutputOptions {
         compact: args.compact,
         verbose: args.verbose || args.debug,
+        no_progress: args.no_progress,
         profile_startup: args.profile_startup || args.debug,
         startup_stages: Vec::new(),
     }

--- a/rust/crates/kcmt-cli/tests/configure_contracts.rs
+++ b/rust/crates/kcmt-cli/tests/configure_contracts.rs
@@ -125,7 +125,7 @@ fn list_models_prints_supported_provider_defaults() {
     assert!(stdout.contains("openai"));
     assert!(stdout.contains("gpt-5-mini-2025-08-07"));
     assert!(stdout.contains("anthropic"));
-    assert!(stdout.contains("claude-3-5-haiku-latest"));
+    assert!(stdout.contains("claude-sonnet-4-20250514"));
     assert!(stdout.contains("xai"));
     assert!(stdout.contains("github"));
 }

--- a/rust/crates/kcmt-cli/tests/live_llm_matrix.rs
+++ b/rust/crates/kcmt-cli/tests/live_llm_matrix.rs
@@ -1,0 +1,439 @@
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
+
+#[derive(Debug, Clone, Copy)]
+struct ProviderCase {
+    provider: &'static str,
+    model: &'static str,
+    batch_model: Option<&'static str>,
+    endpoint: &'static str,
+    api_key_env: &'static str,
+    supports_batch: bool,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum RunMode {
+    Standard,
+    Batch,
+}
+
+impl RunMode {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Standard => "standard",
+            Self::Batch => "batch",
+        }
+    }
+}
+
+#[derive(Debug)]
+struct MatrixResult {
+    provider: &'static str,
+    mode: &'static str,
+    model: &'static str,
+    status: String,
+    reason: String,
+    wall_time_ms: f64,
+    committed_files: usize,
+    ignored_ok: bool,
+    stage_timings: BTreeMap<String, f64>,
+}
+
+struct TempDir {
+    path: PathBuf,
+}
+
+impl TempDir {
+    fn new(label: &str) -> Self {
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock should be after unix epoch")
+            .as_nanos();
+        let suffix = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let path = std::env::temp_dir().join(format!("kcmt-live-{label}-{nanos}-{suffix}"));
+        fs::create_dir_all(&path).expect("temp dir should be created");
+        Self { path }
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.path);
+    }
+}
+
+const PROVIDERS: &[ProviderCase] = &[
+    ProviderCase {
+        provider: "openai",
+        model: "gpt-5-mini-2025-08-07",
+        batch_model: Some("gpt-5-mini-2025-08-07"),
+        endpoint: "https://api.openai.com/v1",
+        api_key_env: "OPENAI_API_KEY",
+        supports_batch: true,
+    },
+    ProviderCase {
+        provider: "anthropic",
+        model: "claude-sonnet-4-20250514",
+        batch_model: None,
+        endpoint: "https://api.anthropic.com",
+        api_key_env: "ANTHROPIC_API_KEY",
+        supports_batch: false,
+    },
+    ProviderCase {
+        provider: "xai",
+        model: "grok-code-fast",
+        batch_model: Some("grok-4.3"),
+        endpoint: "https://api.x.ai/v1",
+        api_key_env: "XAI_API_KEY",
+        supports_batch: true,
+    },
+    ProviderCase {
+        provider: "github",
+        model: "openai/gpt-4.1-mini",
+        batch_model: None,
+        endpoint: "https://models.github.ai/inference",
+        api_key_env: "GITHUB_TOKEN",
+        supports_batch: false,
+    },
+];
+
+const EXPECTED_COMMITTED_FILES: &[&str] = &[
+    "root_modified.txt",
+    "root_deleted.txt",
+    "root_new.txt",
+    "nested/deep/modified.rs",
+    "nested/deep/deleted.md",
+    "nested/deep/new.py",
+    "staged_only.txt",
+];
+
+const EXPECTED_IGNORED_FILES: &[&str] = &["root_ignored.log", "nested/deep/ignored.tmp"];
+
+#[test]
+#[ignore = "live LLM provider matrix requires real API keys and may take minutes"]
+fn live_llm_provider_matrix_commits_all_git_states() {
+    if std::env::var("KCMT_LIVE_LLM_MATRIX").as_deref() != Ok("1") {
+        println!("skipped: set KCMT_LIVE_LLM_MATRIX=1 to run the live provider matrix");
+        return;
+    }
+
+    let mut results = Vec::new();
+    for provider in PROVIDERS {
+        results.push(run_or_skip(*provider, RunMode::Standard));
+        if provider.supports_batch {
+            results.push(run_or_skip(*provider, RunMode::Batch));
+        }
+    }
+
+    print_scoreboard(&results);
+
+    let failures = results
+        .iter()
+        .filter(|result| result.status == "failed")
+        .collect::<Vec<_>>();
+    assert!(
+        failures.is_empty(),
+        "live LLM matrix failures: {failures:#?}"
+    );
+}
+
+fn run_or_skip(provider: ProviderCase, mode: RunMode) -> MatrixResult {
+    if std::env::var(provider.api_key_env)
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .is_none()
+    {
+        return MatrixResult {
+            provider: provider.provider,
+            mode: mode.label(),
+            model: model_for_mode(provider, mode),
+            status: "skipped".to_string(),
+            reason: format!("missing {}", provider.api_key_env),
+            wall_time_ms: 0.0,
+            committed_files: 0,
+            ignored_ok: false,
+            stage_timings: BTreeMap::new(),
+        };
+    }
+
+    let repo = TempDir::new(provider.provider);
+    let seed_hash = seed_repo(repo.path());
+    let config_home = TempDir::new("config-home");
+    let started = Instant::now();
+    let output = run_kcmt(repo.path(), config_home.path(), provider, mode);
+    let wall_time_ms = started.elapsed().as_secs_f64() * 1000.0;
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stage_timings = parse_stage_timings(&stdout);
+
+    if !output.status.success() {
+        return MatrixResult {
+            provider: provider.provider,
+            mode: mode.label(),
+            model: model_for_mode(provider, mode),
+            status: "failed".to_string(),
+            reason: first_error_line(&stdout, &stderr),
+            wall_time_ms,
+            committed_files: count_committed_files(repo.path(), &seed_hash),
+            ignored_ok: ignored_files_are_uncommitted(repo.path()),
+            stage_timings,
+        };
+    }
+
+    let dirty = git(repo.path(), &["status", "--short"]);
+    let committed_files = count_committed_files(repo.path(), &seed_hash);
+    let ignored_ok = ignored_files_are_uncommitted(repo.path());
+    let committed_ok = committed_files == EXPECTED_COMMITTED_FILES.len();
+    let status = if dirty.is_empty() && committed_ok && ignored_ok {
+        "passed"
+    } else {
+        "failed"
+    };
+    let reason = if status == "passed" {
+        "all expected files committed; ignored files preserved".to_string()
+    } else {
+        format!("dirty={dirty:?}; committed_files={committed_files}; ignored_ok={ignored_ok}")
+    };
+
+    MatrixResult {
+        provider: provider.provider,
+        mode: mode.label(),
+        model: model_for_mode(provider, mode),
+        status: status.to_string(),
+        reason,
+        wall_time_ms,
+        committed_files,
+        ignored_ok,
+        stage_timings,
+    }
+}
+
+fn seed_repo(repo: &Path) -> String {
+    git(repo, &["init", "-q"]);
+    git(repo, &["config", "user.name", "kcmt live matrix"]);
+    git(repo, &["config", "user.email", "kcmt-live@example.com"]);
+    fs::create_dir_all(repo.join("nested/deep")).expect("nested dir");
+    fs::write(
+        repo.join(".gitignore"),
+        "*.log\nnested/deep/*.tmp\nignored_dir/\n",
+    )
+    .expect("gitignore");
+    fs::write(repo.join("root_modified.txt"), "root before\n").expect("root modified seed");
+    fs::write(repo.join("root_deleted.txt"), "root delete me\n").expect("root deleted seed");
+    fs::write(repo.join("staged_only.txt"), "staged before\n").expect("staged seed");
+    fs::write(
+        repo.join("nested/deep/modified.rs"),
+        "pub fn value() -> i32 { 1 }\n",
+    )
+    .expect("nested modified seed");
+    fs::write(repo.join("nested/deep/deleted.md"), "# Delete me\n").expect("nested deleted seed");
+    git(repo, &["add", "."]);
+    git(repo, &["commit", "-m", "chore(repo): seed live matrix"]);
+    let seed_hash = git(repo, &["rev-parse", "HEAD"]);
+
+    fs::write(repo.join("root_modified.txt"), "root after\n").expect("root modified");
+    fs::remove_file(repo.join("root_deleted.txt")).expect("root deleted");
+    fs::write(repo.join("root_new.txt"), "root new\n").expect("root new");
+    fs::write(repo.join("root_ignored.log"), "root ignored\n").expect("root ignored");
+    fs::write(
+        repo.join("nested/deep/modified.rs"),
+        "pub fn value() -> i32 { 2 }\n",
+    )
+    .expect("nested modified");
+    fs::remove_file(repo.join("nested/deep/deleted.md")).expect("nested deleted");
+    fs::write(repo.join("nested/deep/new.py"), "print('nested new')\n").expect("nested new");
+    fs::write(repo.join("nested/deep/ignored.tmp"), "nested ignored\n").expect("nested ignored");
+    fs::write(repo.join("staged_only.txt"), "staged after\n").expect("staged update");
+    git(repo, &["add", "staged_only.txt"]);
+    seed_hash
+}
+
+fn run_kcmt(repo: &Path, config_home: &Path, provider: ProviderCase, mode: RunMode) -> Output {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_kcmt"));
+    command
+        .current_dir(repo)
+        .env("KCMT_CONFIG_HOME", config_home)
+        .env("KCMT_GIT_COMMIT_BACKEND", "gix")
+        .arg("--provider")
+        .arg(provider.provider)
+        .arg("--api-key-env")
+        .arg(provider.api_key_env)
+        .arg("--endpoint")
+        .arg(provider.endpoint)
+        .arg("--model")
+        .arg(provider.model)
+        .arg("--debug")
+        .arg("--no-auto-push")
+        .arg("--repo-path")
+        .arg(repo);
+    if matches!(mode, RunMode::Batch) {
+        let batch_model = provider.batch_model.unwrap_or(provider.model);
+        command
+            .arg("--batch")
+            .arg("--batch-model")
+            .arg(batch_model)
+            .arg("--batch-timeout")
+            .arg("900");
+    }
+    command.output().expect("kcmt binary should run")
+}
+
+fn model_for_mode(provider: ProviderCase, mode: RunMode) -> &'static str {
+    match mode {
+        RunMode::Standard => provider.model,
+        RunMode::Batch => provider.batch_model.unwrap_or(provider.model),
+    }
+}
+
+fn parse_stage_timings(stdout: &str) -> BTreeMap<String, f64> {
+    let mut stages = BTreeMap::new();
+    for line in stdout.lines() {
+        let Some(rest) = line.strip_prefix("[kcmt-profile] ") else {
+            continue;
+        };
+        let Some((stage, timing)) = rest.split_once(": ") else {
+            continue;
+        };
+        let Some((duration, _items)) = timing.split_once(" ms items=") else {
+            continue;
+        };
+        if let Ok(ms) = duration.parse::<f64>() {
+            stages.insert(stage.to_string(), ms);
+        }
+    }
+    stages
+}
+
+fn count_committed_files(repo: &Path, seed_hash: &str) -> usize {
+    let names = git(
+        repo,
+        &[
+            "log",
+            "--name-only",
+            "--pretty=format:",
+            "--diff-filter=ACDMRT",
+            &format!("{seed_hash}..HEAD"),
+            "--",
+        ],
+    );
+    EXPECTED_COMMITTED_FILES
+        .iter()
+        .filter(|path| names.lines().any(|line| line == **path))
+        .count()
+}
+
+fn ignored_files_are_uncommitted(repo: &Path) -> bool {
+    let ignored = git(repo, &["status", "--short", "--ignored"]);
+    EXPECTED_IGNORED_FILES
+        .iter()
+        .all(|path| ignored.lines().any(|line| line == format!("!! {path}")))
+        && EXPECTED_IGNORED_FILES.iter().all(|path| {
+            !git(repo, &["log", "--name-only", "--pretty=format:", "--"])
+                .lines()
+                .any(|line| line == *path)
+        })
+}
+
+fn first_error_line(stdout: &str, stderr: &str) -> String {
+    stdout
+        .lines()
+        .chain(stderr.lines())
+        .find(|line| line.contains("provider") || line.contains("✗") || line.contains("failed"))
+        .unwrap_or("command failed without a provider error line")
+        .to_string()
+}
+
+fn print_scoreboard(results: &[MatrixResult]) {
+    const STAGES: &[&str] = &[
+        "status_scan",
+        "diff_preparation",
+        "llm_enqueue",
+        "llm_wait",
+        "commit_create",
+        "commit",
+        "snapshot",
+        "workflow_total",
+    ];
+    println!();
+    println!("Live LLM Provider Matrix Scoreboard");
+    println!(
+        "| provider | mode | model | status | files | ignored | wall_ms | {} | reason |",
+        STAGES.join(" | ")
+    );
+    println!(
+        "|---|---|---|---|---:|---|---:|{}|---|",
+        STAGES.iter().map(|_| "---:").collect::<Vec<_>>().join("|")
+    );
+    for result in results {
+        let stages = STAGES
+            .iter()
+            .map(|stage| {
+                result
+                    .stage_timings
+                    .get(*stage)
+                    .map(|value| format!("{value:.1}"))
+                    .unwrap_or_else(|| "-".to_string())
+            })
+            .collect::<Vec<_>>();
+        println!(
+            "| {} | {} | {} | {} | {} | {} | {:.1} | {} | {} |",
+            result.provider,
+            result.mode,
+            result.model,
+            result.status,
+            result.committed_files,
+            result.ignored_ok,
+            result.wall_time_ms,
+            stages.join(" | "),
+            result.reason.replace('|', "/")
+        );
+    }
+
+    println!();
+    println!("Provider/Mode Stats");
+    println!("| provider | mode | status | wall_ms | llm_wait_ms | workflow_total_ms | files |");
+    println!("|---|---|---|---:|---:|---:|---:|");
+    for result in results {
+        println!(
+            "| {} | {} | {} | {:.1} | {} | {} | {} |",
+            result.provider,
+            result.mode,
+            result.status,
+            result.wall_time_ms,
+            format_optional_stage(&result.stage_timings, "llm_wait"),
+            format_optional_stage(&result.stage_timings, "workflow_total"),
+            result.committed_files
+        );
+    }
+}
+
+fn format_optional_stage(stages: &BTreeMap<String, f64>, stage: &str) -> String {
+    stages
+        .get(stage)
+        .map(|value| format!("{value:.1}"))
+        .unwrap_or_else(|| "-".to_string())
+}
+
+fn git(repo: &Path, args: &[&str]) -> String {
+    let output = Command::new("git")
+        .current_dir(repo)
+        .args(args)
+        .output()
+        .expect("git command should run");
+    assert!(
+        output.status.success(),
+        "git {:?} failed: {}",
+        args,
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
+}

--- a/rust/crates/kcmt-cli/tests/workflow_modes.rs
+++ b/rust/crates/kcmt-cli/tests/workflow_modes.rs
@@ -189,6 +189,39 @@ fn spawn_openai_batch_response() -> (String, mpsc::Receiver<String>) {
     (format!("http://{address}"), receiver)
 }
 
+fn spawn_openai_partial_batch_response() -> (String, mpsc::Receiver<String>) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("mock partial batch listener");
+    let address = listener.local_addr().expect("mock partial batch address");
+    let (sender, receiver) = mpsc::channel();
+    thread::spawn(move || {
+        let responses = [
+            r#"{"id":"file_1"}"#,
+            r#"{"id":"batch_1","status":"validating"}"#,
+            r#"{"id":"batch_1","status":"completed","output_file_id":"output_1"}"#,
+            r#"{"custom_id":"alpha.py","response":{"status_code":200,"body":{"choices":[{"message":{"content":"fix(alpha): batch alpha."}}]}}}
+{"custom_id":"beta.py","response":{"status_code":200,"body":{"choices":[{"message":{"content":"This is not conventional"}}]}}}
+"#,
+        ];
+        for response_body in responses {
+            let (mut stream, _) = listener.accept().expect("mock partial batch connection");
+            let mut buffer = [0_u8; 16384];
+            let bytes = stream.read(&mut buffer).expect("mock partial batch read");
+            sender
+                .send(String::from_utf8_lossy(&buffer[..bytes]).to_string())
+                .expect("request should be recorded");
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nconnection: close\r\n\r\n{}",
+                response_body.len(),
+                response_body
+            );
+            stream
+                .write_all(response.as_bytes())
+                .expect("mock partial batch write");
+        }
+    });
+    (format!("http://{address}"), receiver)
+}
+
 fn spawn_provider_fallback_response() -> (String, mpsc::Receiver<String>) {
     let listener = TcpListener::bind("127.0.0.1:0").expect("mock fallback listener");
     let address = listener.local_addr().expect("mock fallback address");
@@ -836,7 +869,13 @@ fn debug_mode_prints_workflow_telemetry() {
     let output = kcmt_command(env!("CARGO_BIN_EXE_kcmt"))
         .env("KCMT_CONFIG_HOME", &config_home)
         .env("KCMT_GIT_COMMIT_BACKEND", "gix")
-        .args(["--debug", "--file", "tracked.py", "--no-auto-push", "--repo-path"])
+        .args([
+            "--debug",
+            "--file",
+            "tracked.py",
+            "--no-auto-push",
+            "--repo-path",
+        ])
         .arg(&repo)
         .output()
         .expect("kcmt binary should run");
@@ -849,8 +888,14 @@ fn debug_mode_prints_workflow_telemetry() {
     );
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("tracked.py"), "stdout: {stdout}");
-    assert!(stdout.contains("[kcmt-profile] arg_parse:"), "stdout: {stdout}");
-    assert!(stdout.contains("[kcmt-profile] workflow_total:"), "stdout: {stdout}");
+    assert!(
+        stdout.contains("[kcmt-profile] arg_parse:"),
+        "stdout: {stdout}"
+    );
+    assert!(
+        stdout.contains("[kcmt-profile] workflow_total:"),
+        "stdout: {stdout}"
+    );
 }
 
 #[test]
@@ -880,7 +925,10 @@ fn default_workflow_discovers_repo_from_nested_current_directory() {
     );
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("tracked.py"), "stdout: {stdout}");
-    assert!(stdout.contains("[kcmt-profile] repo_discovery:"), "stdout: {stdout}");
+    assert!(
+        stdout.contains("[kcmt-profile] repo_discovery:"),
+        "stdout: {stdout}"
+    );
     assert_eq!(git(&repo, &["status", "--short"]), "");
 }
 
@@ -1045,6 +1093,21 @@ fn file_mode_invokes_openai_compatible_provider_when_api_key_is_available() {
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("fix(core): use provider message"));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("kcmt progress: mode=direct stage=start total=1"),
+        "stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("stage=llm") && stderr.contains("file=tracked.py"),
+        "stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("stage=done")
+            && stderr.contains("status=ok")
+            && stderr.contains("file=tracked.py"),
+        "stderr: {stderr}"
+    );
     let log = git(&repo, &["log", "--pretty=%s", "-1"]);
     assert_eq!(log, "fix(core): use provider message");
 }
@@ -1145,6 +1208,55 @@ fn max_retries_zero_attempts_provider_once() {
 }
 
 #[test]
+fn file_mode_provider_failure_reports_secret_free_error() {
+    let repo = init_repo();
+    let (endpoint, request_rx) = spawn_provider_status_response(
+        401,
+        r#"{"error":{"message":"invalid api key sk-leaked-test"}}"#,
+    );
+    fs::write(repo.join("tracked.py"), "print('seed')\n").expect("tracked seed");
+    git(&repo, &["add", "tracked.py"]);
+    git(&repo, &["commit", "-m", "chore(repo): seed"]);
+    fs::write(repo.join("tracked.py"), "print('changed')\n").expect("tracked change");
+
+    let output = kcmt_command(env!("CARGO_BIN_EXE_kcmt"))
+        .env("OPENAI_TEST_KEY", "sk-leaked-test")
+        .args([
+            "--file",
+            "tracked.py",
+            "--provider",
+            "openai",
+            "--endpoint",
+            &endpoint,
+            "--api-key-env",
+            "OPENAI_TEST_KEY",
+            "--model",
+            "invalid-model",
+            "--max-retries",
+            "0",
+            "--no-auto-push",
+            "--repo-path",
+        ])
+        .arg(&repo)
+        .output()
+        .expect("kcmt binary should run");
+
+    assert_eq!(output.status.code(), Some(1));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("provider request failed"));
+    assert!(stderr.contains("HTTP 401"), "stderr: {stderr}");
+    assert!(stderr.contains("invalid api key"), "stderr: {stderr}");
+    assert!(stderr.contains("[redacted]"), "stderr: {stderr}");
+    assert!(!stderr.contains("sk-leaked-test"));
+    let request = request_rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("provider request should be recorded");
+    assert!(request.contains("authorization: Bearer sk-leaked-test"));
+    let log = git(&repo, &["log", "--pretty=%s", "-1"]);
+    assert_eq!(log, "chore(repo): seed");
+}
+
+#[test]
 fn file_mode_falls_back_to_next_configured_provider_after_primary_failure() {
     let repo = init_repo();
     let config_home = unique_temp_dir("config-home");
@@ -1205,6 +1317,81 @@ fn file_mode_falls_back_to_next_configured_provider_after_primary_failure() {
 }
 
 #[test]
+fn explicit_provider_override_disables_persisted_fallback_priority() {
+    let repo = init_repo();
+    let config_home = unique_temp_dir("config-home");
+    let (endpoint, request_rx) = spawn_provider_fallback_response();
+    fs::create_dir_all(&config_home).expect("config home");
+    fs::write(
+        config_home.join("config.json"),
+        format!(
+            r#"{{
+  "provider": "openai",
+  "model": "gpt-primary",
+  "llm_endpoint": "{endpoint}",
+  "api_key_env": "OPENAI_TEST_KEY",
+  "git_repo_path": ".",
+  "max_commit_length": 72,
+  "auto_push": false,
+  "providers": {{
+    "openai": {{"endpoint": "{endpoint}", "api_key_env": "OPENAI_TEST_KEY", "preferred_model": "gpt-primary"}},
+    "anthropic": {{"endpoint": "{endpoint}", "api_key_env": "ANTHROPIC_TEST_KEY", "preferred_model": "claude-fallback"}}
+  }},
+  "model_priority": [
+    {{"provider": "openai", "model": "gpt-primary"}},
+    {{"provider": "anthropic", "model": "claude-fallback"}}
+  ]
+}}"#
+        ),
+    )
+    .expect("persist fallback config");
+    fs::write(repo.join("tracked.py"), "print('seed')\n").expect("tracked seed");
+    git(&repo, &["add", "tracked.py"]);
+    git(&repo, &["commit", "-m", "chore(repo): seed"]);
+    fs::write(repo.join("tracked.py"), "print('changed')\n").expect("tracked change");
+
+    let output = kcmt_command(env!("CARGO_BIN_EXE_kcmt"))
+        .env("KCMT_CONFIG_HOME", &config_home)
+        .env("OPENAI_TEST_KEY", "primary-key")
+        .env("ANTHROPIC_TEST_KEY", "fallback-key")
+        .args([
+            "--file",
+            "tracked.py",
+            "--provider",
+            "openai",
+            "--api-key-env",
+            "OPENAI_TEST_KEY",
+            "--repo-path",
+        ])
+        .arg(&repo)
+        .output()
+        .expect("kcmt binary should run");
+
+    assert_eq!(output.status.code(), Some(1));
+    let requests: Vec<String> = (0..4)
+        .map(|_| {
+            request_rx
+                .recv_timeout(Duration::from_secs(2))
+                .expect("primary provider request should be recorded")
+        })
+        .collect();
+    assert!(requests
+        .iter()
+        .all(|request| request.contains("POST /chat/completions HTTP/1.1")));
+    assert!(requests
+        .iter()
+        .all(|request| request.contains("authorization: Bearer primary-key")));
+    assert!(requests
+        .iter()
+        .all(|request| !request.contains("POST /v1/messages HTTP/1.1")));
+    assert!(request_rx.recv_timeout(Duration::from_millis(200)).is_err());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(!stderr.contains("fallback-key"), "stderr: {stderr}");
+    let log = git(&repo, &["log", "--pretty=%s", "-1"]);
+    assert_eq!(log, "chore(repo): seed");
+}
+
+#[test]
 fn default_openai_batch_queues_all_file_prompts_before_committing() {
     let repo = init_repo();
     let config_home = unique_temp_dir("config-home");
@@ -1253,6 +1440,8 @@ fn default_openai_batch_queues_all_file_prompts_before_committing() {
     assert!(requests[0].contains("POST /files HTTP/1.1"));
     assert!(requests[0].contains("alpha.py"));
     assert!(requests[0].contains("beta.py"));
+    assert!(requests[0].contains("Return only the commit message"));
+    assert!(requests[0].contains("Prefer a single subject line for simple diffs"));
     assert!(requests[0].contains("print('alpha changed')"));
     assert!(requests[0].contains("print('beta changed')"));
     assert!(!requests.iter().any(|request| {
@@ -1262,6 +1451,21 @@ fn default_openai_batch_queues_all_file_prompts_before_committing() {
     assert!(requests[1].contains("POST /batches HTTP/1.1"));
     assert!(requests[2].contains("GET /batches/batch_1 HTTP/1.1"));
     assert!(requests[3].contains("GET /files/output_1/content HTTP/1.1"));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("kcmt progress: mode=batch stage=start total=2"),
+        "stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("stage=queued") && stderr.contains("file=alpha.py"),
+        "stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("stage=results")
+            && stderr.contains("completed=2")
+            && stderr.contains("failed=0"),
+        "stderr: {stderr}"
+    );
 
     let log = git(&repo, &["log", "--pretty=%s"]);
     let subjects: Vec<&str> = log.lines().collect();
@@ -1272,6 +1476,77 @@ fn default_openai_batch_queues_all_file_prompts_before_committing() {
     let snapshot = raw_status_snapshot(&repo, &config_home);
     assert_eq!(telemetry_stage_items(&snapshot, "diff_preparation"), 2);
     assert_eq!(telemetry_stage_items(&snapshot, "llm_enqueue"), 2);
+}
+
+#[test]
+fn default_openai_batch_reports_partial_invalid_outputs_without_leaking_keys() {
+    let repo = init_repo();
+    let config_home = unique_temp_dir("config-home");
+    let (endpoint, request_rx) = spawn_openai_partial_batch_response();
+    fs::write(repo.join("alpha.py"), "print('alpha')\n").expect("alpha seed");
+    fs::write(repo.join("beta.py"), "print('beta')\n").expect("beta seed");
+    git(&repo, &["add", "alpha.py", "beta.py"]);
+    git(&repo, &["commit", "-m", "chore(repo): seed"]);
+    fs::write(repo.join("alpha.py"), "print('alpha changed')\n").expect("alpha change");
+    fs::write(repo.join("beta.py"), "print('beta changed')\n").expect("beta change");
+
+    let output = kcmt_command(env!("CARGO_BIN_EXE_kcmt"))
+        .env("KCMT_CONFIG_HOME", &config_home)
+        .env("OPENAI_TEST_KEY", "test-key")
+        .args([
+            "--provider",
+            "openai",
+            "--endpoint",
+            &endpoint,
+            "--api-key-env",
+            "OPENAI_TEST_KEY",
+            "--model",
+            "gpt-direct",
+            "--batch",
+            "--batch-model",
+            "gpt-batch",
+            "--batch-timeout",
+            "900",
+            "--no-auto-push",
+            "--repo-path",
+        ])
+        .arg(&repo)
+        .output()
+        .expect("kcmt binary should run");
+
+    assert!(
+        output.status.success(),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stdout.contains("fix(alpha): batch alpha"));
+    assert!(stdout.contains("LLM output missing conventional commit header"));
+    assert!(!stdout.contains("test-key"));
+    assert!(!stderr.contains("test-key"));
+
+    let requests: Vec<String> = (0..4)
+        .map(|_| request_rx.recv_timeout(Duration::from_secs(2)).unwrap())
+        .collect();
+    assert!(requests[0].contains("alpha.py"));
+    assert!(requests[0].contains("beta.py"));
+    assert!(requests[1].contains("POST /batches HTTP/1.1"));
+
+    let log = git(&repo, &["log", "--pretty=%s"]);
+    let subjects: Vec<&str> = log.lines().collect();
+    assert!(subjects.contains(&"fix(alpha): batch alpha"));
+    assert!(!subjects.contains(&"This is not conventional"));
+    let status = git(&repo, &["status", "--short"]);
+    assert!(status.contains("beta.py"));
+    assert!(!status.contains("alpha.py"));
+    let snapshot = raw_status_snapshot(&repo, &config_home);
+    assert_eq!(snapshot["counts"]["commit_success"], 1);
+    assert_eq!(snapshot["counts"]["commit_failure"], 1);
+    let raw_snapshot = serde_json::to_string(&snapshot).expect("snapshot json");
+    assert!(!raw_snapshot.contains("test-key"));
+    assert!(raw_snapshot.contains("OPENAI_TEST_KEY"));
 }
 
 #[test]

--- a/rust/crates/kcmt-core/src/config/loader.rs
+++ b/rust/crates/kcmt-core/src/config/loader.rs
@@ -82,8 +82,8 @@ const PROVIDER_DEFAULTS: &[ProviderDefaults] = &[
     },
     ProviderDefaults {
         provider: "anthropic",
-        model: "claude-3-5-haiku-latest",
-        endpoint: "https://api.anthropic.com/v1",
+        model: "claude-sonnet-4-20250514",
+        endpoint: "https://api.anthropic.com",
         api_key_env: "ANTHROPIC_API_KEY",
     },
     ProviderDefaults {
@@ -116,25 +116,32 @@ pub fn load_config(repo_root: &Path, overrides: &ConfigOverrides) -> Result<Work
 
     let provider = selected_provider(overrides, persisted.as_ref(), &detected);
     let defaults = provider_defaults(&provider).unwrap_or(PROVIDER_DEFAULTS[0]);
+    let persisted_for_provider = persisted.as_ref().filter(|cfg| cfg.provider == provider);
+    let persisted_provider_entry = persisted
+        .as_ref()
+        .and_then(|cfg| cfg.providers.get(&provider));
 
     let model = overrides
         .model
         .clone()
         .or_else(|| env::var("KLINGON_CMT_LLM_MODEL").ok())
-        .or_else(|| persisted.as_ref().map(|cfg| cfg.model.clone()))
+        .or_else(|| persisted_for_provider.map(|cfg| cfg.model.clone()))
+        .or_else(|| persisted_provider_entry.and_then(|entry| entry.preferred_model.clone()))
         .filter(|value| !value.trim().is_empty())
         .unwrap_or_else(|| defaults.model.to_string());
     let llm_endpoint = overrides
         .endpoint
         .clone()
         .or_else(|| env::var("KLINGON_CMT_LLM_ENDPOINT").ok())
-        .or_else(|| persisted.as_ref().map(|cfg| cfg.llm_endpoint.clone()))
+        .or_else(|| persisted_for_provider.map(|cfg| cfg.llm_endpoint.clone()))
+        .or_else(|| persisted_provider_entry.and_then(|entry| entry.endpoint.clone()))
         .filter(|value| !value.trim().is_empty())
         .unwrap_or_else(|| defaults.endpoint.to_string());
     let api_key_env = overrides
         .api_key_env
         .clone()
-        .or_else(|| persisted.as_ref().map(|cfg| cfg.api_key_env.clone()))
+        .or_else(|| persisted_for_provider.map(|cfg| cfg.api_key_env.clone()))
+        .or_else(|| persisted_provider_entry.and_then(|entry| entry.api_key_env.clone()))
         .filter(|value| !value.trim().is_empty())
         .unwrap_or_else(|| selected_api_key_env(&provider, &detected).to_string());
     let git_repo_path = overrides
@@ -179,7 +186,7 @@ pub fn load_config(repo_root: &Path, overrides: &ConfigOverrides) -> Result<Work
                 .map(|value| is_truthy(&value))
         })
         .unwrap_or(false);
-    if provider != "openai" {
+    if !matches!(provider.as_str(), "openai" | "xai") {
         use_batch = false;
     }
     let batch_model = overrides
@@ -188,7 +195,7 @@ pub fn load_config(repo_root: &Path, overrides: &ConfigOverrides) -> Result<Work
         .or_else(|| env::var("KCMT_BATCH_MODEL").ok())
         .or_else(|| persisted.as_ref().and_then(|cfg| cfg.batch_model.clone()))
         .filter(|value| !value.trim().is_empty())
-        .or_else(|| provider_defaults("openai").map(|defaults| defaults.model.to_string()));
+        .or_else(|| default_batch_model(&provider).map(str::to_string));
     let batch_timeout_seconds = overrides
         .batch_timeout_seconds
         .or_else(|| {
@@ -201,16 +208,24 @@ pub fn load_config(repo_root: &Path, overrides: &ConfigOverrides) -> Result<Work
         .unwrap_or(DEFAULT_BATCH_TIMEOUT_SECONDS)
         .max(BATCH_TIMEOUT_MIN_SECONDS);
     let providers = merged_provider_entries(persisted.as_ref());
-    let model_priority = persisted
-        .as_ref()
-        .map(|cfg| cfg.model_priority.clone())
-        .filter(|priority| !priority.is_empty())
-        .unwrap_or_else(|| {
-            vec![ModelPreference {
-                provider: provider.clone(),
-                model: model.clone(),
-            }]
-        });
+    let explicit_primary = overrides.provider.is_some() || overrides.model.is_some();
+    let model_priority = if explicit_primary {
+        vec![ModelPreference {
+            provider: provider.clone(),
+            model: model.clone(),
+        }]
+    } else {
+        persisted
+            .as_ref()
+            .map(|cfg| cfg.model_priority.clone())
+            .filter(|priority| !priority.is_empty())
+            .unwrap_or_else(|| {
+                vec![ModelPreference {
+                    provider: provider.clone(),
+                    model: model.clone(),
+                }]
+            })
+    };
 
     let config = WorkflowConfig {
         provider,
@@ -325,6 +340,14 @@ fn provider_defaults(provider: &str) -> Option<ProviderDefaults> {
         .iter()
         .copied()
         .find(|defaults| defaults.provider == provider)
+}
+
+fn default_batch_model(provider: &str) -> Option<&'static str> {
+    match provider {
+        "openai" => Some("gpt-5-mini-2025-08-07"),
+        "xai" => Some("grok-4.3"),
+        _ => None,
+    }
 }
 
 fn detect_available_providers() -> HashMap<String, Vec<String>> {
@@ -520,5 +543,60 @@ mod tests {
         assert_eq!(cfg.api_key_env, "XAI_SECRET");
         assert_eq!(cfg.max_commit_length, 80);
         assert!(cfg.git_repo_path.ends_with("nested"));
+    }
+
+    #[test]
+    fn provider_override_uses_matching_provider_defaults_not_persisted_top_level() {
+        let _guard = env_lock().lock().unwrap_or_else(|err| err.into_inner());
+        clear_test_env();
+        let repo = unique_temp_dir("provider-override");
+        let cfg_home = unique_temp_dir("cfg-home-provider-override");
+        std::env::set_var("KCMT_CONFIG_HOME", &cfg_home);
+        std::env::set_var("OPENAI_API_KEY", "sk-test");
+        let config_path = config_home().join("config.json");
+        fs::create_dir_all(config_path.parent().expect("config parent")).expect("config dir");
+        fs::write(
+            &config_path,
+            r#"{
+  "provider": "anthropic",
+  "model": "claude-sonnet-4-20250514",
+  "llm_endpoint": "https://api.anthropic.com",
+  "api_key_env": "ANTHROPIC_API_KEY",
+  "git_repo_path": ".",
+  "max_commit_length": 72,
+  "providers": {
+    "openai": {
+      "endpoint": "https://api.openai.com/v1",
+      "api_key_env": "OPENAI_API_KEY",
+      "preferred_model": "gpt-5-mini-2025-08-07"
+    },
+    "anthropic": {
+      "endpoint": "https://api.anthropic.com",
+      "api_key_env": "ANTHROPIC_API_KEY",
+      "preferred_model": "claude-sonnet-4-20250514"
+    }
+  },
+  "model_priority": [
+    {"provider": "anthropic", "model": "claude-sonnet-4-20250514"},
+    {"provider": "openai", "model": "gpt-5-mini-2025-08-07"}
+  ]
+}"#,
+        )
+        .expect("persisted config");
+        let overrides = ConfigOverrides {
+            provider: Some("openai".to_string()),
+            api_key_env: Some("OPENAI_API_KEY".to_string()),
+            ..ConfigOverrides::default()
+        };
+
+        let cfg = load_config(&repo, &overrides).expect("config");
+
+        assert_eq!(cfg.provider, "openai");
+        assert_eq!(cfg.model, "gpt-5-mini-2025-08-07");
+        assert_eq!(cfg.llm_endpoint, "https://api.openai.com/v1");
+        assert_eq!(cfg.api_key_env, "OPENAI_API_KEY");
+        assert_eq!(cfg.model_priority.len(), 1);
+        assert_eq!(cfg.model_priority[0].provider, "openai");
+        assert_eq!(cfg.model_priority[0].model, "gpt-5-mini-2025-08-07");
     }
 }

--- a/rust/crates/kcmt-provider/src/clients/mod.rs
+++ b/rust/crates/kcmt-provider/src/clients/mod.rs
@@ -59,6 +59,18 @@ pub struct OpenAiBatchResult {
     pub content: String,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OpenAiBatchFailure {
+    pub custom_id: String,
+    pub error: String,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct OpenAiBatchOutput {
+    pub results: Vec<OpenAiBatchResult>,
+    pub failures: Vec<OpenAiBatchFailure>,
+}
+
 impl ProviderRequest {
     pub fn header_map(&self) -> Result<HeaderMap> {
         let mut headers = HeaderMap::new();
@@ -109,9 +121,11 @@ impl OpenAiClient {
     }
 
     pub fn build_batch_jsonl(model: &str, jobs: &[OpenAiBatchJob]) -> String {
+        let token_limit_key = openai_token_limit_key(model);
+        let token_limit = openai_token_limit(model);
         jobs.iter()
             .map(|job| {
-                json!({
+                let mut body = json!({
                     "custom_id": job.custom_id,
                     "method": "POST",
                     "url": "/v1/chat/completions",
@@ -121,19 +135,19 @@ impl OpenAiClient {
                             "role": message.role,
                             "content": message.content,
                         })).collect::<Vec<_>>(),
-                        "max_tokens": 512,
                         "temperature": 1
                     }
-                })
-                .to_string()
+                });
+                body["body"][token_limit_key] = json!(token_limit);
+                body.to_string()
             })
             .collect::<Vec<_>>()
             .join("\n")
             + "\n"
     }
 
-    pub fn parse_batch_output(raw_text: &str) -> Result<Vec<OpenAiBatchResult>, String> {
-        let mut results = Vec::new();
+    pub fn parse_batch_output(raw_text: &str) -> Result<OpenAiBatchOutput, String> {
+        let mut output = OpenAiBatchOutput::default();
         for line in raw_text
             .lines()
             .map(str::trim)
@@ -146,7 +160,14 @@ impl OpenAiClient {
                 .and_then(Value::as_str)
                 .ok_or_else(|| "batch output missing custom_id".to_string())?;
             if let Some(error) = payload.get("error").filter(|value| !value.is_null()) {
-                return Err(format!("batch response error for {custom_id}: {error}"));
+                output.failures.push(OpenAiBatchFailure {
+                    custom_id: custom_id.to_string(),
+                    error: format!(
+                        "batch response error for {custom_id}: {}",
+                        redact_json(error)
+                    ),
+                });
+                continue;
             }
             let response = payload
                 .get("response")
@@ -157,23 +178,30 @@ impl OpenAiClient {
                 .and_then(Value::as_u64)
                 .unwrap_or(200);
             if status_code >= 400 {
-                return Err(format!(
-                    "batch response error for {custom_id} (status {status_code})"
-                ));
+                output.failures.push(OpenAiBatchFailure {
+                    custom_id: custom_id.to_string(),
+                    error: format!("batch response error for {custom_id} (status {status_code})"),
+                });
+                continue;
             }
             let body = response
                 .get("body")
                 .ok_or_else(|| format!("batch output missing body for {custom_id}"))?;
-            let content = Self::parse_chat_response(body)?;
-            results.push(OpenAiBatchResult {
-                custom_id: custom_id.to_string(),
-                content,
-            });
+            match Self::parse_chat_response(body) {
+                Ok(content) => output.results.push(OpenAiBatchResult {
+                    custom_id: custom_id.to_string(),
+                    content,
+                }),
+                Err(error) => output.failures.push(OpenAiBatchFailure {
+                    custom_id: custom_id.to_string(),
+                    error,
+                }),
+            }
         }
-        if results.is_empty() {
+        if output.results.is_empty() && output.failures.is_empty() {
             Err("batch output missing expected responses".to_string())
         } else {
-            Ok(results)
+            Ok(output)
         }
     }
 
@@ -185,9 +213,9 @@ impl OpenAiClient {
         jobs: &[OpenAiBatchJob],
         timeout: Duration,
         poll_interval: Duration,
-    ) -> Result<Vec<OpenAiBatchResult>> {
+    ) -> Result<OpenAiBatchOutput> {
         if jobs.is_empty() {
-            return Ok(Vec::new());
+            return Ok(OpenAiBatchOutput::default());
         }
         let mut headers = BTreeMap::new();
         headers.insert("Authorization".to_string(), format!("Bearer {api_key}"));
@@ -268,6 +296,28 @@ impl OpenAiClient {
     }
 }
 
+fn redact_json(value: &Value) -> String {
+    match value {
+        Value::Object(map) => {
+            let redacted = map
+                .iter()
+                .map(|(key, value)| {
+                    if key.to_ascii_lowercase().contains("key")
+                        || key.to_ascii_lowercase().contains("token")
+                        || key.to_ascii_lowercase().contains("secret")
+                    {
+                        (key.clone(), Value::String("[redacted]".to_string()))
+                    } else {
+                        (key.clone(), value.clone())
+                    }
+                })
+                .collect::<serde_json::Map<_, _>>();
+            Value::Object(redacted).to_string()
+        }
+        _ => value.to_string(),
+    }
+}
+
 #[derive(Debug, Default, Clone, Copy)]
 pub struct AnthropicClient;
 
@@ -291,11 +341,11 @@ impl AnthropicClient {
         headers.insert("content-type".to_string(), "application/json".to_string());
 
         ProviderRequest {
-            url: format!("{}/v1/messages", trim_endpoint(endpoint)),
+            url: format!("{}/v1/messages", trim_anthropic_endpoint(endpoint)),
             headers,
             payload: json!({
                 "model": model,
-                "max_output_tokens": 512,
+                "max_tokens": 512,
                 "messages": [{
                     "role": "user",
                     "content": [{
@@ -384,6 +434,167 @@ impl XaiClient {
             .await?;
         Self::parse_chat_response(&response).map_err(|err| anyhow!(err))
     }
+
+    pub fn build_batch_requests_payload(model: &str, jobs: &[OpenAiBatchJob]) -> Value {
+        json!({
+            "batch_requests": jobs.iter().map(|job| json!({
+                "batch_request_id": job.custom_id,
+                "batch_request": {
+                    "responses": {
+                        "model": model,
+                        "input": job.messages.iter().map(|message| json!({
+                            "role": message.role,
+                            "content": message.content,
+                        })).collect::<Vec<_>>()
+                    }
+                }
+            })).collect::<Vec<_>>()
+        })
+    }
+
+    pub fn parse_batch_results(payload: &Value) -> OpenAiBatchOutput {
+        let mut output = OpenAiBatchOutput::default();
+        let Some(results) = payload.get("results").and_then(Value::as_array) else {
+            return output;
+        };
+        for result in results {
+            let custom_id = result
+                .get("batch_request_id")
+                .and_then(Value::as_str)
+                .unwrap_or("unknown")
+                .to_string();
+            if let Some(error) = result.get("error_message").and_then(Value::as_str) {
+                output.failures.push(OpenAiBatchFailure {
+                    custom_id,
+                    error: error.to_string(),
+                });
+                continue;
+            }
+            let content = result
+                .get("batch_result")
+                .and_then(|value| value.get("response"))
+                .and_then(|value| value.get("chat_get_completion"))
+                .or_else(|| result.get("response"))
+                .and_then(|value| parse_openai_compatible_response(value).ok());
+            match content {
+                Some(content) => output
+                    .results
+                    .push(OpenAiBatchResult { custom_id, content }),
+                None => output.failures.push(OpenAiBatchFailure {
+                    custom_id,
+                    error: "xAI batch response missing assistant content".to_string(),
+                }),
+            }
+        }
+        output
+    }
+
+    pub async fn invoke_batch(
+        transport: &AsyncTransport,
+        endpoint: &str,
+        api_key: &str,
+        model: &str,
+        jobs: &[OpenAiBatchJob],
+        timeout: Duration,
+        poll_interval: Duration,
+    ) -> Result<OpenAiBatchOutput> {
+        if jobs.is_empty() {
+            return Ok(OpenAiBatchOutput::default());
+        }
+        let mut headers = BTreeMap::new();
+        headers.insert("Authorization".to_string(), format!("Bearer {api_key}"));
+        headers.insert("content-type".to_string(), "application/json".to_string());
+        let headers = ProviderRequest {
+            url: String::new(),
+            headers,
+            payload: Value::Null,
+        }
+        .header_map()?;
+
+        let batch = transport
+            .post_json(
+                &format!("{}/batches", trim_endpoint(endpoint)),
+                headers.clone(),
+                &json!({"name": "kcmt_commit_messages"}),
+            )
+            .await?;
+        let batch_id = batch
+            .get("batch_id")
+            .or_else(|| batch.get("id"))
+            .and_then(Value::as_str)
+            .ok_or_else(|| anyhow!("xAI batch create missing batch_id"))?
+            .to_string();
+
+        transport
+            .post_json(
+                &format!("{}/batches/{batch_id}/requests", trim_endpoint(endpoint)),
+                headers.clone(),
+                &Self::build_batch_requests_payload(model, jobs),
+            )
+            .await?;
+
+        let deadline = Instant::now() + timeout;
+        loop {
+            let current = transport
+                .get_json(
+                    &format!("{}/batches/{batch_id}", trim_endpoint(endpoint)),
+                    headers.clone(),
+                )
+                .await?;
+            let pending = current
+                .get("state")
+                .and_then(|state| state.get("num_pending"))
+                .and_then(Value::as_u64);
+            let total = current
+                .get("state")
+                .and_then(|state| state.get("num_requests"))
+                .and_then(Value::as_u64);
+            if pending == Some(0) && total.unwrap_or(0) > 0 {
+                break;
+            }
+            if matches!(
+                current.get("status").and_then(Value::as_str),
+                Some("failed" | "cancelled" | "expired")
+            ) {
+                return Err(anyhow!(
+                    "xAI batch exited with status {:?}",
+                    current.get("status")
+                ));
+            }
+            if Instant::now() >= deadline {
+                return Err(anyhow!("xAI batch did not complete before timeout"));
+            }
+            tokio::time::sleep(poll_interval).await;
+        }
+
+        let mut output = OpenAiBatchOutput::default();
+        let mut pagination_token = None::<String>;
+        loop {
+            let url = match pagination_token.as_deref() {
+                Some(token) => format!(
+                    "{}/batches/{batch_id}/results?limit=100&pagination_token={token}",
+                    trim_endpoint(endpoint)
+                ),
+                None => format!(
+                    "{}/batches/{batch_id}/results?limit=100",
+                    trim_endpoint(endpoint)
+                ),
+            };
+            let page = transport.get_json(&url, headers.clone()).await?;
+            let page_output = Self::parse_batch_results(&page);
+            output.results.extend(page_output.results);
+            output.failures.extend(page_output.failures);
+            pagination_token = page
+                .get("pagination_token")
+                .and_then(Value::as_str)
+                .filter(|value| !value.is_empty())
+                .map(ToOwned::to_owned);
+            if pagination_token.is_none() {
+                break;
+            }
+        }
+        Ok(output)
+    }
 }
 
 #[derive(Debug, Default, Clone, Copy)]
@@ -434,45 +645,97 @@ fn build_openai_compatible_request(
     headers.insert("Authorization".to_string(), format!("Bearer {api_key}"));
     headers.insert("content-type".to_string(), "application/json".to_string());
 
+    let mut payload = json!({
+        "model": model,
+        "messages": messages
+            .iter()
+            .map(|message| json!({
+                "role": message.role,
+                "content": message.content,
+            }))
+            .collect::<Vec<_>>(),
+        "temperature": 1,
+    });
+    payload[openai_token_limit_key(model)] = json!(openai_token_limit(model));
+
     ProviderRequest {
         url: format!("{}/chat/completions", trim_endpoint(endpoint)),
         headers,
-        payload: json!({
-            "model": model,
-            "messages": messages
-                .iter()
-                .map(|message| json!({
-                    "role": message.role,
-                    "content": message.content,
-                }))
-                .collect::<Vec<_>>(),
-            "max_tokens": 512,
-            "temperature": 1,
-        }),
+        payload,
+    }
+}
+
+fn openai_token_limit_key(model: &str) -> &'static str {
+    let normalized = model.trim().to_ascii_lowercase();
+    if normalized.starts_with("gpt-5")
+        || normalized.starts_with("o1")
+        || normalized.starts_with("o3")
+        || normalized.starts_with("o4")
+    {
+        "max_completion_tokens"
+    } else {
+        "max_tokens"
+    }
+}
+
+fn openai_token_limit(model: &str) -> u32 {
+    if openai_token_limit_key(model) == "max_completion_tokens" {
+        4096
+    } else {
+        512
     }
 }
 
 fn parse_openai_compatible_response(payload: &Value) -> Result<String, String> {
-    let content = payload
+    let first_choice = payload
         .get("choices")
         .and_then(Value::as_array)
         .and_then(|choices| choices.first())
-        .and_then(|choice| {
-            choice
-                .get("message")
-                .and_then(|message| message.get("content"))
-                .or_else(|| choice.get("text"))
-        })
-        .and_then(Value::as_str)
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .map(ToOwned::to_owned);
+        .ok_or_else(|| "provider response missing choices".to_string())?;
 
-    content.ok_or_else(|| "provider response missing assistant content".to_string())
+    let content = first_choice
+        .get("message")
+        .and_then(|message| message.get("content"))
+        .or_else(|| first_choice.get("text"))
+        .and_then(provider_content_text)
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty());
+
+    content.ok_or_else(|| {
+        let finish_reason = first_choice
+            .get("finish_reason")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown");
+        format!("provider response missing assistant content (finish_reason={finish_reason})")
+    })
+}
+
+fn provider_content_text(value: &Value) -> Option<String> {
+    match value {
+        Value::String(text) => Some(text.clone()),
+        Value::Array(items) => {
+            let text = items
+                .iter()
+                .filter_map(|item| {
+                    item.get("text")
+                        .or_else(|| item.get("content"))
+                        .and_then(Value::as_str)
+                })
+                .filter(|part| !part.trim().is_empty())
+                .collect::<Vec<_>>()
+                .join("\n");
+            (!text.trim().is_empty()).then_some(text)
+        }
+        _ => None,
+    }
 }
 
 fn trim_endpoint(endpoint: &str) -> &str {
     endpoint.trim_end_matches('/')
+}
+
+fn trim_anthropic_endpoint(endpoint: &str) -> &str {
+    trim_endpoint(endpoint).trim_end_matches("/v1")
 }
 
 #[cfg(test)]
@@ -519,6 +782,44 @@ mod tests {
     }
 
     #[test]
+    fn openai_gpt5_uses_max_completion_tokens() {
+        let request = OpenAiClient::build_chat_request(
+            "https://api.openai.com/v1",
+            "sk-test",
+            "gpt-5-mini-2025-08-07",
+            &[ProviderMessage::user("prompt")],
+        );
+
+        assert_eq!(request.payload["max_completion_tokens"], 4096);
+        assert!(request.payload.get("max_tokens").is_none());
+    }
+
+    #[test]
+    fn openai_parses_structured_text_content() {
+        let content = OpenAiClient::parse_chat_response(&json!({
+            "choices": [{
+                "message": {
+                    "content": [{"type": "text", "text": "fix(core): parse structured content"}]
+                },
+                "finish_reason": "stop"
+            }]
+        }))
+        .expect("structured content should parse");
+
+        assert_eq!(content, "fix(core): parse structured content");
+    }
+
+    #[test]
+    fn openai_missing_content_reports_finish_reason() {
+        let err = OpenAiClient::parse_chat_response(&json!({
+            "choices": [{"message": {"content": null}, "finish_reason": "length"}]
+        }))
+        .expect_err("missing content should fail");
+
+        assert!(err.contains("finish_reason=length"));
+    }
+
+    #[test]
     fn anthropic_builds_messages_request_and_extracts_text_chunks() {
         let request = AnthropicClient::build_messages_request(
             "https://api.anthropic.com",
@@ -532,6 +833,8 @@ mod tests {
         assert_eq!(request.headers["x-api-key"], "anthropic-key");
         assert_eq!(request.headers["anthropic-version"], "2023-06-01");
         assert_eq!(request.payload["model"], "claude-test");
+        assert_eq!(request.payload["max_tokens"], 512);
+        assert!(request.payload.get("max_output_tokens").is_none());
         assert_eq!(request.payload["system"], "system");
         assert_eq!(
             request.payload["messages"][0]["content"][0]["text"],
@@ -547,6 +850,19 @@ mod tests {
         }))
         .expect("anthropic response should parse");
         assert_eq!(content, "feat(core): add client\nBody line");
+    }
+
+    #[test]
+    fn anthropic_endpoint_accepts_legacy_v1_suffix() {
+        let request = AnthropicClient::build_messages_request(
+            "https://api.anthropic.com/v1",
+            "anthropic-key",
+            "claude-sonnet-4-20250514",
+            "system",
+            "prompt",
+        );
+
+        assert_eq!(request.url, "https://api.anthropic.com/v1/messages");
     }
 
     #[test]
@@ -576,11 +892,70 @@ mod tests {
     }
 
     #[test]
+    fn xai_builds_responses_batch_requests_payload() {
+        let payload = XaiClient::build_batch_requests_payload(
+            "grok-code-fast",
+            &[OpenAiBatchJob {
+                custom_id: "alpha.py".to_string(),
+                messages: vec![
+                    ProviderMessage::system("system"),
+                    ProviderMessage::user("prompt"),
+                ],
+            }],
+        );
+
+        assert_eq!(payload["batch_requests"][0]["batch_request_id"], "alpha.py");
+        assert_eq!(
+            payload["batch_requests"][0]["batch_request"]["responses"]["model"],
+            "grok-code-fast"
+        );
+        assert_eq!(
+            payload["batch_requests"][0]["batch_request"]["responses"]["input"][0]["role"],
+            "system"
+        );
+        assert_eq!(
+            payload["batch_requests"][0]["batch_request"]["responses"]["input"][1]["content"],
+            "prompt"
+        );
+    }
+
+    #[test]
+    fn xai_parses_batch_results_and_failures() {
+        let output = XaiClient::parse_batch_results(&json!({
+            "results": [
+                {
+                    "batch_request_id": "alpha.py",
+                    "batch_result": {
+                        "response": {
+                            "chat_get_completion": {
+                                "choices": [{
+                                    "message": {"content": "fix(alpha): batch alpha"}
+                                }]
+                            }
+                        }
+                    }
+                },
+                {
+                    "batch_request_id": "beta.py",
+                    "error_message": "model failed"
+                }
+            ]
+        }));
+
+        assert_eq!(output.results.len(), 1);
+        assert_eq!(output.results[0].custom_id, "alpha.py");
+        assert_eq!(output.results[0].content, "fix(alpha): batch alpha");
+        assert_eq!(output.failures.len(), 1);
+        assert_eq!(output.failures[0].custom_id, "beta.py");
+        assert_eq!(output.failures[0].error, "model failed");
+    }
+
+    #[test]
     fn missing_provider_content_is_reported_as_parse_error() {
         let err = OpenAiClient::parse_chat_response(&json!({"choices": []}))
             .expect_err("empty choices should fail");
 
-        assert!(err.contains("missing assistant content"));
+        assert!(err.contains("missing choices"));
     }
 
     #[test]
@@ -598,13 +973,35 @@ mod tests {
         assert!(jsonl.contains(r#""model":"gpt-batch""#));
         assert!(jsonl.contains(r#""content":"prompt""#));
 
-        let results = OpenAiClient::parse_batch_output(
-            r#"{"custom_id":"alpha.py","response":{"status_code":200,"body":{"choices":[{"message":{"content":"fix(core): batch alpha"}}]}}}"#,
+        let output = OpenAiClient::parse_batch_output(
+            r#"{"custom_id":"alpha.py","response":{"status_code":200,"body":{"choices":[{"message":{"content":"fix(core): batch alpha"}}]}}}
+{"custom_id":"beta.py","response":{"status_code":400,"body":{"error":{"message":"invalid model","api_key":"sk-test"}}}}
+{"custom_id":"gamma.py","error":{"message":"rate limited","token":"secret-token"}}"#,
         )
         .expect("batch output should parse");
-        assert_eq!(results.len(), 1);
-        assert_eq!(results[0].custom_id, "alpha.py");
-        assert_eq!(results[0].content, "fix(core): batch alpha");
+        assert_eq!(output.results.len(), 1);
+        assert_eq!(output.results[0].custom_id, "alpha.py");
+        assert_eq!(output.results[0].content, "fix(core): batch alpha");
+        assert_eq!(output.failures.len(), 2);
+        assert_eq!(output.failures[0].custom_id, "beta.py");
+        assert!(output.failures[0].error.contains("status 400"));
+        assert_eq!(output.failures[1].custom_id, "gamma.py");
+        assert!(output.failures[1].error.contains("[redacted]"));
+        assert!(!output.failures[1].error.contains("secret-token"));
+    }
+
+    #[test]
+    fn openai_batch_gpt5_uses_max_completion_tokens() {
+        let jsonl = OpenAiClient::build_batch_jsonl(
+            "gpt-5-mini-2025-08-07",
+            &[OpenAiBatchJob {
+                custom_id: "alpha.py".to_string(),
+                messages: vec![ProviderMessage::user("prompt")],
+            }],
+        );
+
+        assert!(jsonl.contains(r#""max_completion_tokens":4096"#));
+        assert!(!jsonl.contains(r#""max_tokens""#));
     }
 
     #[tokio::test]
@@ -667,7 +1064,7 @@ mod tests {
         let transport =
             AsyncTransport::new(Duration::from_secs(2), RetryPolicy::default()).unwrap();
 
-        let results = OpenAiClient::invoke_batch(
+        let output = OpenAiClient::invoke_batch(
             &transport,
             &endpoint,
             "sk-test",
@@ -688,11 +1085,12 @@ mod tests {
         .await
         .expect("batch should complete");
 
-        assert_eq!(results.len(), 2);
-        assert_eq!(results[0].custom_id, "alpha.py");
-        assert_eq!(results[0].content, "fix(core): batch alpha");
-        assert_eq!(results[1].custom_id, "beta.py");
-        assert_eq!(results[1].content, "fix(core): batch beta");
+        assert_eq!(output.results.len(), 2);
+        assert!(output.failures.is_empty());
+        assert_eq!(output.results[0].custom_id, "alpha.py");
+        assert_eq!(output.results[0].content, "fix(core): batch alpha");
+        assert_eq!(output.results[1].custom_id, "beta.py");
+        assert_eq!(output.results[1].content, "fix(core): batch beta");
 
         let requests: Vec<String> = (0..4)
             .map(|_| received.recv_timeout(Duration::from_secs(2)).unwrap())

--- a/rust/crates/kcmt-provider/src/error_map.rs
+++ b/rust/crates/kcmt-provider/src/error_map.rs
@@ -27,6 +27,64 @@ pub fn normalize_error(raw_message: &str, status: Option<u16>) -> NormalizedProv
 
     NormalizedProviderError {
         kind,
-        message: "Provider request failed; check provider settings and retry.".to_string(),
+        message: render_provider_error_message(raw_message, status, kind),
+    }
+}
+
+fn render_provider_error_message(
+    raw_message: &str,
+    status: Option<u16>,
+    kind: ProviderFailureKind,
+) -> String {
+    let detail = redact_secret_like_values(raw_message)
+        .chars()
+        .filter(|ch| !ch.is_control() || *ch == '\n' || *ch == '\t')
+        .take(1000)
+        .collect::<String>();
+    let kind_label = match kind {
+        ProviderFailureKind::Timeout => "timeout/transient",
+        ProviderFailureKind::RateLimited => "rate limited",
+        ProviderFailureKind::MalformedResponse => "malformed response",
+        ProviderFailureKind::Unauthorized => "unauthorized",
+        ProviderFailureKind::Unknown => "request failed",
+    };
+    match (status, detail.trim().is_empty()) {
+        (Some(status), false) => format!("{kind_label} (HTTP {status}): {detail}"),
+        (Some(status), true) => format!("{kind_label} (HTTP {status})"),
+        (None, false) => format!("{kind_label}: {detail}"),
+        (None, true) => "Provider request failed; check provider settings and retry.".to_string(),
+    }
+}
+
+fn redact_secret_like_values(raw: &str) -> String {
+    let mut redacted = raw.to_string();
+    for marker in ["sk-", "sk_live_", "sk_test_"] {
+        while let Some(start) = redacted.find(marker) {
+            let end = redacted[start..]
+                .find(|ch: char| ch.is_whitespace() || matches!(ch, '"' | '\'' | ',' | '}'))
+                .map(|offset| start + offset)
+                .unwrap_or(redacted.len());
+            redacted.replace_range(start..end, "[redacted]");
+        }
+    }
+    redacted
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{normalize_error, ProviderFailureKind};
+
+    #[test]
+    fn preserves_provider_error_detail_without_secret_values() {
+        let error = normalize_error(
+            "provider request failed with status 400 Bad Request: {\"error\":{\"message\":\"invalid model\",\"api_key\":\"sk-test-secret\"}}",
+            Some(400),
+        );
+
+        assert_eq!(error.kind, ProviderFailureKind::Unknown);
+        assert!(error.message.contains("HTTP 400"));
+        assert!(error.message.contains("invalid model"));
+        assert!(!error.message.contains("sk-test-secret"));
+        assert!(error.message.contains("[redacted]"));
     }
 }

--- a/rust/crates/kcmt-provider/src/transport.rs
+++ b/rust/crates/kcmt-provider/src/transport.rs
@@ -6,6 +6,7 @@ use anyhow::{anyhow, Result};
 use reqwest::header::HeaderMap;
 use reqwest::multipart;
 use reqwest::Client;
+use reqwest::Response;
 use serde_json::Value;
 use tokio::time::sleep;
 
@@ -62,17 +63,9 @@ impl AsyncTransport {
                         sleep(self.retry_policy.base_backoff * attempt as u32).await;
                         continue;
                     }
-                    return Err(anyhow!(
-                        "provider request failed with status {}",
-                        resp.status()
-                    ));
+                    return provider_status_error(resp).await;
                 }
-                Ok(resp) => {
-                    return Err(anyhow!(
-                        "provider request failed with status {}",
-                        resp.status()
-                    ));
-                }
+                Ok(resp) => return provider_status_error(resp).await,
                 Err(err) if attempt < self.retry_policy.max_attempts => {
                     sleep(self.retry_policy.base_backoff * attempt as u32).await;
                     tracing::warn!("transient transport error (attempt {attempt}): {err}");
@@ -95,17 +88,9 @@ impl AsyncTransport {
                         sleep(self.retry_policy.base_backoff * attempt as u32).await;
                         continue;
                     }
-                    return Err(anyhow!(
-                        "provider request failed with status {}",
-                        resp.status()
-                    ));
+                    return provider_status_error(resp).await;
                 }
-                Ok(resp) => {
-                    return Err(anyhow!(
-                        "provider request failed with status {}",
-                        resp.status()
-                    ));
-                }
+                Ok(resp) => return provider_status_error(resp).await,
                 Err(err) if attempt < self.retry_policy.max_attempts => {
                     sleep(self.retry_policy.base_backoff * attempt as u32).await;
                     tracing::warn!("transient transport error (attempt {attempt}): {err}");
@@ -128,17 +113,9 @@ impl AsyncTransport {
                         sleep(self.retry_policy.base_backoff * attempt as u32).await;
                         continue;
                     }
-                    return Err(anyhow!(
-                        "provider request failed with status {}",
-                        resp.status()
-                    ));
+                    return provider_status_error(resp).await;
                 }
-                Ok(resp) => {
-                    return Err(anyhow!(
-                        "provider request failed with status {}",
-                        resp.status()
-                    ));
-                }
+                Ok(resp) => return provider_status_error(resp).await,
                 Err(err) if attempt < self.retry_policy.max_attempts => {
                     sleep(self.retry_policy.base_backoff * attempt as u32).await;
                     tracing::warn!("transient transport error (attempt {attempt}): {err}");
@@ -179,17 +156,9 @@ impl AsyncTransport {
                         sleep(self.retry_policy.base_backoff * attempt as u32).await;
                         continue;
                     }
-                    return Err(anyhow!(
-                        "provider request failed with status {}",
-                        resp.status()
-                    ));
+                    return provider_status_error(resp).await;
                 }
-                Ok(resp) => {
-                    return Err(anyhow!(
-                        "provider request failed with status {}",
-                        resp.status()
-                    ));
-                }
+                Ok(resp) => return provider_status_error(resp).await,
                 Err(err) if attempt < self.retry_policy.max_attempts => {
                     sleep(self.retry_policy.base_backoff * attempt as u32).await;
                     tracing::warn!("transient transport error (attempt {attempt}): {err}");
@@ -198,6 +167,37 @@ impl AsyncTransport {
             }
         }
     }
+}
+
+async fn provider_status_error<T>(resp: Response) -> Result<T> {
+    let status = resp.status();
+    let body = resp.text().await.unwrap_or_default();
+    let excerpt = redact_provider_error_body(&body);
+    if excerpt.is_empty() {
+        Err(anyhow!("provider request failed with status {status}"))
+    } else {
+        Err(anyhow!(
+            "provider request failed with status {status}: {excerpt}"
+        ))
+    }
+}
+
+fn redact_provider_error_body(body: &str) -> String {
+    let mut redacted = body.to_string();
+    for marker in ["sk-", "sk_live_", "sk_test_"] {
+        while let Some(start) = redacted.find(marker) {
+            let end = redacted[start..]
+                .find(|ch: char| ch.is_whitespace() || matches!(ch, '"' | '\'' | ',' | '}'))
+                .map(|offset| start + offset)
+                .unwrap_or(redacted.len());
+            redacted.replace_range(start..end, "[redacted]");
+        }
+    }
+    redacted
+        .chars()
+        .filter(|ch| !ch.is_control() || *ch == '\n' || *ch == '\t')
+        .take(1000)
+        .collect::<String>()
 }
 
 #[cfg(test)]
@@ -248,6 +248,37 @@ mod tests {
             .all(|request| request.contains("{\"prompt\":\"alpha\"}")));
     }
 
+    #[tokio::test]
+    async fn post_json_reports_redacted_error_body() {
+        let (endpoint, _received) = spawn_single_response_server(
+            "400 Bad Request",
+            r#"{"error":{"message":"invalid model","api_key":"sk-test-secret"}}"#,
+        );
+        let transport = AsyncTransport::new(
+            Duration::from_secs(2),
+            RetryPolicy {
+                max_attempts: 1,
+                base_backoff: Duration::from_millis(1),
+            },
+        )
+        .expect("transport");
+
+        let err = transport
+            .post_json(
+                &endpoint,
+                HeaderMap::new(),
+                &serde_json::json!({"prompt":"alpha"}),
+            )
+            .await
+            .expect_err("status should fail");
+        let message = err.to_string();
+
+        assert!(message.contains("400 Bad Request"), "{message}");
+        assert!(message.contains("invalid model"), "{message}");
+        assert!(!message.contains("sk-test-secret"), "{message}");
+        assert!(message.contains("[redacted]"), "{message}");
+    }
+
     fn spawn_retrying_multipart_server() -> (String, mpsc::Receiver<String>) {
         let listener = TcpListener::bind("127.0.0.1:0").expect("bind mock server");
         let endpoint = format!(
@@ -280,6 +311,33 @@ mod tests {
                     .write_all(response.as_bytes())
                     .expect("write response");
             }
+        });
+
+        (endpoint, receiver)
+    }
+
+    fn spawn_single_response_server(
+        status: &'static str,
+        body: &'static str,
+    ) -> (String, mpsc::Receiver<String>) {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind mock server");
+        let endpoint = format!("http://{}/chat", listener.local_addr().expect("local addr"));
+        let (sender, receiver) = mpsc::channel();
+
+        thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept request");
+            let mut buffer = [0_u8; 16384];
+            let read = stream.read(&mut buffer).expect("read request");
+            let request = String::from_utf8_lossy(&buffer[..read]).to_string();
+            sender.send(request).expect("send captured request");
+            let response = format!(
+                "HTTP/1.1 {status}\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            stream
+                .write_all(response.as_bytes())
+                .expect("write response");
         });
 
         (endpoint, receiver)

--- a/tests/features/rust_workflow_parity.feature
+++ b/tests/features/rust_workflow_parity.feature
@@ -87,6 +87,13 @@ Feature: Rust workflow parity
     Then the batch provider receives both file prompts before commits are written
     And both files are committed with the batch provider messages
 
+  Scenario: Default OpenAI batch reports partial invalid provider output
+    Given a git repository with two changed tracked files and a partially invalid OpenAI batch provider
+    When the Rust kcmt command runs in default batch mode
+    Then the batch provider receives both file prompts before commits are written
+    And only the valid batch file is committed
+    And provider output and status remain secret-free
+
   Scenario: File workflow falls back to the next configured provider
     Given a git repository with one changed tracked file and a fallback provider chain
     When the Rust kcmt command commits the file using configured provider fallback

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -294,7 +294,7 @@ def test_render_benchmark_markdown_report_remains_provider_focused() -> None:
     exclusions = [
         bench.BenchExclusion(
             provider="anthropic",
-            model="claude-3-5-haiku-latest",
+            model="claude-sonnet-4-20250514",
             reason="missing_api_key",
             detail="ANTHROPIC_API_KEY is not set",
         )

--- a/tests/test_rust_workflow_parity_bdd.py
+++ b/tests/test_rust_workflow_parity_bdd.py
@@ -124,6 +124,30 @@ def _start_batch_provider() -> tuple[str, type[_BatchHandler], HTTPServer]:
     return f"http://127.0.0.1:{server.server_port}", Handler, server
 
 
+def _start_partial_batch_provider() -> tuple[str, type[_BatchHandler], HTTPServer]:
+    class Handler(_BatchHandler):
+        requests: list[tuple[str, str, str]] = []
+
+        def do_GET(self) -> None:  # noqa: N802
+            self._record()
+            if self.path == "/batches/batch_1":
+                self._json(
+                    '{"id":"batch_1","status":"completed","output_file_id":"output_1"}'
+                )
+            elif self.path == "/files/output_1/content":
+                self._json(
+                    '{"custom_id":"alpha.py","response":{"status_code":200,"body":{"choices":[{"message":{"content":"fix(alpha): batch alpha."}}]}}}\n'
+                    '{"custom_id":"beta.py","response":{"status_code":200,"body":{"choices":[{"message":{"content":"This is not conventional"}}]}}}\n'
+                )
+            else:
+                self.send_error(404)
+
+    server = HTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return f"http://127.0.0.1:{server.server_port}", Handler, server
+
+
 class _FallbackHandler(BaseHTTPRequestHandler):
     requests: list[tuple[str, str, str]] = []
 
@@ -268,6 +292,21 @@ def git_repository_with_two_changed_files_and_mocked_batch_provider(
 ) -> dict[str, Any]:
     context = git_repository_with_two_changed_tracked_files(tmp_path)
     endpoint, handler, server = _start_batch_provider()
+    context["endpoint"] = endpoint
+    context["batch_handler"] = handler
+    context["batch_server"] = server
+    return context
+
+
+@given(
+    "a git repository with two changed tracked files and a partially invalid OpenAI batch provider",
+    target_fixture="workflow_context",
+)
+def git_repository_with_two_changed_files_and_partial_batch_provider(
+    tmp_path: Path,
+) -> dict[str, Any]:
+    context = git_repository_with_two_changed_tracked_files(tmp_path)
+    endpoint, handler, server = _start_partial_batch_provider()
     context["endpoint"] = endpoint
     context["batch_handler"] = handler
     context["batch_server"] = server
@@ -1354,6 +1393,43 @@ def both_files_are_committed_with_the_batch_provider_messages(
     assert "fix(beta): batch beta" in subjects
 
 
+@then("only the valid batch file is committed")
+def only_the_valid_batch_file_is_committed(workflow_context: dict[str, Any]) -> None:
+    output = workflow_context["output"]
+    assert "fix(alpha): batch alpha" in output
+    assert "LLM output missing conventional commit header" in output
+    log = _git(workflow_context["repo"], ["log", "--pretty=%s"])
+    subjects = log.splitlines()
+    assert "fix(alpha): batch alpha" in subjects
+    assert "This is not conventional" not in subjects
+    status = _git(workflow_context["repo"], ["status", "--short"])
+    assert "beta.py" in status
+    assert "alpha.py" not in status
+
+
+@then("provider output and status remain secret-free")
+def provider_output_and_status_remain_secret_free(
+    workflow_context: dict[str, Any],
+) -> None:
+    output = workflow_context["output"]
+    assert "test-key" not in output
+    raw_status = _run(
+        [
+            str(_rust_bin("kcmt")),
+            "status",
+            "--raw",
+            "--repo-path",
+            str(workflow_context["repo"]),
+        ],
+        REPO_ROOT,
+        env=_clean_env(workflow_context["config_home"]),
+    )
+    assert "test-key" not in raw_status
+    assert '"api_key_env": "OPENAI_TEST_KEY"' in raw_status
+    assert '"commit_success": 1' in raw_status
+    assert '"commit_failure": 1' in raw_status
+
+
 @then("the fallback provider is used after the primary provider fails")
 def fallback_provider_is_used_after_the_primary_provider_fails(
     workflow_context: dict[str, Any],
@@ -1454,7 +1530,7 @@ def model_list_includes_all_supported_providers(
     assert "openai" in output
     assert "gpt-5-mini-2025-08-07" in output
     assert "anthropic" in output
-    assert "claude-3-5-haiku-latest" in output
+    assert "claude-sonnet-4-20250514" in output
     assert "xai" in output
     assert "github" in output
 


### PR DESCRIPTION
## Summary

- Adds standardized Rust workflow progress output for direct and batch provider modes.
- Hardens OpenAI, Anthropic, xAI, and GitHub provider request/response handling for production LLM use.
- Adds xAI batch support with provider-specific batch model defaults.
- Adds an ignored live LLM provider matrix integration test and `make test-llm-matrix`.
- Updates docs and parity tests for the Rust live-provider rollout.

## Conventional Commit Breakdown

| Commit | Type | Scope | Summary |
|---|---|---|---|
| `74d34b4` | feat | rust | harden live llm provider workflows |

## Release Notes Draft

Rust provider workflows now support live production smoke testing across OpenAI, Anthropic, xAI, and GitHub Models. OpenAI and xAI batch modes are covered by the live matrix. Progress output is standardized across direct and batch modes.

## Behaviour Changes

- `--batch` supports OpenAI and xAI provider workflows.
- xAI standard defaults to `grok-code-fast`; xAI batch defaults to `grok-4.3`.
- Anthropic default model is updated to `claude-sonnet-4-20250514`.
- Provider HTTP errors include redacted diagnostic detail.
- Direct and batch runs emit consistent `kcmt progress:` state lines unless progress is disabled.

## API / Schema / Contract Changes

- Adds `make test-llm-matrix` for opt-in live provider integration testing.
- Adds ignored Rust integration test `live_llm_matrix`.
- No public API schema migration required.

## Testing Evidence

- `make check`: passed.
- `make quality-gates`: passed.
- `make test-llm-matrix`: passed.
- Live matrix passed all provider/mode combinations: OpenAI standard, OpenAI batch, Anthropic standard, xAI standard, xAI batch, GitHub standard.

## Live Matrix Summary

| provider | mode | model | status | files | ignored | workflow_total_ms |
|---|---|---|---|---:|---|---:|
| openai | standard | gpt-5-mini-2025-08-07 | passed | 7 | true | 14186.4 |
| openai | batch | gpt-5-mini-2025-08-07 | passed | 7 | true | 141091.1 |
| anthropic | standard | claude-sonnet-4-20250514 | passed | 7 | true | 3836.4 |
| xai | standard | grok-code-fast | passed | 7 | true | 46404.1 |
| xai | batch | grok-4.3 | passed | 7 | true | 30898.4 |
| github | standard | openai/gpt-4.1-mini | passed | 7 | true | 3128.8 |

## Risk and Rollback

Risk is mainly provider API drift or provider-specific batch model availability. Rollback is reverting this commit; no data migration is required.

## Operational Notes

Live matrix requires real provider keys and is intentionally ignored in normal test runs. Use `make test-llm-matrix` when validating provider production readiness.

## Linked Work

Not provided.

## Reviewer Checklist

- [ ] Review provider request/response parsing and redaction.
- [ ] Review progress output format for direct and batch modes.
- [ ] Review live matrix coverage and skipped/default model behavior.
- [ ] Confirm docs match intended Rust rollout workflow.
