### PR TITLE
feat(rust): add model preferences selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ test -n "$OPENAI_API_KEY" && \
 | Provider  | Default model             | Default endpoint                         |
 |-----------|---------------------------|------------------------------------------|
 | OpenAI    | `gpt-5-mini-2025-08-07`   | `https://api.openai.com/v1`              |
-| Anthropic | `claude-sonnet-4-20250514` | `https://api.anthropic.com`             |
+| Anthropic | `claude-3-5-haiku-latest`  | `https://api.anthropic.com`             |
 | xAI       | `grok-code-fast`          | `https://api.x.ai/v1`                   |
 | GitHub    | `openai/gpt-4.1-mini`     | `https://models.github.ai/inference`    |
 
@@ -223,6 +223,7 @@ Additional LLM behaviour environment variables:
 - `KCMT_OPENAI_MINIMAL_PROMPT` – force minimal prompt style (adaptive toggle)
 - `KCMT_OPENAI_MAX_TOKENS` – max completion tokens for OpenAI-like providers
 - `KCMT_FAST_LOCAL_FOR_SMALL_DIFFS` – opt-in local conventional subject for tiny diffs (<=3 changed lines)
+- `KCMT_DISABLE_KEYCHAIN=1` – skip OS keychain lookup for hermetic CI/test runs
 - `KLINGON_CMT_AUTO_PUSH=0|1` (disable or enable automatic `git push`; default is enabled)
 
 ## List models and pricing

--- a/README.md
+++ b/README.md
@@ -65,11 +65,14 @@ Dependencies
 
 ## Configuration
 
-Run `kcmt --configure` inside a repository to launch a colourful wizard that:
+Run `kcmt --configure` inside a repository to write or refresh global config.
+Use `kcmt --configure --tui` to open the terminal menu shell when stdin/stdout
+are attached to a terminal.
 
 - Detects available API keys (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `XAI_API_KEY`, `GITHUB_TOKEN`).
 - Lets you choose the provider, tweak model/endpoint, and pick the env var to use.
 - Persists the selection to `~/.config/kcmt/config.json` (global, per-user).
+- Persists selector, prompt, and TUI defaults to `~/.config/kcmt/preferences.json`.
 
 Per-provider settings
 
@@ -77,7 +80,8 @@ kcmt maintains a per-provider settings map in `~/.config/kcmt/config.json`. Each
 
 - `name`: friendly display name
 - `endpoint`: base URL for API calls
-- `api_key_env`: environment variable that holds your API key/token (kcmt stores the variable name, not the secret)
+- `api_key_env`: fallback environment variable that holds your API key/token (kcmt stores the variable name, not the secret)
+- `keychain_account`: OS keychain account reference; credential resolution is explicit CLI input, then OS keychain, then environment variable
 - `preferred_model`: your saved default model for that provider
 
 Example (`~/.config/kcmt/config.json` excerpt):
@@ -163,8 +167,8 @@ kcmt --help
 ```
 
 Optional live smoke commands use real provider keys only when the corresponding
-environment variable is already set. They do not print secret values; `status
---raw` records the env var name, not the key.
+OS keychain entry or environment variable is already set. They do not print
+secret values; `status --raw` records credential references, not the key.
 
 ```shell
 test -n "$OPENAI_API_KEY" && \
@@ -223,12 +227,27 @@ Additional LLM behaviour environment variables:
 
 ## List models and pricing
 
-`kcmt --list-models` prints a simple cross-provider pricing board ordered by output (completion) price per 1M tokens, including context window and max output when available. Use `--debug` to see the raw structured listings.
+`kcmt --list-models` prints supported provider models. When credentials are
+available, kcmt tries live provider model listing and falls back to curated
+defaults offline. Use `--debug` to see structured listings.
 
 Example:
 
 ```shell
 kcmt --list-models
+```
+
+## Preferences, rules, and stats
+
+Provider rules and prompt profiles live in `~/.config/kcmt/preferences.json`.
+The first selector policy is `fastest_cheap`; provider presets include rules
+such as Anthropic `latest_haiku`. The commit workflow records local aggregate
+usage telemetry per repository without storing prompts, diffs, generated commit
+messages, or secret values.
+
+```shell
+kcmt stats --json --repo-path .
+printf '%s' "$ANTHROPIC_API_KEY" | kcmt --configure --provider anthropic --api-key-stdin --save-api-key
 ```
 
 ## Benchmarking

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -402,27 +402,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dbus"
-version = "0.9.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b942602992bb7acfd1f51c49811c58a610ef9181b6e66f3e519d79b540a3bf73"
-dependencies = [
- "libc",
- "libdbus-sys",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "dbus-secret-service"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "708b509edf7889e53d7efb0ffadd994cc6c2345ccb62f55cfd6b0682165e4fa6"
-dependencies = [
- "dbus",
- "zeroize",
-]
-
-[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1858,7 +1837,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
 dependencies = [
  "byteorder",
- "dbus-secret-service",
  "log",
  "security-framework 2.11.1",
  "security-framework 3.7.0",
@@ -1880,15 +1858,6 @@ name = "libc"
 version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
-
-[[package]]
-name = "libdbus-sys"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
-dependencies = [
- "pkg-config",
-]
 
 [[package]]
 name = "linux-raw-sys"
@@ -2072,12 +2041,6 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "pkg-config"
-version = "0.3.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "portable-atomic"
@@ -3425,20 +3388,6 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
-dependencies = [
- "zeroize_derive",
-]
-
-[[package]]
-name = "zeroize_derive"
-version = "1.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "zerotrie"

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -242,6 +242,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -276,6 +311,24 @@ dependencies = [
  "mio",
  "parking_lot",
  "rustix 0.38.44",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "derive_more",
+ "document-features",
+ "mio",
+ "parking_lot",
+ "rustix 1.1.4",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -349,12 +402,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "dbus"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b942602992bb7acfd1f51c49811c58a610ef9181b6e66f3e519d79b540a3bf73"
+dependencies = [
+ "libc",
+ "libdbus-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "dbus-secret-service"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "708b509edf7889e53d7efb0ffadd994cc6c2345ccb62f55cfd6b0682165e4fa6"
+dependencies = [
+ "dbus",
+ "zeroize",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
 ]
 
 [[package]]
@@ -376,6 +472,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -1702,6 +1807,7 @@ dependencies = [
  "kcmt-bench",
  "kcmt-core",
  "kcmt-provider",
+ "kcmt-tui",
  "serde_json",
  "sha2",
  "tokio",
@@ -1713,9 +1819,12 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "gix",
+ "keyring",
  "serde",
  "serde_json",
+ "sha2",
  "thiserror",
+ "time",
  "tracing",
 ]
 
@@ -1737,8 +1846,24 @@ name = "kcmt-tui"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "crossterm 0.29.0",
  "ratatui",
  "tracing",
+]
+
+[[package]]
+name = "keyring"
+version = "3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
+dependencies = [
+ "byteorder",
+ "dbus-secret-service",
+ "log",
+ "security-framework 2.11.1",
+ "security-framework 3.7.0",
+ "windows-sys 0.60.2",
+ "zeroize",
 ]
 
 [[package]]
@@ -1757,6 +1882,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
+name = "libdbus-sys"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
+dependencies = [
+ "pkg-config",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1773,6 +1907,12 @@ name = "litemap"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "lock_api"
@@ -1932,6 +2072,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "portable-atomic"
@@ -2098,7 +2244,7 @@ dependencies = [
  "bitflags",
  "cassowary",
  "compact_str",
- "crossterm",
+ "crossterm 0.28.1",
  "indoc",
  "instability",
  "itertools",
@@ -2184,6 +2330,15 @@ name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustix"
@@ -2272,6 +2427,48 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -3228,6 +3425,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zerotrie"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -25,6 +25,7 @@ tracing = "0.1"
 sha2 = "0.10"
 time = { version = "0.3", features = ["formatting", "macros"] }
 gix = { version = "0.73", default-features = false, features = ["status"] }
+keyring = { version = "3.6", features = ["apple-native", "windows-native", "sync-secret-service"] }
 
 [profile.release]
 panic = "abort"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -25,7 +25,6 @@ tracing = "0.1"
 sha2 = "0.10"
 time = { version = "0.3", features = ["formatting", "macros"] }
 gix = { version = "0.73", default-features = false, features = ["status"] }
-keyring = { version = "3.6", features = ["apple-native", "windows-native", "sync-secret-service"] }
 
 [profile.release]
 panic = "abort"

--- a/rust/crates/kcmt-cli/Cargo.toml
+++ b/rust/crates/kcmt-cli/Cargo.toml
@@ -27,6 +27,7 @@ clap.workspace = true
 kcmt-bench = { path = "../kcmt-bench" }
 kcmt-core = { path = "../kcmt-core" }
 kcmt-provider = { path = "../kcmt-provider" }
+kcmt-tui = { path = "../kcmt-tui" }
 serde_json.workspace = true
 sha2.workspace = true
 tokio.workspace = true

--- a/rust/crates/kcmt-cli/src/args.rs
+++ b/rust/crates/kcmt-cli/src/args.rs
@@ -33,6 +33,15 @@ pub struct CliArgs {
     #[arg(long = "github-token")]
     pub github_token: Option<String>,
 
+    #[arg(long = "api-key")]
+    pub api_key: Option<String>,
+
+    #[arg(long = "save-api-key")]
+    pub save_api_key: bool,
+
+    #[arg(long = "api-key-stdin")]
+    pub api_key_stdin: bool,
+
     #[arg(long, alias = "summary")]
     pub compact: bool,
 
@@ -41,6 +50,9 @@ pub struct CliArgs {
 
     #[arg(long = "configure-all")]
     pub configure_all: bool,
+
+    #[arg(long = "tui")]
+    pub tui: bool,
 
     #[arg(long = "list-models")]
     pub list_models: bool,
@@ -128,6 +140,7 @@ impl CliArgs {
 #[derive(Debug, Subcommand, Clone)]
 pub enum CliCommand {
     Status(StatusArgs),
+    Stats(StatsArgs),
     Benchmark(BenchmarkArgs),
 }
 
@@ -135,6 +148,12 @@ pub enum CliCommand {
 pub struct StatusArgs {
     #[arg(long)]
     pub raw: bool,
+}
+
+#[derive(Debug, Args, Clone, Default)]
+pub struct StatsArgs {
+    #[arg(long)]
+    pub json: bool,
 }
 
 #[derive(Debug, Args, Clone, Default)]

--- a/rust/crates/kcmt-cli/src/commands/benchmark.rs
+++ b/rust/crates/kcmt-cli/src/commands/benchmark.rs
@@ -83,6 +83,7 @@ pub fn run_provider_benchmark(repo_path: PathBuf, args: &CliArgs) -> i32 {
         model: args.model.clone(),
         endpoint: args.endpoint.clone(),
         api_key_env: args.api_key_env.clone(),
+        keychain_account: None,
         repo_path: Some(repo_path.clone()),
         max_commit_length: args.max_commit_length,
         auto_push: args.auto_push_override(),

--- a/rust/crates/kcmt-cli/src/commands/configure.rs
+++ b/rust/crates/kcmt-cli/src/commands/configure.rs
@@ -117,9 +117,15 @@ fn live_models_for_provider(
     endpoint: &str,
     api_key_env: &str,
 ) -> Option<Vec<String>> {
+    let explicit_provider = std::env::var("KCMT_EXPLICIT_API_KEY_PROVIDER").ok();
+    let explicit_secret = if explicit_provider.as_deref().unwrap_or(provider) == provider {
+        std::env::var("KCMT_EXPLICIT_API_KEY").ok()
+    } else {
+        None
+    };
     let request = CredentialRequest {
         provider: provider.to_string(),
-        explicit_secret: None,
+        explicit_secret,
         keychain_account: Some(default_keychain_account(provider)),
         env_var: api_key_env.to_string(),
     };

--- a/rust/crates/kcmt-cli/src/commands/configure.rs
+++ b/rust/crates/kcmt-cli/src/commands/configure.rs
@@ -1,9 +1,16 @@
 use std::collections::HashMap;
 use std::fs;
 use std::path::PathBuf;
+use std::time::Duration;
 
 use kcmt_core::config::loader::{config_file_path, load_config, ConfigOverrides};
 use kcmt_core::model::{ModelPreference, ProviderConfigEntry};
+use kcmt_core::preferences::{
+    default_keychain_account, load_preferences, resolve_credential, save_preferences,
+    CredentialRequest, OsKeychainStore,
+};
+use kcmt_provider::clients::{AnthropicClient, GitHubModelsClient, OpenAiClient, XaiClient};
+use kcmt_provider::transport::{AsyncTransport, RetryPolicy};
 use serde_json::json;
 
 const PROVIDERS: &[(&str, &str, &str, &str, &str)] = &[
@@ -17,7 +24,7 @@ const PROVIDERS: &[(&str, &str, &str, &str, &str)] = &[
     (
         "anthropic",
         "Anthropic",
-        "claude-sonnet-4-20250514",
+        "claude-3-5-haiku-latest",
         "https://api.anthropic.com",
         "ANTHROPIC_API_KEY",
     ),
@@ -51,18 +58,23 @@ pub fn run_configure(repo_path: PathBuf, overrides: ConfigOverrides) -> i32 {
 }
 
 pub fn run_list_models(debug: bool) -> i32 {
+    let provider_models = resolved_provider_models();
     if debug {
         let payload = PROVIDERS
             .iter()
             .map(|(provider, name, model, endpoint, api_key_env)| {
+                let models = provider_models
+                    .get(*provider)
+                    .cloned()
+                    .unwrap_or_else(|| vec![(*model).to_string()]);
                 json!({
                     "provider": provider,
                     "display_name": name,
-                    "models": [{
-                        "id": model,
+                    "models": models.into_iter().map(|model_id| json!({
+                        "id": model_id,
                         "endpoint": endpoint,
                         "api_key_env": api_key_env
-                    }]
+                    })).collect::<Vec<_>>()
                 })
             })
             .collect::<Vec<_>>();
@@ -77,9 +89,67 @@ pub fn run_list_models(debug: bool) -> i32 {
     }
 
     for (provider, _name, model, endpoint, _api_key_env) in PROVIDERS {
-        println!("{provider}\t{model}\t{endpoint}");
+        let models = provider_models
+            .get(*provider)
+            .cloned()
+            .unwrap_or_else(|| vec![(*model).to_string()]);
+        for model in models {
+            println!("{provider}\t{model}\t{endpoint}");
+        }
     }
     0
+}
+
+fn resolved_provider_models() -> HashMap<String, Vec<String>> {
+    PROVIDERS
+        .iter()
+        .map(|(provider, _name, model, endpoint, api_key_env)| {
+            let models = live_models_for_provider(provider, endpoint, api_key_env)
+                .filter(|models| !models.is_empty())
+                .unwrap_or_else(|| vec![(*model).to_string()]);
+            ((*provider).to_string(), models)
+        })
+        .collect()
+}
+
+fn live_models_for_provider(
+    provider: &str,
+    endpoint: &str,
+    api_key_env: &str,
+) -> Option<Vec<String>> {
+    let request = CredentialRequest {
+        provider: provider.to_string(),
+        explicit_secret: None,
+        keychain_account: Some(default_keychain_account(provider)),
+        env_var: api_key_env.to_string(),
+    };
+    let api_key = resolve_credential(&request, &OsKeychainStore)
+        .ok()
+        .flatten()?
+        .secret;
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .ok()?;
+    let transport = AsyncTransport::new(
+        Duration::from_secs(5),
+        RetryPolicy {
+            max_attempts: 1,
+            base_backoff: Duration::from_millis(100),
+        },
+    )
+    .ok()?;
+    runtime
+        .block_on(async {
+            match provider {
+                "anthropic" => AnthropicClient::list_models(&transport, endpoint, &api_key).await,
+                "xai" => XaiClient::list_models(&transport, endpoint, &api_key).await,
+                "github" => GitHubModelsClient::list_models(&transport, endpoint, &api_key).await,
+                _ => OpenAiClient::list_models(&transport, endpoint, &api_key).await,
+            }
+        })
+        .ok()
+        .map(|models| models.into_iter().map(|model| model.id).collect())
 }
 
 pub fn run_verify_keys() -> i32 {
@@ -114,6 +184,9 @@ fn write_config(repo_path: PathBuf, overrides: ConfigOverrides) -> anyhow::Resul
                     .api_key_env
                     .get_or_insert_with(|| (*api_key_env).to_string());
                 entry
+                    .keychain_account
+                    .get_or_insert_with(|| format!("provider/{provider}/default"));
+                entry
                     .preferred_model
                     .get_or_insert_with(|| (*model).to_string());
             })
@@ -121,6 +194,7 @@ fn write_config(repo_path: PathBuf, overrides: ConfigOverrides) -> anyhow::Resul
                 name: Some((*name).to_string()),
                 endpoint: Some((*endpoint).to_string()),
                 api_key_env: Some((*api_key_env).to_string()),
+                keychain_account: Some(format!("provider/{provider}/default")),
                 preferred_model: Some((*model).to_string()),
             });
     }
@@ -128,6 +202,9 @@ fn write_config(repo_path: PathBuf, overrides: ConfigOverrides) -> anyhow::Resul
     if let Some(primary) = providers.get_mut(&cfg.provider) {
         primary.endpoint = Some(cfg.llm_endpoint.clone());
         primary.api_key_env = Some(cfg.api_key_env.clone());
+        primary
+            .keychain_account
+            .get_or_insert_with(|| format!("provider/{}/default", cfg.provider));
         primary.preferred_model = Some(cfg.model.clone());
     }
 
@@ -159,5 +236,7 @@ fn write_config(repo_path: PathBuf, overrides: ConfigOverrides) -> anyhow::Resul
         fs::create_dir_all(parent)?;
     }
     fs::write(&path, serde_json::to_string_pretty(&payload)?)?;
+    let preferences = load_preferences().unwrap_or_default();
+    save_preferences(&preferences)?;
     Ok(path)
 }

--- a/rust/crates/kcmt-cli/src/commands/mod.rs
+++ b/rust/crates/kcmt-cli/src/commands/mod.rs
@@ -1,5 +1,6 @@
 pub mod benchmark;
 pub mod configure;
 pub mod history;
+pub mod stats;
 pub mod status;
 pub mod workflow;

--- a/rust/crates/kcmt-cli/src/commands/stats.rs
+++ b/rust/crates/kcmt-cli/src/commands/stats.rs
@@ -1,0 +1,45 @@
+use std::path::PathBuf;
+
+use kcmt_core::telemetry::load_usage_summary;
+
+use crate::args::StatsArgs;
+
+pub fn render_stats_command(repo_path: PathBuf, args: StatsArgs) -> i32 {
+    match load_usage_summary(&repo_path) {
+        Ok(summary) if args.json => match serde_json::to_string_pretty(&summary) {
+            Ok(rendered) => {
+                println!("{rendered}");
+                0
+            }
+            Err(err) => {
+                eprintln!("{err}");
+                1
+            }
+        },
+        Ok(summary) => {
+            println!("kcmt usage statistics");
+            if summary.aggregates.is_empty() {
+                println!("No usage telemetry recorded for this repository.");
+                return 0;
+            }
+            println!("provider\tmodel\truns\tsuccesses\tfailures\tavg_latency_ms\trule");
+            for aggregate in summary.aggregates {
+                println!(
+                    "{}\t{}\t{}\t{}\t{}\t{:.1}\t{}",
+                    aggregate.provider,
+                    aggregate.model,
+                    aggregate.runs,
+                    aggregate.successes,
+                    aggregate.failures,
+                    aggregate.avg_latency_ms,
+                    aggregate.selected_rule.unwrap_or_else(|| "-".to_string())
+                );
+            }
+            0
+        }
+        Err(err) => {
+            eprintln!("{err}");
+            1
+        }
+    }
+}

--- a/rust/crates/kcmt-cli/src/commands/workflow.rs
+++ b/rust/crates/kcmt-cli/src/commands/workflow.rs
@@ -597,7 +597,7 @@ fn run_entries_workflow(
                 .model_selection
                 .rule_applied
                 .as_ref()
-                .map(|rule| format!("{rule:?}").to_ascii_lowercase()),
+                .map(|rule| rule.as_str().to_string()),
             success: failures.is_empty() && !commits.is_empty(),
             latency_ms: workflow_start.elapsed().as_secs_f64() * 1000.0,
             fallback_count: u64::from(runtime.model_selection.fallback_reason.is_some()),

--- a/rust/crates/kcmt-cli/src/commands/workflow.rs
+++ b/rust/crates/kcmt-cli/src/commands/workflow.rs
@@ -17,7 +17,15 @@ use kcmt_core::git::commit_file::{
     GixCommitSession,
 };
 use kcmt_core::git::repo::{CliGitRepository, GitRepository};
-use kcmt_core::message::{build_prompt, sanitize_commit_output};
+use kcmt_core::message::{
+    build_prompt_with_profile, sanitize_commit_output, selected_prompt_profile,
+};
+use kcmt_core::preferences::{
+    default_keychain_account, load_preferences, resolve_credential, CredentialRequest,
+    CredentialSource, OsKeychainStore, Preferences, PromptProfile,
+};
+use kcmt_core::selector::{default_models_for_provider, select_model, ModelSelection};
+use kcmt_core::telemetry::{load_usage_summary, record_usage, TelemetryRunRecord};
 use kcmt_provider::clients::{
     AnthropicClient, GitHubModelsClient, OpenAiBatchJob, OpenAiClient, ProviderMessage, XaiClient,
 };
@@ -206,6 +214,13 @@ struct ProviderCandidate {
     model: String,
     endpoint: String,
     api_key_env: String,
+    keychain_account: String,
+}
+
+#[derive(Debug, Clone)]
+struct WorkflowRuntime {
+    prompt_profile: PromptProfile,
+    model_selection: ModelSelection,
 }
 
 #[derive(Debug, Clone)]
@@ -412,6 +427,36 @@ fn run_entries_workflow(
     let total_entries = entries.len();
     let mut commits = Vec::new();
     let mut failures = Vec::new();
+    let preferences = load_preferences().unwrap_or_else(|_| Preferences::default());
+    let usage_summary = load_usage_summary(&repo_path).unwrap_or_default();
+    let model_catalog = provider_candidates(config)
+        .iter()
+        .flat_map(|candidate| default_models_for_provider(&candidate.provider))
+        .collect::<Vec<_>>();
+    let available = available_providers(config);
+    let mut model_selection = select_model(
+        config,
+        &preferences,
+        &model_catalog,
+        &usage_summary,
+        &available,
+    );
+    if !preferences.provider_rules.contains_key(&config.provider)
+        && config.model != provider_default_model(&config.provider)
+    {
+        model_selection = ModelSelection {
+            provider: config.provider.clone(),
+            model: config.model.clone(),
+            rule_applied: None,
+            fallback_reason: None,
+        };
+    }
+    let selected_config = selected_workflow_config(config, &model_selection);
+    let runtime = WorkflowRuntime {
+        prompt_profile: selected_prompt_profile(&preferences),
+        model_selection,
+    };
+    let config = &selected_config;
 
     let prepare_workers = select_prepare_workers(entries.len(), prepare_workers_override);
     telemetry.prepare_workers = prepare_workers;
@@ -426,6 +471,7 @@ fn run_entries_workflow(
         &repo_path,
         entries,
         config,
+        &runtime,
         max_attempts,
         prepare_workers,
         progress,
@@ -542,6 +588,22 @@ fn run_entries_workflow(
         &mut telemetry,
         workflow_start,
     )?;
+    let _ = record_usage(
+        &repo_path,
+        &TelemetryRunRecord {
+            provider: config.provider.clone(),
+            model: config.model.clone(),
+            selected_rule: runtime
+                .model_selection
+                .rule_applied
+                .as_ref()
+                .map(|rule| format!("{rule:?}").to_ascii_lowercase()),
+            success: failures.is_empty() && !commits.is_empty(),
+            latency_ms: workflow_start.elapsed().as_secs_f64() * 1000.0,
+            fallback_count: u64::from(runtime.model_selection.fallback_reason.is_some()),
+            request_count: prepared_count as u64,
+        },
+    );
 
     if commits.is_empty() && total_entries <= 1 {
         if let Some(failure) = failures.first() {
@@ -658,6 +720,7 @@ fn commit_message_for_entry(
     repo_path: &Path,
     entry: &StatusEntry,
     config: &kcmt_core::model::WorkflowConfig,
+    runtime: &WorkflowRuntime,
     max_attempts: usize,
 ) -> Result<String> {
     if entry.is_deletion() {
@@ -675,7 +738,7 @@ fn commit_message_for_entry(
             config.max_commit_length,
         ))
     } else if configured_api_key(config).is_some() {
-        invoke_provider_with_fallback(repo_path, entry, config, max_attempts)
+        invoke_provider_with_fallback(repo_path, entry, config, runtime, max_attempts)
     } else if local_synthesis_enabled() {
         Ok(heuristic_commit_message(
             &entry.path,
@@ -777,6 +840,7 @@ fn prepare_messages_for_entries(
     repo_path: &Path,
     entries: Vec<StatusEntry>,
     config: &kcmt_core::model::WorkflowConfig,
+    runtime: &WorkflowRuntime,
     max_attempts: usize,
     prepare_workers: usize,
     progress: WorkflowProgress,
@@ -787,6 +851,7 @@ fn prepare_messages_for_entries(
                 repo_path,
                 entries,
                 config,
+                runtime,
                 &api_key,
                 max_attempts,
                 progress,
@@ -800,7 +865,7 @@ fn prepare_messages_for_entries(
             .map(|entry| {
                 progress.queued("diff", &entry.path);
                 progress.event("llm", &entry.path);
-                match commit_message_for_entry(repo_path, &entry, config, max_attempts) {
+                match commit_message_for_entry(repo_path, &entry, config, runtime, max_attempts) {
                     Ok(message) => {
                         progress.completed(&entry.path);
                         Ok(PreparedEntry { entry, message })
@@ -823,6 +888,7 @@ fn prepare_messages_for_entries(
         repo_path,
         entries,
         config,
+        runtime,
         max_attempts,
         prepare_workers,
         progress.clone(),
@@ -838,6 +904,7 @@ fn prepare_messages_in_workers(
     repo_path: &Path,
     entries: Vec<StatusEntry>,
     config: &kcmt_core::model::WorkflowConfig,
+    runtime: &WorkflowRuntime,
     max_attempts: usize,
     prepare_workers: usize,
     progress: WorkflowProgress,
@@ -854,6 +921,7 @@ fn prepare_messages_in_workers(
         .map(|bucket| {
             let repo_path = repo_path.to_path_buf();
             let config = config.clone();
+            let runtime = runtime.clone();
             let progress = progress.clone();
             thread::spawn(move || {
                 bucket
@@ -865,6 +933,7 @@ fn prepare_messages_in_workers(
                             &repo_path,
                             &entry,
                             &config,
+                            &runtime,
                             max_attempts,
                         ) {
                             Ok(message) => {
@@ -904,10 +973,41 @@ fn commit_message_system_prompt(max_commit_length: usize) -> String {
     )
 }
 
+fn provider_default_model(provider: &str) -> &'static str {
+    match provider {
+        "anthropic" => "claude-3-5-haiku-latest",
+        "xai" => "grok-code-fast",
+        "github" => "openai/gpt-4.1-mini",
+        _ => "gpt-5-mini-2025-08-07",
+    }
+}
+
+fn system_prompt_for_runtime(
+    runtime_context: &WorkflowRuntime,
+    max_commit_length: usize,
+) -> String {
+    if runtime_context.prompt_profile.id == "conventional"
+        || runtime_context
+            .prompt_profile
+            .system_instruction
+            .trim()
+            .is_empty()
+    {
+        commit_message_system_prompt(max_commit_length)
+    } else {
+        format!(
+            "{}\n{}",
+            commit_message_system_prompt(max_commit_length),
+            runtime_context.prompt_profile.system_instruction
+        )
+    }
+}
+
 fn prepare_provider_batch_messages(
     repo_path: &Path,
     entries: Vec<StatusEntry>,
     config: &kcmt_core::model::WorkflowConfig,
+    runtime_context: &WorkflowRuntime,
     api_key: &str,
     max_attempts: usize,
     progress: WorkflowProgress,
@@ -916,7 +1016,7 @@ fn prepare_provider_batch_messages(
     let mut batch_entries = Vec::new();
     let mut jobs = Vec::new();
     let mut telemetry = PreparationTelemetry::default();
-    let system = commit_message_system_prompt(config.max_commit_length);
+    let system = system_prompt_for_runtime(runtime_context, config.max_commit_length);
     for entry in entries {
         if entry.is_deletion() {
             let message = deletion_commit_message(&entry.path, config.max_commit_length);
@@ -942,7 +1042,7 @@ fn prepare_provider_batch_messages(
         telemetry.diff_preparation_items += 1;
         let enqueue_start = Instant::now();
         let context = format!("File: {}", entry.path);
-        let prompt = build_prompt(&diff, &context, "conventional");
+        let prompt = build_prompt_with_profile(&diff, &context, &runtime_context.prompt_profile);
         jobs.push(OpenAiBatchJob {
             custom_id: entry.path.clone(),
             messages: vec![
@@ -1124,10 +1224,18 @@ fn prepare_provider_batch_messages(
 }
 
 fn configured_api_key(config: &kcmt_core::model::WorkflowConfig) -> Option<String> {
-    env::var(&config.api_key_env)
-        .ok()
-        .map(|value| value.trim().to_string())
-        .filter(|value| !value.is_empty())
+    let candidate = ProviderCandidate {
+        provider: config.provider.clone(),
+        model: config.model.clone(),
+        endpoint: config.llm_endpoint.clone(),
+        api_key_env: config.api_key_env.clone(),
+        keychain_account: config
+            .providers
+            .get(&config.provider)
+            .and_then(|entry| entry.keychain_account.clone())
+            .unwrap_or_else(|| default_keychain_account(&config.provider)),
+    };
+    credential_for_candidate(&candidate).map(|credential| credential.0)
 }
 
 fn provider_candidates(config: &kcmt_core::model::WorkflowConfig) -> Vec<ProviderCandidate> {
@@ -1137,6 +1245,11 @@ fn provider_candidates(config: &kcmt_core::model::WorkflowConfig) -> Vec<Provide
         model: config.model.clone(),
         endpoint: config.llm_endpoint.clone(),
         api_key_env: config.api_key_env.clone(),
+        keychain_account: config
+            .providers
+            .get(&config.provider)
+            .and_then(|entry| entry.keychain_account.clone())
+            .unwrap_or_else(|| default_keychain_account(&config.provider)),
     });
     for preference in config.model_priority.iter().skip(1) {
         if preference.provider.trim().is_empty() || preference.model.trim().is_empty() {
@@ -1149,11 +1262,15 @@ fn provider_candidates(config: &kcmt_core::model::WorkflowConfig) -> Vec<Provide
         let api_key_env = entry
             .and_then(|entry| entry.api_key_env.clone())
             .unwrap_or_else(|| default_provider_api_key_env(&preference.provider).to_string());
+        let keychain_account = entry
+            .and_then(|entry| entry.keychain_account.clone())
+            .unwrap_or_else(|| default_keychain_account(&preference.provider));
         candidates.push(ProviderCandidate {
             provider: preference.provider.clone(),
             model: preference.model.clone(),
             endpoint,
             api_key_env,
+            keychain_account,
         });
     }
     let mut seen = std::collections::BTreeSet::new();
@@ -1186,22 +1303,60 @@ fn default_provider_api_key_env(provider: &str) -> &'static str {
     }
 }
 
-fn api_key_for_env(api_key_env: &str) -> Option<String> {
-    env::var(api_key_env)
+fn credential_for_candidate(candidate: &ProviderCandidate) -> Option<(String, CredentialSource)> {
+    let explicit_provider = env::var("KCMT_EXPLICIT_API_KEY_PROVIDER").ok();
+    let explicit_secret = if explicit_provider.as_deref() == Some(candidate.provider.as_str()) {
+        env::var("KCMT_EXPLICIT_API_KEY").ok()
+    } else {
+        None
+    };
+    let request = CredentialRequest {
+        provider: candidate.provider.clone(),
+        explicit_secret,
+        keychain_account: Some(candidate.keychain_account.clone()),
+        env_var: candidate.api_key_env.clone(),
+    };
+    resolve_credential(&request, &OsKeychainStore)
         .ok()
-        .map(|value| value.trim().to_string())
-        .filter(|value| !value.is_empty())
+        .flatten()
+        .map(|credential| (credential.secret, credential.source))
+}
+
+fn available_providers(config: &kcmt_core::model::WorkflowConfig) -> Vec<String> {
+    provider_candidates(config)
+        .into_iter()
+        .filter(|candidate| credential_for_candidate(candidate).is_some())
+        .map(|candidate| candidate.provider)
+        .collect()
+}
+
+fn selected_workflow_config(
+    config: &kcmt_core::model::WorkflowConfig,
+    selection: &ModelSelection,
+) -> kcmt_core::model::WorkflowConfig {
+    let mut selected = config.clone();
+    selected.provider = selection.provider.clone();
+    selected.model = selection.model.clone();
+    if let Some(candidate) = provider_candidates(config)
+        .into_iter()
+        .find(|candidate| candidate.provider == selection.provider)
+    {
+        selected.llm_endpoint = candidate.endpoint;
+        selected.api_key_env = candidate.api_key_env;
+    }
+    selected
 }
 
 fn invoke_provider_with_fallback(
     repo_path: &Path,
     entry: &StatusEntry,
     config: &kcmt_core::model::WorkflowConfig,
+    runtime_context: &WorkflowRuntime,
     max_attempts: usize,
 ) -> Result<String> {
     let mut last_error = None;
     for candidate in provider_candidates(config) {
-        let Some(api_key) = api_key_for_env(&candidate.api_key_env) else {
+        let Some((api_key, _source)) = credential_for_candidate(&candidate) else {
             continue;
         };
         match invoke_provider_candidate(
@@ -1209,6 +1364,7 @@ fn invoke_provider_with_fallback(
             entry,
             &candidate,
             &api_key,
+            runtime_context,
             max_attempts,
             config.max_commit_length,
         )
@@ -1231,13 +1387,14 @@ fn invoke_provider_candidate(
     entry: &StatusEntry,
     candidate: &ProviderCandidate,
     api_key: &str,
+    runtime_context: &WorkflowRuntime,
     max_attempts: usize,
     max_commit_length: usize,
 ) -> Result<String> {
     let diff = diff_for_entry(repo_path, entry)?;
     let context = format!("File: {}", entry.path);
-    let prompt = build_prompt(&diff, &context, "conventional");
-    let system = commit_message_system_prompt(max_commit_length);
+    let prompt = build_prompt_with_profile(&diff, &context, &runtime_context.prompt_profile);
+    let system = system_prompt_for_runtime(runtime_context, max_commit_length);
     let runtime = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()

--- a/rust/crates/kcmt-cli/src/lib.rs
+++ b/rust/crates/kcmt-cli/src/lib.rs
@@ -4,11 +4,13 @@ pub mod args;
 pub mod commands;
 
 use clap::Parser;
+use std::io::{self, Read};
 use std::path::PathBuf;
 use std::time::Instant;
 
 use kcmt_core::config::loader::ConfigOverrides;
 use kcmt_core::git::repo::find_git_repo_root;
+use kcmt_core::preferences::{default_keychain_account, OsKeychainStore, SecretStore};
 
 use args::{CliArgs, CliCommand, StatusArgs};
 use commands::workflow::WorkflowOutputOptions;
@@ -35,6 +37,7 @@ fn config_overrides(args: &CliArgs, repo_path: PathBuf) -> ConfigOverrides {
         model: args.model.clone(),
         endpoint: args.endpoint.clone(),
         api_key_env: args.api_key_env.clone(),
+        keychain_account: None,
         repo_path: Some(repo_path),
         max_commit_length: args.max_commit_length,
         auto_push: args.auto_push_override(),
@@ -66,6 +69,22 @@ fn dispatch(_entrypoint: &str, args: CliArgs, arg_parse_ms: f64) -> i32 {
     {
         std::env::set_var("GITHUB_TOKEN", token);
     }
+    let stdin_api_key = if args.api_key_stdin {
+        read_secret_from_stdin()
+    } else {
+        None
+    };
+    let explicit_api_key = args
+        .api_key
+        .as_ref()
+        .filter(|token| !token.trim().is_empty())
+        .cloned()
+        .or(stdin_api_key);
+    if let Some(api_key) = explicit_api_key.as_ref() {
+        std::env::set_var("KCMT_EXPLICIT_API_KEY", api_key);
+        let provider = args.provider.as_deref().unwrap_or("openai");
+        std::env::set_var("KCMT_EXPLICIT_API_KEY_PROVIDER", provider);
+    }
 
     if args.list_models {
         return commands::configure::run_list_models(args.debug);
@@ -79,7 +98,41 @@ fn dispatch(_entrypoint: &str, args: CliArgs, arg_parse_ms: f64) -> i32 {
     let repo_path = repo_discovery.repo_path.clone();
 
     if args.configure || args.configure_all {
+        if args.save_api_key {
+            let Some(api_key) = explicit_api_key
+                .as_deref()
+                .filter(|value| !value.trim().is_empty())
+            else {
+                eprintln!("--save-api-key requires --api-key or --api-key-stdin");
+                return 1;
+            };
+            let provider = args.provider.as_deref().unwrap_or("openai");
+            let account = default_keychain_account(provider);
+            if let Err(err) = OsKeychainStore.set_secret(&account, api_key) {
+                eprintln!("failed to save API key to OS keychain: {err}");
+                return 1;
+            }
+            println!("Saved {provider} credentials to OS keychain account {account}");
+        }
         let overrides = config_overrides(&args, repo_path.clone());
+        if args.tui && kcmt_tui::should_enable_tui(false) {
+            let state = kcmt_tui::ConfigureTuiState {
+                provider: args
+                    .provider
+                    .clone()
+                    .unwrap_or_else(|| "auto/default".to_string()),
+                model: args
+                    .model
+                    .clone()
+                    .unwrap_or_else(|| "auto/default".to_string()),
+                rule: "provider presets enabled".to_string(),
+                credential_status: "keychain first, environment fallback".to_string(),
+            };
+            if let Err(err) = kcmt_tui::run_configure_tui(state) {
+                eprintln!("{err}");
+                return 1;
+            }
+        }
         return commands::configure::run_configure(repo_path, overrides);
     }
 
@@ -100,6 +153,7 @@ fn dispatch(_entrypoint: &str, args: CliArgs, arg_parse_ms: f64) -> i32 {
                 }
             }
         }
+        Some(CliCommand::Stats(stats)) => commands::stats::render_stats_command(repo_path, stats),
         Some(CliCommand::Benchmark(benchmark)) => {
             commands::benchmark::run_benchmark_command(repo_path, benchmark)
         }
@@ -202,6 +256,17 @@ fn dispatch(_entrypoint: &str, args: CliArgs, arg_parse_ms: f64) -> i32 {
                 }
             }
         }
+    }
+}
+
+fn read_secret_from_stdin() -> Option<String> {
+    let mut value = String::new();
+    io::stdin().read_to_string(&mut value).ok()?;
+    let value = value.trim().to_string();
+    if value.is_empty() {
+        None
+    } else {
+        Some(value)
     }
 }
 

--- a/rust/crates/kcmt-cli/tests/configure_contracts.rs
+++ b/rust/crates/kcmt-cli/tests/configure_contracts.rs
@@ -125,9 +125,36 @@ fn list_models_prints_supported_provider_defaults() {
     assert!(stdout.contains("openai"));
     assert!(stdout.contains("gpt-5-mini-2025-08-07"));
     assert!(stdout.contains("anthropic"));
-    assert!(stdout.contains("claude-sonnet-4-20250514"));
+    assert!(stdout.contains("claude-3-5-haiku-latest"));
     assert!(stdout.contains("xai"));
     assert!(stdout.contains("github"));
+}
+
+#[test]
+fn configure_writes_default_preferences_file() {
+    let config_home = unique_temp_dir("home");
+    let repo = unique_temp_dir("repo");
+
+    let output = kcmt_command()
+        .env("KCMT_CONFIG_HOME", &config_home)
+        .args(["--configure", "--repo-path"])
+        .arg(&repo)
+        .output()
+        .expect("kcmt configure should run");
+
+    assert!(
+        output.status.success(),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let preferences_path = config_home.join("preferences.json");
+    let preferences: serde_json::Value =
+        serde_json::from_slice(&fs::read(&preferences_path).expect("preferences file"))
+            .expect("preferences json");
+    assert_eq!(preferences["selection_policy"], "fastest_cheap");
+    assert_eq!(preferences["default_prompt_profile"], "conventional");
+    assert_eq!(preferences["prompt_profiles"][0]["id"], "conventional");
 }
 
 #[test]

--- a/rust/crates/kcmt-cli/tests/configure_contracts.rs
+++ b/rust/crates/kcmt-cli/tests/configure_contracts.rs
@@ -24,6 +24,7 @@ fn kcmt_command() -> Command {
             command.env(key, value);
         }
     }
+    command.env("KCMT_DISABLE_KEYCHAIN", "1");
     command
 }
 

--- a/rust/crates/kcmt-cli/tests/workflow_modes.rs
+++ b/rust/crates/kcmt-cli/tests/workflow_modes.rs
@@ -61,6 +61,7 @@ fn kcmt_command(binary_path: &str) -> Command {
         }
     }
     command.env("KCMT_ALLOW_LOCAL_SYNTHESIS", "1");
+    command.env("KCMT_DISABLE_KEYCHAIN", "1");
     command.env("KCMT_RUNTIME_BENCHMARK", "0");
     command
 }

--- a/rust/crates/kcmt-core/Cargo.toml
+++ b/rust/crates/kcmt-core/Cargo.toml
@@ -12,10 +12,15 @@ path = "src/lib.rs"
 [dependencies]
 anyhow.workspace = true
 gix.workspace = true
-keyring.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 time.workspace = true
 tracing.workspace = true
+
+[target.'cfg(target_os = "macos")'.dependencies]
+keyring = { version = "3.6", features = ["apple-native"] }
+
+[target.'cfg(target_os = "windows")'.dependencies]
+keyring = { version = "3.6", features = ["windows-native"] }

--- a/rust/crates/kcmt-core/Cargo.toml
+++ b/rust/crates/kcmt-core/Cargo.toml
@@ -12,7 +12,10 @@ path = "src/lib.rs"
 [dependencies]
 anyhow.workspace = true
 gix.workspace = true
+keyring.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+sha2.workspace = true
 thiserror.workspace = true
+time.workspace = true
 tracing.workspace = true

--- a/rust/crates/kcmt-core/src/config/loader.rs
+++ b/rust/crates/kcmt-core/src/config/loader.rs
@@ -9,6 +9,7 @@ use crate::config::persisted::load_persisted_config;
 use crate::config::workflow_config::validate_config;
 use crate::error::Result;
 use crate::model::{ModelPreference, ProviderConfigEntry, WorkflowConfig};
+use crate::preferences::default_keychain_account;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ConfigSource {
@@ -35,6 +36,7 @@ pub struct ConfigOverrides {
     pub model: Option<String>,
     pub endpoint: Option<String>,
     pub api_key_env: Option<String>,
+    pub keychain_account: Option<String>,
     pub repo_path: Option<PathBuf>,
     pub max_commit_length: Option<usize>,
     pub auto_push: Option<bool>,
@@ -256,6 +258,7 @@ fn merged_provider_entries(
                 name: None,
                 endpoint: Some(defaults.endpoint.to_string()),
                 api_key_env: Some(defaults.api_key_env.to_string()),
+                keychain_account: Some(default_keychain_account(defaults.provider)),
                 preferred_model: Some(defaults.model.to_string()),
             },
         );
@@ -273,6 +276,9 @@ fn merged_provider_entries(
                     }
                     if entry.api_key_env.is_some() {
                         existing.api_key_env = entry.api_key_env.clone();
+                    }
+                    if entry.keychain_account.is_some() {
+                        existing.keychain_account = entry.keychain_account.clone();
                     }
                     if entry.preferred_model.is_some() {
                         existing.preferred_model = entry.preferred_model.clone();
@@ -530,6 +536,7 @@ mod tests {
             model: Some("grok-code-fast".to_string()),
             endpoint: Some("https://custom.x.ai".to_string()),
             api_key_env: Some("XAI_SECRET".to_string()),
+            keychain_account: None,
             repo_path: Some(repo.join("nested")),
             max_commit_length: Some(80),
             ..ConfigOverrides::default()

--- a/rust/crates/kcmt-core/src/lib.rs
+++ b/rust/crates/kcmt-core/src/lib.rs
@@ -6,6 +6,9 @@ pub mod git;
 pub mod message;
 pub mod metrics;
 pub mod model;
+pub mod preferences;
+pub mod selector;
+pub mod telemetry;
 pub mod workflow;
 
 /// Returns the workspace package name for smoke checks.

--- a/rust/crates/kcmt-core/src/message.rs
+++ b/rust/crates/kcmt-core/src/message.rs
@@ -1,5 +1,7 @@
 //! Provider prompt and commit-message post-processing.
 
+use crate::preferences::{Preferences, PromptProfile};
+
 const CONVENTIONAL_TYPES: &[&str] = &[
     "feat", "fix", "docs", "style", "refactor", "test", "chore", "perf", "ci", "build", "revert",
 ];
@@ -34,6 +36,26 @@ pub fn build_prompt(diff: &str, context: &str, style: &str) -> String {
     parts.push(String::new());
     parts.push("Analyze the changes carefully and be specific.".to_string());
     parts.join("\n")
+}
+
+pub fn selected_prompt_profile(preferences: &Preferences) -> PromptProfile {
+    preferences
+        .prompt_profiles
+        .iter()
+        .find(|profile| profile.id == preferences.default_prompt_profile)
+        .cloned()
+        .or_else(|| preferences.prompt_profiles.first().cloned())
+        .unwrap_or_else(PromptProfile::default_commit)
+}
+
+pub fn build_prompt_with_profile(diff: &str, context: &str, profile: &PromptProfile) -> String {
+    let mut prompt = build_prompt(diff, context, "conventional");
+    let instruction = profile.user_instruction.trim();
+    if !instruction.is_empty() {
+        prompt.push_str("\n\nUSER PREFERENCES:\n");
+        prompt.push_str(instruction);
+    }
+    prompt
 }
 
 pub fn sanitize_commit_output(raw: &str) -> Result<String, String> {
@@ -138,7 +160,11 @@ fn is_wrapped(value: &str, delimiter: char) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{build_prompt, sanitize_commit_output, validate_conventional_commit};
+    use super::{
+        build_prompt, build_prompt_with_profile, sanitize_commit_output,
+        validate_conventional_commit,
+    };
+    use crate::preferences::PromptProfile;
 
     #[test]
     fn build_prompt_matches_python_conventional_shape() {
@@ -163,6 +189,21 @@ mod tests {
         .expect("wrapped provider output should sanitize");
 
         assert_eq!(sanitized, "fix(core): handle retries\n\nExplains the fix.");
+    }
+
+    #[test]
+    fn build_prompt_with_profile_appends_user_instruction() {
+        let profile = PromptProfile {
+            id: "team".to_string(),
+            name: "Team".to_string(),
+            system_instruction: "system".to_string(),
+            user_instruction: "Prefer repo-specific scopes.".to_string(),
+        };
+
+        let prompt = build_prompt_with_profile("diff", "File: app.py", &profile);
+
+        assert!(prompt.contains("STRICT REQUIREMENTS"));
+        assert!(prompt.contains("USER PREFERENCES:\nPrefer repo-specific scopes."));
     }
 
     #[test]

--- a/rust/crates/kcmt-core/src/model.rs
+++ b/rust/crates/kcmt-core/src/model.rs
@@ -27,6 +27,7 @@ pub struct ProviderConfigEntry {
     pub name: Option<String>,
     pub endpoint: Option<String>,
     pub api_key_env: Option<String>,
+    pub keychain_account: Option<String>,
     pub preferred_model: Option<String>,
 }
 

--- a/rust/crates/kcmt-core/src/preferences.rs
+++ b/rust/crates/kcmt-core/src/preferences.rs
@@ -1,0 +1,350 @@
+//! User preferences and credential resolution.
+
+use std::collections::BTreeMap;
+use std::env;
+use std::fs;
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+use crate::config::loader::config_home;
+use crate::error::{KcmtError, Result};
+
+pub const PREFERENCES_SCHEMA_VERSION: u32 = 1;
+pub const KEYCHAIN_SERVICE: &str = "kcmt";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct Preferences {
+    pub schema_version: u32,
+    pub selection_policy: SelectionPolicy,
+    pub provider_rules: BTreeMap<String, ProviderRule>,
+    pub prompt_profiles: Vec<PromptProfile>,
+    pub default_prompt_profile: String,
+    pub tui: TuiPreferences,
+    pub model_cache: ModelCachePreferences,
+}
+
+impl Default for Preferences {
+    fn default() -> Self {
+        let default_profile = PromptProfile::default_commit();
+        Self {
+            schema_version: PREFERENCES_SCHEMA_VERSION,
+            selection_policy: SelectionPolicy::FastestCheap,
+            provider_rules: BTreeMap::new(),
+            default_prompt_profile: default_profile.id.clone(),
+            prompt_profiles: vec![default_profile],
+            tui: TuiPreferences::default(),
+            model_cache: ModelCachePreferences::default(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum SelectionPolicy {
+    FastestCheap,
+    Balanced,
+    BestQuality,
+}
+
+impl Default for SelectionPolicy {
+    fn default() -> Self {
+        Self::FastestCheap
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct ProviderRule {
+    pub preset: ProviderRulePreset,
+    pub value: Option<String>,
+    pub strict: bool,
+}
+
+impl Default for ProviderRule {
+    fn default() -> Self {
+        Self {
+            preset: ProviderRulePreset::None,
+            value: None,
+            strict: false,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ProviderRulePreset {
+    None,
+    PinExactModel,
+    LatestFamily,
+    LatestHaiku,
+    CheapestCodeModel,
+    FastestCodeModel,
+    ExcludeBeta,
+}
+
+impl Default for ProviderRulePreset {
+    fn default() -> Self {
+        Self::None
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct PromptProfile {
+    pub id: String,
+    pub name: String,
+    pub system_instruction: String,
+    pub user_instruction: String,
+}
+
+impl PromptProfile {
+    pub fn default_commit() -> Self {
+        Self {
+            id: "conventional".to_string(),
+            name: "Conventional Commit".to_string(),
+            system_instruction: "You generate strictly valid Conventional Commit messages."
+                .to_string(),
+            user_instruction:
+                "Analyze the changes carefully and be specific. Only output the commit message."
+                    .to_string(),
+        }
+    }
+}
+
+impl Default for PromptProfile {
+    fn default() -> Self {
+        Self::default_commit()
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct TuiPreferences {
+    pub last_screen: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct ModelCachePreferences {
+    pub ttl_seconds: u64,
+}
+
+impl Default for ModelCachePreferences {
+    fn default() -> Self {
+        Self {
+            ttl_seconds: 86_400,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CredentialRequest {
+    pub provider: String,
+    pub explicit_secret: Option<String>,
+    pub keychain_account: Option<String>,
+    pub env_var: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Credential {
+    pub secret: String,
+    pub source: CredentialSource,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CredentialSource {
+    Explicit,
+    Keychain,
+    Environment,
+}
+
+pub trait SecretStore {
+    fn get_secret(&self, account: &str) -> std::result::Result<Option<String>, String>;
+    fn set_secret(&self, account: &str, secret: &str) -> std::result::Result<(), String>;
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct OsKeychainStore;
+
+impl SecretStore for OsKeychainStore {
+    fn get_secret(&self, account: &str) -> std::result::Result<Option<String>, String> {
+        let entry =
+            keyring::Entry::new(KEYCHAIN_SERVICE, account).map_err(|err| err.to_string())?;
+        match entry.get_password() {
+            Ok(secret) if !secret.trim().is_empty() => Ok(Some(secret)),
+            Ok(_) => Ok(None),
+            Err(keyring::Error::NoEntry) => Ok(None),
+            Err(err) => Err(err.to_string()),
+        }
+    }
+
+    fn set_secret(&self, account: &str, secret: &str) -> std::result::Result<(), String> {
+        let entry =
+            keyring::Entry::new(KEYCHAIN_SERVICE, account).map_err(|err| err.to_string())?;
+        entry.set_password(secret).map_err(|err| err.to_string())
+    }
+}
+
+pub fn preferences_path() -> PathBuf {
+    config_home().join("preferences.json")
+}
+
+pub fn load_preferences() -> Result<Preferences> {
+    let path = preferences_path();
+    if !path.exists() {
+        return Ok(Preferences::default());
+    }
+    let raw = fs::read_to_string(path)?;
+    let mut preferences: Preferences =
+        serde_json::from_str(&raw).map_err(|err| KcmtError::Message(err.to_string()))?;
+    if preferences.prompt_profiles.is_empty() {
+        preferences
+            .prompt_profiles
+            .push(PromptProfile::default_commit());
+    }
+    if preferences.default_prompt_profile.trim().is_empty() {
+        preferences.default_prompt_profile = preferences.prompt_profiles[0].id.clone();
+    }
+    Ok(preferences)
+}
+
+pub fn save_preferences(preferences: &Preferences) -> Result<PathBuf> {
+    let path = preferences_path();
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let rendered = serde_json::to_string_pretty(preferences)
+        .map_err(|err| KcmtError::Message(err.to_string()))?;
+    fs::write(&path, rendered)?;
+    Ok(path)
+}
+
+pub fn resolve_credential(
+    request: &CredentialRequest,
+    store: &dyn SecretStore,
+) -> std::result::Result<Option<Credential>, String> {
+    if let Some(secret) = request
+        .explicit_secret
+        .as_ref()
+        .map(|value| value.trim())
+        .filter(|value| !value.is_empty())
+    {
+        return Ok(Some(Credential {
+            secret: secret.to_string(),
+            source: CredentialSource::Explicit,
+        }));
+    }
+
+    let account = request
+        .keychain_account
+        .clone()
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| default_keychain_account(&request.provider));
+    if let Ok(Some(secret)) = store.get_secret(&account) {
+        return Ok(Some(Credential {
+            secret,
+            source: CredentialSource::Keychain,
+        }));
+    }
+
+    if let Ok(secret) = env::var(&request.env_var) {
+        let secret = secret.trim().to_string();
+        if !secret.is_empty() {
+            return Ok(Some(Credential {
+                secret,
+                source: CredentialSource::Environment,
+            }));
+        }
+    }
+
+    Ok(None)
+}
+
+pub fn default_keychain_account(provider: &str) -> String {
+    format!("provider/{provider}/default")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        resolve_credential, CredentialRequest, CredentialSource, Preferences, SecretStore,
+    };
+    use std::collections::BTreeMap;
+    use std::sync::{Mutex, OnceLock};
+
+    #[derive(Default)]
+    struct FakeStore {
+        secrets: BTreeMap<String, String>,
+    }
+
+    impl SecretStore for FakeStore {
+        fn get_secret(&self, account: &str) -> std::result::Result<Option<String>, String> {
+            Ok(self.secrets.get(account).cloned())
+        }
+
+        fn set_secret(&self, _account: &str, _secret: &str) -> std::result::Result<(), String> {
+            Ok(())
+        }
+    }
+
+    fn env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    #[test]
+    fn default_preferences_include_conventional_prompt() {
+        let preferences = Preferences::default();
+
+        assert_eq!(
+            preferences.selection_policy,
+            super::SelectionPolicy::FastestCheap
+        );
+        assert_eq!(preferences.default_prompt_profile, "conventional");
+        assert_eq!(preferences.prompt_profiles.len(), 1);
+    }
+
+    #[test]
+    fn credential_resolution_prefers_cli_then_keychain_then_env() {
+        let _guard = env_lock().lock().unwrap_or_else(|err| err.into_inner());
+        std::env::set_var("KCMT_TEST_API_KEY", "env-secret");
+        let mut store = FakeStore::default();
+        store.secrets.insert(
+            "provider/openai/default".to_string(),
+            "keychain-secret".to_string(),
+        );
+        let base = CredentialRequest {
+            provider: "openai".to_string(),
+            explicit_secret: None,
+            keychain_account: None,
+            env_var: "KCMT_TEST_API_KEY".to_string(),
+        };
+
+        let from_cli = resolve_credential(
+            &CredentialRequest {
+                explicit_secret: Some("cli-secret".to_string()),
+                ..base.clone()
+            },
+            &store,
+        )
+        .expect("credential")
+        .expect("present");
+        assert_eq!(from_cli.source, CredentialSource::Explicit);
+        assert_eq!(from_cli.secret, "cli-secret");
+
+        let from_keychain = resolve_credential(&base, &store)
+            .expect("credential")
+            .expect("present");
+        assert_eq!(from_keychain.source, CredentialSource::Keychain);
+        assert_eq!(from_keychain.secret, "keychain-secret");
+
+        let from_env = resolve_credential(&base, &FakeStore::default())
+            .expect("credential")
+            .expect("present");
+        assert_eq!(from_env.source, CredentialSource::Environment);
+        assert_eq!(from_env.secret, "env-secret");
+        std::env::remove_var("KCMT_TEST_API_KEY");
+    }
+}

--- a/rust/crates/kcmt-core/src/preferences.rs
+++ b/rust/crates/kcmt-core/src/preferences.rs
@@ -84,6 +84,20 @@ pub enum ProviderRulePreset {
     ExcludeBeta,
 }
 
+impl ProviderRulePreset {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::None => "none",
+            Self::PinExactModel => "pin_exact_model",
+            Self::LatestFamily => "latest_family",
+            Self::LatestHaiku => "latest_haiku",
+            Self::CheapestCodeModel => "cheapest_code_model",
+            Self::FastestCodeModel => "fastest_code_model",
+            Self::ExcludeBeta => "exclude_beta",
+        }
+    }
+}
+
 impl Default for ProviderRulePreset {
     fn default() -> Self {
         Self::None
@@ -168,6 +182,7 @@ pub trait SecretStore {
 #[derive(Debug, Clone, Copy, Default)]
 pub struct OsKeychainStore;
 
+#[cfg(any(target_os = "macos", target_os = "windows"))]
 impl SecretStore for OsKeychainStore {
     fn get_secret(&self, account: &str) -> std::result::Result<Option<String>, String> {
         let entry =
@@ -184,6 +199,17 @@ impl SecretStore for OsKeychainStore {
         let entry =
             keyring::Entry::new(KEYCHAIN_SERVICE, account).map_err(|err| err.to_string())?;
         entry.set_password(secret).map_err(|err| err.to_string())
+    }
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+impl SecretStore for OsKeychainStore {
+    fn get_secret(&self, _account: &str) -> std::result::Result<Option<String>, String> {
+        Ok(None)
+    }
+
+    fn set_secret(&self, _account: &str, _secret: &str) -> std::result::Result<(), String> {
+        Err("OS keychain is not available on this platform".to_string())
     }
 }
 
@@ -237,16 +263,18 @@ pub fn resolve_credential(
         }));
     }
 
-    let account = request
-        .keychain_account
-        .clone()
-        .filter(|value| !value.trim().is_empty())
-        .unwrap_or_else(|| default_keychain_account(&request.provider));
-    if let Ok(Some(secret)) = store.get_secret(&account) {
-        return Ok(Some(Credential {
-            secret,
-            source: CredentialSource::Keychain,
-        }));
+    if !keychain_disabled() {
+        let account = request
+            .keychain_account
+            .clone()
+            .filter(|value| !value.trim().is_empty())
+            .unwrap_or_else(|| default_keychain_account(&request.provider));
+        if let Ok(Some(secret)) = store.get_secret(&account) {
+            return Ok(Some(Credential {
+                secret,
+                source: CredentialSource::Keychain,
+            }));
+        }
     }
 
     if let Ok(secret) = env::var(&request.env_var) {
@@ -260,6 +288,16 @@ pub fn resolve_credential(
     }
 
     Ok(None)
+}
+
+fn keychain_disabled() -> bool {
+    env::var("KCMT_DISABLE_KEYCHAIN")
+        .ok()
+        .map(|value| {
+            let normalized = value.trim().to_ascii_lowercase();
+            matches!(normalized.as_str(), "1" | "true" | "yes" | "on")
+        })
+        .unwrap_or(false)
 }
 
 pub fn default_keychain_account(provider: &str) -> String {
@@ -309,6 +347,7 @@ mod tests {
     #[test]
     fn credential_resolution_prefers_cli_then_keychain_then_env() {
         let _guard = env_lock().lock().unwrap_or_else(|err| err.into_inner());
+        std::env::remove_var("KCMT_DISABLE_KEYCHAIN");
         std::env::set_var("KCMT_TEST_API_KEY", "env-secret");
         let mut store = FakeStore::default();
         store.secrets.insert(
@@ -346,5 +385,32 @@ mod tests {
         assert_eq!(from_env.source, CredentialSource::Environment);
         assert_eq!(from_env.secret, "env-secret");
         std::env::remove_var("KCMT_TEST_API_KEY");
+    }
+
+    #[test]
+    fn credential_resolution_can_disable_keychain_for_hermetic_runs() {
+        let _guard = env_lock().lock().unwrap_or_else(|err| err.into_inner());
+        std::env::set_var("KCMT_DISABLE_KEYCHAIN", "1");
+        std::env::set_var("KCMT_TEST_API_KEY", "env-secret");
+        let mut store = FakeStore::default();
+        store.secrets.insert(
+            "provider/openai/default".to_string(),
+            "keychain-secret".to_string(),
+        );
+        let request = CredentialRequest {
+            provider: "openai".to_string(),
+            explicit_secret: None,
+            keychain_account: None,
+            env_var: "KCMT_TEST_API_KEY".to_string(),
+        };
+
+        let credential = resolve_credential(&request, &store)
+            .expect("credential")
+            .expect("present");
+
+        assert_eq!(credential.source, CredentialSource::Environment);
+        assert_eq!(credential.secret, "env-secret");
+        std::env::remove_var("KCMT_TEST_API_KEY");
+        std::env::remove_var("KCMT_DISABLE_KEYCHAIN");
     }
 }

--- a/rust/crates/kcmt-core/src/selector.rs
+++ b/rust/crates/kcmt-core/src/selector.rs
@@ -1,0 +1,497 @@
+//! Model metadata, provider rules, and selection policy.
+
+use std::cmp::Ordering;
+
+use serde::{Deserialize, Serialize};
+
+use crate::model::WorkflowConfig;
+use crate::preferences::{Preferences, ProviderRule, ProviderRulePreset, SelectionPolicy};
+use crate::telemetry::UsageSummary;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(default)]
+pub struct ModelCandidate {
+    pub provider: String,
+    pub id: String,
+    pub family: Option<String>,
+    pub code_capable: bool,
+    pub beta: bool,
+    pub input_cost_per_million: Option<f64>,
+    pub output_cost_per_million: Option<f64>,
+    pub median_latency_ms: Option<f64>,
+    pub created_at: Option<String>,
+}
+
+impl Default for ModelCandidate {
+    fn default() -> Self {
+        Self {
+            provider: String::new(),
+            id: String::new(),
+            family: None,
+            code_capable: true,
+            beta: false,
+            input_cost_per_million: None,
+            output_cost_per_million: None,
+            median_latency_ms: None,
+            created_at: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ModelSelection {
+    pub provider: String,
+    pub model: String,
+    pub rule_applied: Option<ProviderRulePreset>,
+    pub fallback_reason: Option<String>,
+}
+
+pub fn select_model(
+    config: &WorkflowConfig,
+    preferences: &Preferences,
+    live_models: &[ModelCandidate],
+    telemetry: &UsageSummary,
+    available_providers: &[String],
+) -> ModelSelection {
+    let mut providers = available_providers.to_vec();
+    if providers.is_empty() {
+        providers.push(config.provider.clone());
+    } else if available_providers
+        .iter()
+        .any(|provider| provider == &config.provider)
+        && providers.first() != Some(&config.provider)
+    {
+        providers.insert(0, config.provider.clone());
+    }
+
+    let mut fallback_reason = None;
+    for provider in providers {
+        let provider_models: Vec<ModelCandidate> = live_models
+            .iter()
+            .filter(|model| model.provider == provider)
+            .cloned()
+            .collect();
+        let defaults = default_models_for_provider(&provider);
+        let candidates = if provider_models.is_empty() {
+            defaults
+        } else {
+            provider_models
+        };
+        if candidates.is_empty() {
+            continue;
+        }
+        let rule = preferences.provider_rules.get(&provider);
+        let (filtered, rule_reason) = apply_provider_rule(&provider, &candidates, rule);
+        if let Some(reason) = rule_reason {
+            fallback_reason = Some(reason);
+        }
+        if filtered.is_empty() {
+            if rule.is_some_and(|rule| rule.strict) {
+                continue;
+            }
+            let ranked = rank_candidates(&candidates, &preferences.selection_policy, telemetry);
+            if let Some(selected) = ranked.first() {
+                return ModelSelection {
+                    provider,
+                    model: selected.id.clone(),
+                    rule_applied: rule.map(|rule| rule.preset.clone()),
+                    fallback_reason,
+                };
+            }
+        } else {
+            let ranked = rank_candidates(&filtered, &preferences.selection_policy, telemetry);
+            if let Some(selected) = ranked.first() {
+                return ModelSelection {
+                    provider,
+                    model: selected.id.clone(),
+                    rule_applied: rule.map(|rule| rule.preset.clone()),
+                    fallback_reason,
+                };
+            }
+        }
+    }
+
+    ModelSelection {
+        provider: config.provider.clone(),
+        model: config.model.clone(),
+        rule_applied: None,
+        fallback_reason: Some("no selectable live model; using configured model".to_string()),
+    }
+}
+
+pub fn apply_provider_rule(
+    provider: &str,
+    candidates: &[ModelCandidate],
+    rule: Option<&ProviderRule>,
+) -> (Vec<ModelCandidate>, Option<String>) {
+    let Some(rule) = rule else {
+        return (candidates.to_vec(), None);
+    };
+    let filtered = match rule.preset {
+        ProviderRulePreset::None => candidates.to_vec(),
+        ProviderRulePreset::PinExactModel => rule
+            .value
+            .as_ref()
+            .map(|value| {
+                candidates
+                    .iter()
+                    .filter(|candidate| candidate.id == *value)
+                    .cloned()
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default(),
+        ProviderRulePreset::LatestFamily => {
+            let family = rule.value.as_deref().unwrap_or_default();
+            newest_matching(candidates, |candidate| {
+                candidate
+                    .family
+                    .as_deref()
+                    .is_some_and(|value| value.eq_ignore_ascii_case(family))
+                    || candidate
+                        .id
+                        .to_ascii_lowercase()
+                        .contains(&family.to_ascii_lowercase())
+            })
+        }
+        ProviderRulePreset::LatestHaiku => newest_matching(candidates, |candidate| {
+            candidate.id.to_ascii_lowercase().contains("haiku")
+                || candidate
+                    .family
+                    .as_deref()
+                    .is_some_and(|value| value.eq_ignore_ascii_case("haiku"))
+        }),
+        ProviderRulePreset::CheapestCodeModel => cheapest(candidates),
+        ProviderRulePreset::FastestCodeModel => fastest(candidates),
+        ProviderRulePreset::ExcludeBeta => candidates
+            .iter()
+            .filter(|candidate| {
+                !candidate.beta && !candidate.id.to_ascii_lowercase().contains("beta")
+            })
+            .cloned()
+            .collect(),
+    };
+    let reason = if filtered.is_empty() {
+        Some(format!(
+            "provider rule {:?} matched no models for {provider}",
+            rule.preset
+        ))
+    } else {
+        None
+    };
+    (filtered, reason)
+}
+
+pub fn default_models_for_provider(provider: &str) -> Vec<ModelCandidate> {
+    let id = match provider {
+        "anthropic" => "claude-3-5-haiku-latest",
+        "xai" => "grok-code-fast",
+        "github" => "openai/gpt-4.1-mini",
+        _ => "gpt-5-mini-2025-08-07",
+    };
+    vec![ModelCandidate {
+        provider: provider.to_string(),
+        id: id.to_string(),
+        family: infer_family(id),
+        code_capable: true,
+        beta: id.contains("beta"),
+        input_cost_per_million: None,
+        output_cost_per_million: None,
+        median_latency_ms: None,
+        created_at: None,
+    }]
+}
+
+fn newest_matching(
+    candidates: &[ModelCandidate],
+    predicate: impl Fn(&ModelCandidate) -> bool,
+) -> Vec<ModelCandidate> {
+    let mut matches: Vec<ModelCandidate> = candidates
+        .iter()
+        .filter(|candidate| predicate(candidate))
+        .cloned()
+        .collect();
+    matches.sort_by(|left, right| compare_newest(left, right));
+    matches.into_iter().take(1).collect()
+}
+
+fn cheapest(candidates: &[ModelCandidate]) -> Vec<ModelCandidate> {
+    let mut matches: Vec<ModelCandidate> = candidates
+        .iter()
+        .filter(|candidate| candidate.code_capable)
+        .cloned()
+        .collect();
+    matches.sort_by(|left, right| compare_cost(left, right));
+    matches.into_iter().take(1).collect()
+}
+
+fn fastest(candidates: &[ModelCandidate]) -> Vec<ModelCandidate> {
+    let mut matches: Vec<ModelCandidate> = candidates
+        .iter()
+        .filter(|candidate| candidate.code_capable)
+        .cloned()
+        .collect();
+    matches.sort_by(|left, right| compare_latency(left, right));
+    matches.into_iter().take(1).collect()
+}
+
+fn rank_candidates(
+    candidates: &[ModelCandidate],
+    policy: &SelectionPolicy,
+    telemetry: &UsageSummary,
+) -> Vec<ModelCandidate> {
+    let mut ranked = candidates.to_vec();
+    ranked.sort_by(|left, right| match policy {
+        SelectionPolicy::FastestCheap => compare_fastest_cheap(left, right, telemetry),
+        SelectionPolicy::Balanced => compare_newest(left, right),
+        SelectionPolicy::BestQuality => compare_quality_hint(left, right),
+    });
+    ranked
+}
+
+fn compare_fastest_cheap(
+    left: &ModelCandidate,
+    right: &ModelCandidate,
+    telemetry: &UsageSummary,
+) -> Ordering {
+    compare_latency_with_telemetry(left, right, telemetry)
+        .then_with(|| compare_cost(left, right))
+        .then_with(|| compare_quality_hint(left, right))
+}
+
+fn compare_latency_with_telemetry(
+    left: &ModelCandidate,
+    right: &ModelCandidate,
+    telemetry: &UsageSummary,
+) -> Ordering {
+    let left_latency = telemetry
+        .latency_for(&left.provider, &left.id)
+        .or(left.median_latency_ms)
+        .unwrap_or(f64::MAX);
+    let right_latency = telemetry
+        .latency_for(&right.provider, &right.id)
+        .or(right.median_latency_ms)
+        .unwrap_or(f64::MAX);
+    left_latency
+        .partial_cmp(&right_latency)
+        .unwrap_or(Ordering::Equal)
+}
+
+fn compare_latency(left: &ModelCandidate, right: &ModelCandidate) -> Ordering {
+    left.median_latency_ms
+        .unwrap_or(f64::MAX)
+        .partial_cmp(&right.median_latency_ms.unwrap_or(f64::MAX))
+        .unwrap_or(Ordering::Equal)
+}
+
+fn compare_cost(left: &ModelCandidate, right: &ModelCandidate) -> Ordering {
+    model_cost(left)
+        .partial_cmp(&model_cost(right))
+        .unwrap_or(Ordering::Equal)
+}
+
+fn compare_quality_hint(left: &ModelCandidate, right: &ModelCandidate) -> Ordering {
+    right
+        .code_capable
+        .cmp(&left.code_capable)
+        .then_with(|| left.id.cmp(&right.id))
+}
+
+fn compare_newest(left: &ModelCandidate, right: &ModelCandidate) -> Ordering {
+    right
+        .created_at
+        .cmp(&left.created_at)
+        .then_with(|| right.id.cmp(&left.id))
+}
+
+fn model_cost(model: &ModelCandidate) -> f64 {
+    model.input_cost_per_million.unwrap_or(1_000_000.0)
+        + model.output_cost_per_million.unwrap_or(1_000_000.0)
+}
+
+fn infer_family(model_id: &str) -> Option<String> {
+    let lower = model_id.to_ascii_lowercase();
+    for family in ["haiku", "sonnet", "opus", "gpt", "grok"] {
+        if lower.contains(family) {
+            return Some(family.to_string());
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{apply_provider_rule, select_model, ModelCandidate};
+    use crate::model::WorkflowConfig;
+    use crate::preferences::{Preferences, ProviderRule, ProviderRulePreset};
+    use crate::telemetry::{TelemetryAggregate, UsageSummary};
+
+    fn model(
+        provider: &str,
+        id: &str,
+        latency: f64,
+        cost: f64,
+        created_at: &str,
+    ) -> ModelCandidate {
+        ModelCandidate {
+            provider: provider.to_string(),
+            id: id.to_string(),
+            family: None,
+            code_capable: true,
+            beta: id.contains("beta"),
+            input_cost_per_million: Some(cost),
+            output_cost_per_million: Some(cost),
+            median_latency_ms: Some(latency),
+            created_at: Some(created_at.to_string()),
+        }
+    }
+
+    #[test]
+    fn latest_haiku_rule_selects_newest_haiku() {
+        let candidates = vec![
+            model(
+                "anthropic",
+                "claude-3-haiku-20240101",
+                900.0,
+                1.0,
+                "2024-01-01",
+            ),
+            model(
+                "anthropic",
+                "claude-3-5-haiku-20250601",
+                950.0,
+                1.2,
+                "2025-06-01",
+            ),
+            model(
+                "anthropic",
+                "claude-3-7-sonnet-20250501",
+                800.0,
+                2.0,
+                "2025-05-01",
+            ),
+        ];
+        let rule = ProviderRule {
+            preset: ProviderRulePreset::LatestHaiku,
+            value: None,
+            strict: false,
+        };
+
+        let (selected, reason) = apply_provider_rule("anthropic", &candidates, Some(&rule));
+
+        assert_eq!(reason, None);
+        assert_eq!(selected.len(), 1);
+        assert_eq!(selected[0].id, "claude-3-5-haiku-20250601");
+    }
+
+    #[test]
+    fn fastest_cheap_policy_uses_telemetry_latency_first() {
+        let config = WorkflowConfig {
+            provider: "openai".to_string(),
+            model: "slow".to_string(),
+            ..WorkflowConfig::default()
+        };
+        let preferences = Preferences::default();
+        let models = vec![
+            model("openai", "cheap-slow", 1000.0, 0.1, "2025-01-01"),
+            model("openai", "fast-expensive", 100.0, 10.0, "2025-01-01"),
+        ];
+        let telemetry = UsageSummary {
+            aggregates: vec![TelemetryAggregate {
+                provider: "openai".to_string(),
+                model: "cheap-slow".to_string(),
+                selected_rule: None,
+                runs: 3,
+                successes: 3,
+                failures: 0,
+                avg_latency_ms: 50.0,
+                fallback_count: 0,
+                request_count: 3,
+            }],
+        };
+
+        let selected = select_model(
+            &config,
+            &preferences,
+            &models,
+            &telemetry,
+            &["openai".to_string()],
+        );
+
+        assert_eq!(selected.model, "cheap-slow");
+    }
+
+    #[test]
+    fn non_strict_unmatched_rule_falls_back_with_reason() {
+        let config = WorkflowConfig {
+            provider: "anthropic".to_string(),
+            model: "claude-3-5-haiku-latest".to_string(),
+            ..WorkflowConfig::default()
+        };
+        let mut preferences = Preferences::default();
+        preferences.provider_rules.insert(
+            "anthropic".to_string(),
+            ProviderRule {
+                preset: ProviderRulePreset::PinExactModel,
+                value: Some("missing-model".to_string()),
+                strict: false,
+            },
+        );
+        let models = vec![model(
+            "anthropic",
+            "claude-3-5-haiku-latest",
+            100.0,
+            1.0,
+            "2025-01-01",
+        )];
+
+        let selected = select_model(
+            &config,
+            &preferences,
+            &models,
+            &UsageSummary::default(),
+            &["anthropic".to_string()],
+        );
+
+        assert_eq!(selected.model, "claude-3-5-haiku-latest");
+        assert!(selected
+            .fallback_reason
+            .as_deref()
+            .is_some_and(|reason| reason.contains("matched no models")));
+    }
+
+    #[test]
+    fn strict_unmatched_rule_skips_to_configured_fallback() {
+        let config = WorkflowConfig {
+            provider: "anthropic".to_string(),
+            model: "configured-fallback".to_string(),
+            ..WorkflowConfig::default()
+        };
+        let mut preferences = Preferences::default();
+        preferences.provider_rules.insert(
+            "anthropic".to_string(),
+            ProviderRule {
+                preset: ProviderRulePreset::PinExactModel,
+                value: Some("missing-model".to_string()),
+                strict: true,
+            },
+        );
+        let models = vec![model(
+            "anthropic",
+            "claude-3-5-haiku-latest",
+            100.0,
+            1.0,
+            "2025-01-01",
+        )];
+
+        let selected = select_model(
+            &config,
+            &preferences,
+            &models,
+            &UsageSummary::default(),
+            &["anthropic".to_string()],
+        );
+
+        assert_eq!(selected.model, "configured-fallback");
+        assert!(selected.fallback_reason.is_some());
+    }
+}

--- a/rust/crates/kcmt-core/src/telemetry.rs
+++ b/rust/crates/kcmt-core/src/telemetry.rs
@@ -1,0 +1,203 @@
+//! Local aggregate usage telemetry.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::config::loader::config_home;
+use crate::error::{KcmtError, Result};
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+#[serde(default)]
+pub struct UsageSummary {
+    pub aggregates: Vec<TelemetryAggregate>,
+}
+
+impl UsageSummary {
+    pub fn latency_for(&self, provider: &str, model: &str) -> Option<f64> {
+        self.aggregates
+            .iter()
+            .find(|entry| entry.provider == provider && entry.model == model && entry.runs > 0)
+            .map(|entry| entry.avg_latency_ms)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+#[serde(default)]
+pub struct TelemetryAggregate {
+    pub provider: String,
+    pub model: String,
+    pub selected_rule: Option<String>,
+    pub runs: u64,
+    pub successes: u64,
+    pub failures: u64,
+    pub avg_latency_ms: f64,
+    pub fallback_count: u64,
+    pub request_count: u64,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct TelemetryRunRecord {
+    pub provider: String,
+    pub model: String,
+    pub selected_rule: Option<String>,
+    pub success: bool,
+    pub latency_ms: f64,
+    pub fallback_count: u64,
+    pub request_count: u64,
+}
+
+pub fn usage_summary_path(repo_path: &Path) -> PathBuf {
+    state_dir(repo_path).join("usage_summary.json")
+}
+
+pub fn load_usage_summary(repo_path: &Path) -> Result<UsageSummary> {
+    let path = usage_summary_path(repo_path);
+    if !path.exists() {
+        return Ok(UsageSummary::default());
+    }
+    let raw = fs::read_to_string(path)?;
+    serde_json::from_str(&raw).map_err(|err| KcmtError::Message(err.to_string()))
+}
+
+pub fn record_usage(repo_path: &Path, record: &TelemetryRunRecord) -> Result<PathBuf> {
+    let mut summary = load_usage_summary(repo_path)?;
+    let aggregate = summary.aggregates.iter_mut().find(|entry| {
+        entry.provider == record.provider
+            && entry.model == record.model
+            && entry.selected_rule == record.selected_rule
+    });
+    if let Some(aggregate) = aggregate {
+        let previous_runs = aggregate.runs;
+        aggregate.runs += 1;
+        aggregate.successes += u64::from(record.success);
+        aggregate.failures += u64::from(!record.success);
+        aggregate.avg_latency_ms = ((aggregate.avg_latency_ms * previous_runs as f64)
+            + record.latency_ms)
+            / aggregate.runs as f64;
+        aggregate.fallback_count += record.fallback_count;
+        aggregate.request_count += record.request_count;
+    } else {
+        summary.aggregates.push(TelemetryAggregate {
+            provider: record.provider.clone(),
+            model: record.model.clone(),
+            selected_rule: record.selected_rule.clone(),
+            runs: 1,
+            successes: u64::from(record.success),
+            failures: u64::from(!record.success),
+            avg_latency_ms: record.latency_ms,
+            fallback_count: record.fallback_count,
+            request_count: record.request_count,
+        });
+    }
+    save_usage_summary(repo_path, &summary)
+}
+
+pub fn save_usage_summary(repo_path: &Path, summary: &UsageSummary) -> Result<PathBuf> {
+    let path = usage_summary_path(repo_path);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let rendered =
+        serde_json::to_string_pretty(summary).map_err(|err| KcmtError::Message(err.to_string()))?;
+    fs::write(&path, rendered)?;
+    Ok(path)
+}
+
+fn state_dir(repo_path: &Path) -> PathBuf {
+    config_home().join("repos").join(repo_namespace(repo_path))
+}
+
+fn repo_namespace(repo_path: &Path) -> String {
+    let normalized = if repo_path.is_absolute() {
+        repo_path.to_path_buf()
+    } else {
+        std::env::current_dir()
+            .unwrap_or_else(|_| PathBuf::from("."))
+            .join(repo_path)
+    };
+    let digest = Sha256::digest(normalized.to_string_lossy().as_bytes());
+    let digest_hex = format!("{digest:x}");
+    let safe_tail = normalized
+        .file_name()
+        .and_then(|name| name.to_str())
+        .map(|raw| {
+            raw.chars()
+                .map(|ch| {
+                    if ch.is_ascii_alphanumeric() || matches!(ch, '.' | '_' | '-') {
+                        ch
+                    } else {
+                        '-'
+                    }
+                })
+                .collect::<String>()
+        })
+        .filter(|tail| !tail.is_empty())
+        .unwrap_or_else(|| "repo".to_string());
+    format!("{}-{}", safe_tail, &digest_hex[..8])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{record_usage, TelemetryRunRecord};
+    use std::fs;
+    use std::path::PathBuf;
+    use std::sync::{Mutex, OnceLock};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    fn unique_temp_dir(label: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock should be after unix epoch")
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!("kcmt-telemetry-{label}-{nanos}"));
+        fs::create_dir_all(&path).expect("temp dir should be created");
+        path
+    }
+
+    #[test]
+    fn aggregate_usage_does_not_store_payload_content() {
+        let _guard = env_lock().lock().unwrap_or_else(|err| err.into_inner());
+        let config_home = unique_temp_dir("home");
+        let repo = unique_temp_dir("repo");
+        std::env::set_var("KCMT_CONFIG_HOME", &config_home);
+
+        record_usage(
+            &repo,
+            &TelemetryRunRecord {
+                provider: "anthropic".to_string(),
+                model: "claude-3-5-haiku-latest".to_string(),
+                selected_rule: Some("latest_haiku".to_string()),
+                success: true,
+                latency_ms: 42.0,
+                fallback_count: 0,
+                request_count: 1,
+            },
+        )
+        .expect("record usage");
+
+        let raw = fs::read_to_string(
+            config_home
+                .join("repos")
+                .read_dir()
+                .expect("repos dir")
+                .next()
+                .expect("repo entry")
+                .expect("repo entry")
+                .path()
+                .join("usage_summary.json"),
+        )
+        .expect("summary");
+        assert!(raw.contains("latest_haiku"));
+        assert!(!raw.contains("DIFF:"));
+        assert!(!raw.contains("Generate a conventional commit"));
+        std::env::remove_var("KCMT_CONFIG_HOME");
+    }
+}

--- a/rust/crates/kcmt-provider/src/clients/mod.rs
+++ b/rust/crates/kcmt-provider/src/clients/mod.rs
@@ -71,6 +71,12 @@ pub struct OpenAiBatchOutput {
     pub failures: Vec<OpenAiBatchFailure>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ListedModel {
+    pub id: String,
+    pub created_at: Option<String>,
+}
+
 impl ProviderRequest {
     pub fn header_map(&self) -> Result<HeaderMap> {
         let mut headers = HeaderMap::new();
@@ -118,6 +124,26 @@ impl OpenAiClient {
             .post_json(&request.url, request.header_map()?, &request.payload)
             .await?;
         Self::parse_chat_response(&response).map_err(|err| anyhow!(err))
+    }
+
+    pub fn build_models_request(endpoint: &str, api_key: &str) -> ProviderRequest {
+        build_bearer_models_request(endpoint, api_key)
+    }
+
+    pub fn parse_models_response(payload: &Value) -> Result<Vec<ListedModel>, String> {
+        parse_openai_compatible_models_response(payload)
+    }
+
+    pub async fn list_models(
+        transport: &AsyncTransport,
+        endpoint: &str,
+        api_key: &str,
+    ) -> Result<Vec<ListedModel>> {
+        let request = Self::build_models_request(endpoint, api_key);
+        let response = transport
+            .get_json(&request.url, request.header_map()?)
+            .await?;
+        Self::parse_models_response(&response).map_err(|err| anyhow!(err))
     }
 
     pub fn build_batch_jsonl(model: &str, jobs: &[OpenAiBatchJob]) -> String {
@@ -396,6 +422,34 @@ impl AnthropicClient {
             .await?;
         Self::parse_messages_response(&response).map_err(|err| anyhow!(err))
     }
+
+    pub fn build_models_request(endpoint: &str, api_key: &str) -> ProviderRequest {
+        let mut headers = BTreeMap::new();
+        headers.insert("x-api-key".to_string(), api_key.to_string());
+        headers.insert("anthropic-version".to_string(), "2023-06-01".to_string());
+        headers.insert("content-type".to_string(), "application/json".to_string());
+        ProviderRequest {
+            url: format!("{}/v1/models", trim_anthropic_endpoint(endpoint)),
+            headers,
+            payload: Value::Null,
+        }
+    }
+
+    pub fn parse_models_response(payload: &Value) -> Result<Vec<ListedModel>, String> {
+        parse_openai_compatible_models_response(payload)
+    }
+
+    pub async fn list_models(
+        transport: &AsyncTransport,
+        endpoint: &str,
+        api_key: &str,
+    ) -> Result<Vec<ListedModel>> {
+        let request = Self::build_models_request(endpoint, api_key);
+        let response = transport
+            .get_json(&request.url, request.header_map()?)
+            .await?;
+        Self::parse_models_response(&response).map_err(|err| anyhow!(err))
+    }
 }
 
 #[derive(Debug, Default, Clone, Copy)]
@@ -433,6 +487,26 @@ impl XaiClient {
             .post_json(&request.url, request.header_map()?, &request.payload)
             .await?;
         Self::parse_chat_response(&response).map_err(|err| anyhow!(err))
+    }
+
+    pub fn build_models_request(endpoint: &str, api_key: &str) -> ProviderRequest {
+        build_bearer_models_request(endpoint, api_key)
+    }
+
+    pub fn parse_models_response(payload: &Value) -> Result<Vec<ListedModel>, String> {
+        parse_openai_compatible_models_response(payload)
+    }
+
+    pub async fn list_models(
+        transport: &AsyncTransport,
+        endpoint: &str,
+        api_key: &str,
+    ) -> Result<Vec<ListedModel>> {
+        let request = Self::build_models_request(endpoint, api_key);
+        let response = transport
+            .get_json(&request.url, request.header_map()?)
+            .await?;
+        Self::parse_models_response(&response).map_err(|err| anyhow!(err))
     }
 
     pub fn build_batch_requests_payload(model: &str, jobs: &[OpenAiBatchJob]) -> Value {
@@ -633,6 +707,26 @@ impl GitHubModelsClient {
             .await?;
         Self::parse_chat_response(&response).map_err(|err| anyhow!(err))
     }
+
+    pub fn build_models_request(endpoint: &str, api_key: &str) -> ProviderRequest {
+        build_bearer_models_request(endpoint, api_key)
+    }
+
+    pub fn parse_models_response(payload: &Value) -> Result<Vec<ListedModel>, String> {
+        parse_openai_compatible_models_response(payload)
+    }
+
+    pub async fn list_models(
+        transport: &AsyncTransport,
+        endpoint: &str,
+        api_key: &str,
+    ) -> Result<Vec<ListedModel>> {
+        let request = Self::build_models_request(endpoint, api_key);
+        let response = transport
+            .get_json(&request.url, request.header_map()?)
+            .await?;
+        Self::parse_models_response(&response).map_err(|err| anyhow!(err))
+    }
 }
 
 fn build_openai_compatible_request(
@@ -662,6 +756,17 @@ fn build_openai_compatible_request(
         url: format!("{}/chat/completions", trim_endpoint(endpoint)),
         headers,
         payload,
+    }
+}
+
+fn build_bearer_models_request(endpoint: &str, api_key: &str) -> ProviderRequest {
+    let mut headers = BTreeMap::new();
+    headers.insert("Authorization".to_string(), format!("Bearer {api_key}"));
+    headers.insert("content-type".to_string(), "application/json".to_string());
+    ProviderRequest {
+        url: format!("{}/models", trim_endpoint(endpoint)),
+        headers,
+        payload: Value::Null,
     }
 }
 
@@ -708,6 +813,38 @@ fn parse_openai_compatible_response(payload: &Value) -> Result<String, String> {
             .unwrap_or("unknown");
         format!("provider response missing assistant content (finish_reason={finish_reason})")
     })
+}
+
+fn parse_openai_compatible_models_response(payload: &Value) -> Result<Vec<ListedModel>, String> {
+    let data = payload
+        .get("data")
+        .and_then(Value::as_array)
+        .or_else(|| payload.get("models").and_then(Value::as_array))
+        .ok_or_else(|| "provider models response missing data array".to_string())?;
+    let models = data
+        .iter()
+        .filter_map(|entry| {
+            let id = entry.get("id").and_then(Value::as_str)?;
+            let created_at = entry
+                .get("created_at")
+                .or_else(|| entry.get("created"))
+                .and_then(|value| {
+                    value
+                        .as_str()
+                        .map(ToOwned::to_owned)
+                        .or_else(|| value.as_i64().map(|number| number.to_string()))
+                });
+            Some(ListedModel {
+                id: id.to_string(),
+                created_at,
+            })
+        })
+        .collect::<Vec<_>>();
+    if models.is_empty() {
+        Err("provider models response did not include model ids".to_string())
+    } else {
+        Ok(models)
+    }
 }
 
 fn provider_content_text(value: &Value) -> Option<String> {

--- a/rust/crates/kcmt-tui/Cargo.toml
+++ b/rust/crates/kcmt-tui/Cargo.toml
@@ -11,5 +11,6 @@ path = "src/lib.rs"
 
 [dependencies]
 anyhow.workspace = true
+crossterm = "0.29"
 ratatui = "0.29"
 tracing.workspace = true

--- a/rust/crates/kcmt-tui/src/lib.rs
+++ b/rust/crates/kcmt-tui/src/lib.rs
@@ -42,13 +42,26 @@ pub struct ConfigureTuiState {
 pub fn run_configure_tui(state: ConfigureTuiState) -> anyhow::Result<()> {
     enable_raw_mode()?;
     let mut stdout = io::stdout();
-    execute!(stdout, EnterAlternateScreen)?;
+    if let Err(err) = execute!(stdout, EnterAlternateScreen) {
+        let _ = disable_raw_mode();
+        return Err(err.into());
+    }
     let backend = CrosstermBackend::new(stdout);
-    let mut terminal = Terminal::new(backend)?;
+    let mut terminal = match Terminal::new(backend) {
+        Ok(terminal) => terminal,
+        Err(err) => {
+            let _ = disable_raw_mode();
+            let _ = execute!(io::stdout(), LeaveAlternateScreen);
+            return Err(err.into());
+        }
+    };
     let result = run_loop(&mut terminal, &state);
-    disable_raw_mode()?;
-    execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
-    terminal.show_cursor()?;
+    let raw_mode_result = disable_raw_mode();
+    let screen_result = execute!(terminal.backend_mut(), LeaveAlternateScreen);
+    let cursor_result = terminal.show_cursor();
+    raw_mode_result?;
+    screen_result?;
+    cursor_result?;
     result
 }
 

--- a/rust/crates/kcmt-tui/src/lib.rs
+++ b/rust/crates/kcmt-tui/src/lib.rs
@@ -1,6 +1,18 @@
-//! Optional TUI scaffolding gated behind terminal checks.
+//! Optional Ratatui configure shell gated behind terminal checks.
 
 use std::io::{self, IsTerminal};
+use std::time::Duration;
+
+use crossterm::event::{self, Event, KeyCode};
+use crossterm::execute;
+use crossterm::terminal::{
+    disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen,
+};
+use ratatui::backend::CrosstermBackend;
+use ratatui::layout::{Constraint, Direction, Layout};
+use ratatui::style::{Modifier, Style};
+use ratatui::widgets::{Block, Borders, List, ListItem, Paragraph};
+use ratatui::Terminal;
 
 /// Minimal TUI placeholder used until interactive workflows are implemented.
 pub struct TuiApp;
@@ -17,4 +29,69 @@ pub fn should_enable_tui(explicit_no_tui: bool) -> bool {
         return false;
     }
     io::stdin().is_terminal() && io::stdout().is_terminal()
+}
+
+#[derive(Debug, Clone)]
+pub struct ConfigureTuiState {
+    pub provider: String,
+    pub model: String,
+    pub rule: String,
+    pub credential_status: String,
+}
+
+pub fn run_configure_tui(state: ConfigureTuiState) -> anyhow::Result<()> {
+    enable_raw_mode()?;
+    let mut stdout = io::stdout();
+    execute!(stdout, EnterAlternateScreen)?;
+    let backend = CrosstermBackend::new(stdout);
+    let mut terminal = Terminal::new(backend)?;
+    let result = run_loop(&mut terminal, &state);
+    disable_raw_mode()?;
+    execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
+    terminal.show_cursor()?;
+    result
+}
+
+fn run_loop(
+    terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
+    state: &ConfigureTuiState,
+) -> anyhow::Result<()> {
+    let items = [
+        "Providers and credentials",
+        "Provider model rules",
+        "Models and defaults",
+        "Prompt profiles",
+        "Usage statistics",
+        "Save summary",
+    ];
+    loop {
+        terminal.draw(|frame| {
+            let chunks = Layout::default()
+                .direction(Direction::Vertical)
+                .constraints([Constraint::Length(5), Constraint::Min(8), Constraint::Length(3)])
+                .split(frame.area());
+            let summary = Paragraph::new(format!(
+                "Provider: {}\nModel: {}\nRule: {}\nCredentials: {}",
+                state.provider, state.model, state.rule, state.credential_status
+            ))
+            .block(Block::default().title("kcmt configure").borders(Borders::ALL));
+            frame.render_widget(summary, chunks[0]);
+            let list = List::new(items.iter().map(|item| ListItem::new(*item)).collect::<Vec<_>>())
+                .block(Block::default().title("Menu").borders(Borders::ALL))
+                .style(Style::default())
+                .highlight_style(Style::default().add_modifier(Modifier::BOLD));
+            frame.render_widget(list, chunks[1]);
+            let footer = Paragraph::new("This v1 configure TUI is read-oriented. Press q or Esc to exit; use CLI flags to save until editable TUI forms land.")
+                .block(Block::default().borders(Borders::ALL));
+            frame.render_widget(footer, chunks[2]);
+        })?;
+        if event::poll(Duration::from_millis(250))? {
+            if let Event::Key(key) = event::read()? {
+                if matches!(key.code, KeyCode::Char('q') | KeyCode::Esc) {
+                    break;
+                }
+            }
+        }
+    }
+    Ok(())
 }

--- a/tests/features/rust_workflow_parity.feature
+++ b/tests/features/rust_workflow_parity.feature
@@ -126,6 +126,18 @@ Feature: Rust workflow parity
     Given an empty runtime configuration home
     When the Rust kcmt command configures Anthropic non-interactively
     Then the Rust configuration file contains the Anthropic provider settings
+    And the Rust preferences file contains default selector preferences
+
+  Scenario: Anthropic latest Haiku rule selects the Haiku model
+    Given a git repository with one changed tracked file and Anthropic latest Haiku preferences
+    When the Rust kcmt command commits the file with Anthropic preferences
+    Then the Anthropic provider receives the latest Haiku model
+    And the latest commit uses the Anthropic provider message
+
+  Scenario: Rust stats reports aggregate usage telemetry
+    Given a git repository with one changed tracked file
+    When the Rust kcmt command runs in oneshot mode
+    Then the Rust stats command reports usage telemetry
 
   Scenario: Rust list-models shows supported default models
     Given an empty runtime configuration home

--- a/tests/test_rust_workflow_parity_bdd.py
+++ b/tests/test_rust_workflow_parity_bdd.py
@@ -53,6 +53,7 @@ def _clean_env(config_home: Path) -> dict[str, str]:
     }
     env["KCMT_CONFIG_HOME"] = str(config_home)
     env["KCMT_ALLOW_LOCAL_SYNTHESIS"] = "1"
+    env["KCMT_DISABLE_KEYCHAIN"] = "1"
     return env
 
 

--- a/tests/test_rust_workflow_parity_bdd.py
+++ b/tests/test_rust_workflow_parity_bdd.py
@@ -366,6 +366,70 @@ def git_repository_with_one_changed_tracked_file(tmp_path: Path) -> dict[str, An
 
 
 @given(
+    "a git repository with one changed tracked file and Anthropic latest Haiku preferences",
+    target_fixture="workflow_context",
+)
+def git_repository_with_anthropic_latest_haiku_preferences(
+    tmp_path: Path,
+) -> dict[str, Any]:
+    context = git_repository_with_one_changed_tracked_file(tmp_path)
+    endpoint, handler, server = _start_fallback_provider()
+    config_home = context["config_home"]
+    config_home.mkdir(parents=True, exist_ok=True)
+    (config_home / "config.json").write_text(
+        json.dumps(
+            {
+                "provider": "anthropic",
+                "model": "claude-sonnet-4-20250514",
+                "llm_endpoint": endpoint,
+                "api_key_env": "ANTHROPIC_API_KEY",
+                "git_repo_path": str(context["repo"]),
+                "max_commit_length": 72,
+                "auto_push": False,
+                "use_batch": False,
+                "batch_model": None,
+                "batch_timeout_seconds": 900,
+                "providers": {
+                    "anthropic": {
+                        "endpoint": endpoint,
+                        "api_key_env": "ANTHROPIC_API_KEY",
+                        "preferred_model": "claude-sonnet-4-20250514",
+                    }
+                },
+                "model_priority": [
+                    {"provider": "anthropic", "model": "claude-sonnet-4-20250514"}
+                ],
+            }
+        )
+    )
+    (config_home / "preferences.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "selection_policy": "fastest_cheap",
+                "provider_rules": {
+                    "anthropic": {"preset": "latest_haiku", "strict": False}
+                },
+                "prompt_profiles": [
+                    {
+                        "id": "conventional",
+                        "name": "Conventional Commit",
+                        "system_instruction": "You generate strictly valid Conventional Commit messages.",
+                        "user_instruction": "Only output the commit message.",
+                    }
+                ],
+                "default_prompt_profile": "conventional",
+                "tui": {},
+                "model_cache": {"ttl_seconds": 86400},
+            }
+        )
+    )
+    context["anthropic_handler"] = handler
+    context["anthropic_server"] = server
+    return context
+
+
+@given(
     "a git repository with one changed tracked file and a broken origin",
     target_fixture="workflow_context",
 )
@@ -807,6 +871,27 @@ def rust_kcmt_configures_anthropic_non_interactively(
             "https://anthropic.test",
             "--api-key-env",
             "ANTHROPIC_TEST_KEY",
+            "--no-auto-push",
+            "--repo-path",
+            str(workflow_context["repo"]),
+        ],
+        REPO_ROOT,
+        env=env,
+    )
+    workflow_context["output"] = output
+
+
+@when("the Rust kcmt command commits the file with Anthropic preferences")
+def rust_kcmt_commits_file_with_anthropic_preferences(
+    workflow_context: dict[str, Any],
+) -> None:
+    env = _clean_env(workflow_context["config_home"])
+    env["ANTHROPIC_API_KEY"] = "bdd-anthropic-key"
+    output = _run(
+        [
+            str(_rust_bin("kcmt")),
+            "--file",
+            "tracked.py",
             "--no-auto-push",
             "--repo-path",
             str(workflow_context["repo"]),
@@ -1522,6 +1607,59 @@ def rust_configuration_file_contains_anthropic_provider_settings(
     assert config["providers"]["anthropic"]["api_key_env"] == "ANTHROPIC_TEST_KEY"
 
 
+@then("the Rust preferences file contains default selector preferences")
+def rust_preferences_file_contains_default_selector_preferences(
+    workflow_context: dict[str, Any],
+) -> None:
+    preferences = json.loads(
+        (workflow_context["config_home"] / "preferences.json").read_text()
+    )
+    assert preferences["selection_policy"] == "fastest_cheap"
+    assert preferences["default_prompt_profile"] == "conventional"
+    assert preferences["prompt_profiles"][0]["id"] == "conventional"
+
+
+@then("the Anthropic provider receives the latest Haiku model")
+def anthropic_provider_receives_latest_haiku_model(
+    workflow_context: dict[str, Any],
+) -> None:
+    requests = workflow_context["anthropic_handler"].requests
+    assert requests
+    assert any("claude-3-5-haiku-latest" in body for _method, _path, body in requests)
+
+
+@then("the latest commit uses the Anthropic provider message")
+def latest_commit_uses_anthropic_provider_message(
+    workflow_context: dict[str, Any],
+) -> None:
+    log = _git(workflow_context["repo"], ["log", "-1", "--pretty=%s"])
+    assert log == "fix(fallback): use secondary provider"
+
+
+@then("the Rust stats command reports usage telemetry")
+def rust_stats_command_reports_usage_telemetry(
+    workflow_context: dict[str, Any],
+) -> None:
+    env = _clean_env(workflow_context["config_home"])
+    output = _run(
+        [
+            str(_rust_bin("kcmt")),
+            "stats",
+            "--json",
+            "--repo-path",
+            str(workflow_context["repo"]),
+        ],
+        REPO_ROOT,
+        env=env,
+    )
+    payload = json.loads(output)
+    assert payload["aggregates"]
+    aggregate = payload["aggregates"][0]
+    assert aggregate["runs"] >= 1
+    assert "provider" in aggregate
+    assert "model" in aggregate
+
+
 @then("the model list includes all supported providers")
 def model_list_includes_all_supported_providers(
     workflow_context: dict[str, Any],
@@ -1530,7 +1668,7 @@ def model_list_includes_all_supported_providers(
     assert "openai" in output
     assert "gpt-5-mini-2025-08-07" in output
     assert "anthropic" in output
-    assert "claude-sonnet-4-20250514" in output
+    assert "claude-3-5-haiku-latest" in output
     assert "xai" in output
     assert "github" in output
 


### PR DESCRIPTION
## Summary

Adds the Rust-side model preferences and provider selection foundation for the commit pipeline.

- Adds global Rust preferences for selection policy, provider rules, prompt profiles, TUI defaults, and model cache metadata.
- Adds OS keychain-backed credential resolution with explicit CLI input first, then keychain, then environment fallback.
- Wires provider preset rules, including Anthropic latest Haiku, into the Rust workflow model selector.
- Adds aggregate repo-aware usage telemetry and a `kcmt stats` command.
- Adds live `--list-models` discovery with offline/static fallback.
- Adds an explicit `--tui` configure shell and keeps noninteractive `--configure` non-blocking.

## Conventional Commit Breakdown

| Commit | Type | Scope | Summary |
|---|---|---|---|
| 14812dc | feat | rust | add model preferences selector |

## Release Notes Draft

Rust users can now configure model selection preferences, provider model rules, prompt profiles, keychain-backed credentials, and inspect local aggregate usage telemetry.

## Behaviour Changes

- `kcmt --configure` writes compatible config and default preferences without opening a TUI unless `--tui` is passed.
- Credential resolution now prefers explicit CLI input, then OS keychain, then environment variables.
- Anthropic can be configured through a provider rule to prefer the latest Haiku model.
- `kcmt stats` reports aggregate per-repo usage telemetry without storing prompts, diffs, generated messages, or secrets.

## API / Schema / Contract Changes

- Adds `~/.config/kcmt/preferences.json` for Rust selector, prompt, and TUI preferences.
- Extends provider config entries with optional `keychain_account`.
- Adds CLI flags: `--api-key`, `--api-key-stdin`, `--save-api-key`, `--tui`.
- Adds `kcmt stats [--json]`.

## Testing Evidence

- `cargo check --manifest-path rust/Cargo.toml --workspace`
- `cargo test --manifest-path rust/Cargo.toml --workspace --no-fail-fast` passed: 140 passed, 1 ignored.
- `uv run pytest tests/test_rust_workflow_parity_bdd.py --no-cov -q` passed: 29 passed.
- `make check` passed.

## Coverage Evidence

- `make quality-gates` passed, including coverage.

## Quality Gate Evidence

- `make quality-gates` passed.
- `git diff --check` passed.

## Demo Evidence

Not provided.

## Versioning / SemVer Impact

Minor: adds user-visible Rust configuration and stats capabilities without intentionally breaking existing CLI contracts.

## Risk and Rollback

Risk is concentrated in Rust workflow selection and credential resolution. Roll back by reverting this commit; existing env-var config remains represented in `config.json` and existing CLI flags continue to work.

## Operational Notes

No secrets are written to source-controlled files. API keys saved through the new path are stored in the OS keychain; config files store only references.

## Linked Work

Refs: none

## Reviewer Checklist

- [ ] Confirm credential precedence matches explicit CLI, keychain, environment fallback.
- [ ] Confirm `--configure` remains non-blocking unless `--tui` is set.
- [ ] Confirm Anthropic latest-Haiku rule behavior and fallback semantics.
- [ ] Confirm telemetry remains aggregate and secret-free.

## Adversarial Review Result

Brute subagent review found issues around fallback selection, TUI blocking, command-line secret risk, live model listing, and missing BDD coverage. This PR addresses those findings with credentialed fallback selection, explicit `--tui`, `--api-key-stdin`, live `--list-models`, and added BDD/Rust contract coverage.
