### PR TITLE
fix(rust): align git status diff parity

### DIFF
--- a/rust/crates/kcmt-cli/src/commands/workflow.rs
+++ b/rust/crates/kcmt-cli/src/commands/workflow.rs
@@ -13,8 +13,8 @@ use kcmt_core::config::loader::{load_config, ConfigOverrides};
 use kcmt_core::error::KcmtError;
 use kcmt_core::error::Result;
 use kcmt_core::git::commit_file::{
-    commit_file_with_staging, gix_commit_backend_enabled, recent_commit_hash, CommitStaging,
-    GixCommitSession,
+    commit_file_with_staging, commit_paths_with_staging, gix_commit_backend_enabled,
+    recent_commit_hash, CommitStaging, GixCommitSession,
 };
 use kcmt_core::git::repo::{CliGitRepository, GitRepository};
 use kcmt_core::message::{
@@ -39,15 +39,36 @@ use super::history::snapshot_path;
 struct StatusEntry {
     code: String,
     path: String,
+    source_path: Option<String>,
 }
 
 impl StatusEntry {
+    fn index_status(&self) -> char {
+        self.code.chars().next().unwrap_or(' ')
+    }
+
+    fn worktree_status(&self) -> char {
+        self.code.chars().nth(1).unwrap_or(' ')
+    }
+
     fn is_deletion(&self) -> bool {
         self.code.contains('D')
     }
 
-    fn is_new_file(&self) -> bool {
-        self.code == "??" || self.code.contains('A')
+    fn is_untracked(&self) -> bool {
+        self.code == "??"
+    }
+
+    fn is_rename_or_copy(&self) -> bool {
+        self.code.contains('R') || self.code.contains('C')
+    }
+
+    fn has_staged_changes(&self) -> bool {
+        self.index_status() != ' ' && self.index_status() != '?'
+    }
+
+    fn has_worktree_changes(&self) -> bool {
+        self.worktree_status() != ' ' && self.worktree_status() != '?'
     }
 
     fn commit_staging(&self) -> CommitStaging {
@@ -58,8 +79,20 @@ impl StatusEntry {
         }
     }
 
+    fn commit_pathspecs(&self) -> Vec<&str> {
+        let mut pathspecs = Vec::new();
+        if let Some(source_path) = self.source_path.as_deref() {
+            pathspecs.push(source_path);
+        }
+        pathspecs.push(self.path.as_str());
+        pathspecs
+    }
+
     fn requires_staging_before_commit(&self) -> bool {
-        self.code == "??" || self.code.contains('A') || self.code.contains('U')
+        self.code == "??"
+            || self.code.contains('A')
+            || self.code.contains('U')
+            || self.is_rename_or_copy()
     }
 }
 
@@ -500,7 +533,13 @@ fn run_entries_workflow(
     let mut commit_read_hash_ms = 0.0;
     let mut commit_hash_reads = 0;
     let mut commit_stage_path_invocations = 0;
-    let mut gix_session = if gix_commit_backend_enabled() {
+    let can_use_gix_session = prepared_outcomes.iter().all(|outcome| {
+        outcome
+            .as_ref()
+            .map(|prepared| prepared.entry.source_path.is_none())
+            .unwrap_or(true)
+    });
+    let mut gix_session = if gix_commit_backend_enabled() && can_use_gix_session {
         Some(GixCommitSession::open_with_deferred_index_writes(
             &repo_path,
             total_entries > 1,
@@ -521,11 +560,18 @@ fn run_entries_workflow(
         let staging = entry.commit_staging();
         let commit_outcome = match gix_session.as_mut() {
             Some(session) => session.commit_path(&entry.path, &message, staging),
+            None if entry.source_path.is_some() => {
+                let pathspecs = entry.commit_pathspecs();
+                commit_paths_with_staging(&repo_path, &pathspecs, &message, false, staging)
+            }
             None => commit_file_with_staging(&repo_path, &entry.path, &message, false, staging),
         };
         let commit_outcome = match commit_outcome {
             Ok(outcome) => outcome,
             Err(err) => {
+                if let Some(source_path) = &entry.source_path {
+                    unstage_path(&repo_path, source_path);
+                }
                 unstage_path(&repo_path, &entry.path);
                 failures.push(WorkflowFailure::commit(&entry, err.to_string()));
                 continue;
@@ -633,14 +679,33 @@ fn parse_status_entries(status: &str) -> Vec<StatusEntry> {
                 return None;
             }
             let code = line[0..2].to_string();
-            let path = line[3..].trim().to_string();
+            if code == "!!" {
+                return None;
+            }
+            let (path, source_path) = parse_porcelain_path(&line[3..]);
             if path.is_empty() {
                 None
             } else {
-                Some(StatusEntry { code, path })
+                Some(StatusEntry {
+                    code,
+                    path,
+                    source_path,
+                })
             }
         })
         .collect()
+}
+
+fn parse_porcelain_path(raw_path: &str) -> (String, Option<String>) {
+    let path = raw_path.trim();
+    if let Some((source, destination)) = path.rsplit_once(" -> ") {
+        (
+            destination.trim().to_string(),
+            Some(source.trim().to_string()).filter(|path| !path.is_empty()),
+        )
+    } else {
+        (path.to_string(), None)
+    }
 }
 
 fn render_workflow_output(
@@ -1491,22 +1556,55 @@ fn provider_status_from_error(raw_error: &str) -> Option<u16> {
 }
 
 fn diff_for_entry(repo_path: &Path, entry: &StatusEntry) -> Result<String> {
-    if entry.is_new_file() {
+    if entry.is_untracked() {
         return file_content_diff(repo_path, entry);
     }
 
-    let output = Command::new("git")
-        .current_dir(repo_path)
-        .args(["diff", "--no-color", "--no-ext-diff", "--", &entry.path])
-        .output()?;
-    if output.status.success() {
-        let diff = String::from_utf8_lossy(&output.stdout).to_string();
-        if !diff.trim().is_empty() {
+    if entry.has_staged_changes() && !entry.has_worktree_changes() {
+        if let Some(diff) = git_diff_for_entry(repo_path, entry, &["--cached"])? {
             return Ok(diff);
         }
     }
 
+    if entry.has_staged_changes() && entry.has_worktree_changes() {
+        if let Some(diff) = git_diff_for_entry(repo_path, entry, &["HEAD"])? {
+            return Ok(diff);
+        }
+    }
+
+    if entry.has_worktree_changes() {
+        if let Some(diff) = git_diff_for_entry(repo_path, entry, &[])? {
+            return Ok(diff);
+        }
+    }
+
+    if let Some(diff) = git_diff_for_entry(repo_path, entry, &["HEAD"])? {
+        return Ok(diff);
+    }
+
     file_content_diff(repo_path, entry)
+}
+
+fn git_diff_for_entry(
+    repo_path: &Path,
+    entry: &StatusEntry,
+    extra_args: &[&str],
+) -> Result<Option<String>> {
+    let mut args = vec!["diff", "--no-color", "--no-ext-diff"];
+    args.extend(extra_args);
+    args.extend(["--", entry.path.as_str()]);
+    let output = Command::new("git")
+        .current_dir(repo_path)
+        .args(args)
+        .output()?;
+    if output.status.success() {
+        let diff = String::from_utf8_lossy(&output.stdout).to_string();
+        if !diff.trim().is_empty() {
+            return Ok(Some(diff));
+        }
+    }
+
+    Ok(None)
 }
 
 fn file_content_diff(repo_path: &Path, entry: &StatusEntry) -> Result<String> {
@@ -2085,18 +2183,42 @@ mod tests {
 
     #[test]
     fn parses_porcelain_entries() {
-        let entries = parse_status_entries(" M alpha.py\n?? beta.py\n");
+        let entries = parse_status_entries(" M alpha.py\n?? beta.py\n!! ignored.log\n");
 
         assert_eq!(
             entries,
             vec![
                 StatusEntry {
                     code: " M".to_string(),
-                    path: "alpha.py".to_string()
+                    path: "alpha.py".to_string(),
+                    source_path: None
                 },
                 StatusEntry {
                     code: "??".to_string(),
-                    path: "beta.py".to_string()
+                    path: "beta.py".to_string(),
+                    source_path: None
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn parses_porcelain_rename_and_copy_destinations() {
+        let entries =
+            parse_status_entries("R  old_name.py -> new_name.py\n C template.py -> copied.py\n");
+
+        assert_eq!(
+            entries,
+            vec![
+                StatusEntry {
+                    code: "R ".to_string(),
+                    path: "new_name.py".to_string(),
+                    source_path: Some("old_name.py".to_string())
+                },
+                StatusEntry {
+                    code: " C".to_string(),
+                    path: "copied.py".to_string(),
+                    source_path: Some("template.py".to_string())
                 },
             ]
         );
@@ -2111,6 +2233,7 @@ mod tests {
             let entry = StatusEntry {
                 code: code.to_string(),
                 path: "new.md".to_string(),
+                source_path: None,
             };
             let diff = diff_for_entry(&repo, &entry).expect("new file diff");
 
@@ -2129,6 +2252,7 @@ mod tests {
         let entry = StatusEntry {
             code: " M".to_string(),
             path: "tracked.py".to_string(),
+            source_path: None,
         };
 
         let diff = diff_for_entry(&repo, &entry).expect("tracked diff");
@@ -2139,19 +2263,86 @@ mod tests {
     }
 
     #[test]
+    fn diff_for_staged_only_entry_uses_cached_diff() {
+        let repo = unique_temp_dir("staged-diff");
+        git(&repo, &["init", "-q"]);
+        fs::write(repo.join("tracked.py"), "print('seed')\n").expect("tracked seed");
+        git(&repo, &["add", "tracked.py"]);
+        git(&repo, &["commit", "-m", "chore(repo): seed"]);
+        fs::write(repo.join("tracked.py"), "print('staged')\n").expect("staged change");
+        git(&repo, &["add", "tracked.py"]);
+        let entry = StatusEntry {
+            code: "M ".to_string(),
+            path: "tracked.py".to_string(),
+            source_path: None,
+        };
+
+        let diff = diff_for_entry(&repo, &entry).expect("staged diff");
+
+        assert!(diff.starts_with("diff --git a/tracked.py b/tracked.py"));
+        assert!(diff.contains("-print('seed')"));
+        assert!(diff.contains("+print('staged')"));
+    }
+
+    #[test]
+    fn diff_for_mixed_entry_uses_head_diff() {
+        let repo = unique_temp_dir("mixed-diff");
+        git(&repo, &["init", "-q"]);
+        fs::write(repo.join("tracked.py"), "print('seed')\n").expect("tracked seed");
+        git(&repo, &["add", "tracked.py"]);
+        git(&repo, &["commit", "-m", "chore(repo): seed"]);
+        fs::write(repo.join("tracked.py"), "print('staged')\n").expect("staged change");
+        git(&repo, &["add", "tracked.py"]);
+        fs::write(repo.join("tracked.py"), "print('working')\n").expect("working change");
+        let entry = StatusEntry {
+            code: "MM".to_string(),
+            path: "tracked.py".to_string(),
+            source_path: None,
+        };
+
+        let diff = diff_for_entry(&repo, &entry).expect("mixed diff");
+
+        assert!(diff.starts_with("diff --git a/tracked.py b/tracked.py"));
+        assert!(diff.contains("-print('seed')"));
+        assert!(diff.contains("+print('working')"));
+    }
+
+    #[test]
+    fn diff_for_binary_tracked_entry_uses_git_binary_summary() {
+        let repo = unique_temp_dir("binary-diff");
+        git(&repo, &["init", "-q"]);
+        fs::write(repo.join("image.bin"), [0_u8, 159, 146, 150]).expect("binary seed");
+        git(&repo, &["add", "image.bin"]);
+        git(&repo, &["commit", "-m", "chore(repo): seed"]);
+        fs::write(repo.join("image.bin"), [0_u8, 159, 146, 151]).expect("binary change");
+        let entry = StatusEntry {
+            code: " M".to_string(),
+            path: "image.bin".to_string(),
+            source_path: None,
+        };
+
+        let diff = diff_for_entry(&repo, &entry).expect("binary diff");
+
+        assert!(diff.contains("Binary files"));
+        assert!(diff.contains("image.bin"));
+    }
+
+    #[test]
     fn tracked_statuses_can_commit_directly_without_staging() {
         for code in [" M", " D", "M ", "D ", "MM", "MD", "DM"] {
             let entry = StatusEntry {
                 code: code.to_string(),
                 path: "tracked.py".to_string(),
+                source_path: None,
             };
             assert_eq!(entry.commit_staging(), CommitStaging::DirectPath, "{code}");
         }
 
-        for code in ["??", "A ", "AM", "UU"] {
+        for code in ["??", "A ", "AM", "UU", "R ", " C"] {
             let entry = StatusEntry {
                 code: code.to_string(),
                 path: "new.py".to_string(),
+                source_path: None,
             };
             assert_eq!(entry.commit_staging(), CommitStaging::StagePath, "{code}");
         }

--- a/rust/crates/kcmt-cli/tests/workflow_modes.rs
+++ b/rust/crates/kcmt-cli/tests/workflow_modes.rs
@@ -434,6 +434,77 @@ fn default_mode_commits_all_changed_files_separately() {
 }
 
 #[test]
+fn default_mode_skips_ignored_files_and_expands_untracked_directories() {
+    let repo = init_repo();
+    fs::write(repo.join(".gitignore"), "ignored_dir/\n*.log\n").expect("gitignore");
+    let nested = repo.join("newpkg").join("sub");
+    fs::create_dir_all(&nested).expect("nested dir");
+    fs::write(nested.join("alpha.py"), "print('alpha')\n").expect("alpha file");
+    fs::write(nested.join("beta.py"), "print('beta')\n").expect("beta file");
+    fs::create_dir_all(repo.join("ignored_dir")).expect("ignored dir");
+    fs::write(repo.join("ignored_dir").join("skip.txt"), "skip\n").expect("ignored file");
+    fs::write(repo.join("debug.log"), "skip\n").expect("ignored log");
+
+    let output = kcmt_command(env!("CARGO_BIN_EXE_kcmt"))
+        .args(["--no-auto-push", "--repo-path"])
+        .arg(&repo)
+        .output()
+        .expect("kcmt binary should run");
+
+    assert!(
+        output.status.success(),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("✓ .gitignore"));
+    assert!(stdout.contains("✓ newpkg/sub/alpha.py"));
+    assert!(stdout.contains("✓ newpkg/sub/beta.py"));
+    assert!(!stdout.contains("ignored_dir"));
+    assert!(!stdout.contains("debug.log"));
+
+    let log = git(&repo, &["log", "--pretty=%s"]);
+    assert_eq!(log.lines().count(), 3);
+    assert!(git(&repo, &["status", "--short"]).is_empty());
+}
+
+#[test]
+fn default_mode_commits_rename_source_and_destination_together() {
+    let repo = init_repo();
+    fs::write(repo.join("old_name.py"), "print('seed')\n").expect("old seed");
+    git(&repo, &["add", "old_name.py"]);
+    git(&repo, &["commit", "-m", "chore(repo): seed"]);
+    git(&repo, &["mv", "old_name.py", "new_name.py"]);
+
+    let output = kcmt_command(env!("CARGO_BIN_EXE_kcmt"))
+        .args(["--no-auto-push", "--repo-path"])
+        .arg(&repo)
+        .output()
+        .expect("kcmt binary should run");
+
+    assert!(
+        output.status.success(),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("✓ new_name.py"));
+    assert!(git(&repo, &["status", "--short"]).is_empty());
+    let committed = git(
+        &repo,
+        &["show", "--name-status", "--pretty=format:", "HEAD"],
+    );
+    assert!(
+        committed
+            .lines()
+            .any(|line| line.contains("old_name.py") && line.contains("new_name.py")),
+        "name-status: {committed}"
+    );
+}
+
+#[test]
 fn default_mode_records_prepare_failure_without_blocking_deletion_commit() {
     let repo = init_repo();
     let config_home = unique_temp_dir("config-home");
@@ -1111,6 +1182,89 @@ fn file_mode_invokes_openai_compatible_provider_when_api_key_is_available() {
     );
     let log = git(&repo, &["log", "--pretty=%s", "-1"]);
     assert_eq!(log, "fix(core): use provider message");
+}
+
+#[test]
+fn file_mode_provider_prompt_uses_staged_diff_for_staged_only_change() {
+    let repo = init_repo();
+    let (endpoint, request_rx) = spawn_provider_response(
+        r#"{"choices":[{"message":{"content":"fix(core): commit staged change."}}]}"#,
+    );
+    fs::write(repo.join("tracked.py"), "print('seed')\n").expect("tracked seed");
+    git(&repo, &["add", "tracked.py"]);
+    git(&repo, &["commit", "-m", "chore(repo): seed"]);
+    fs::write(repo.join("tracked.py"), "print('staged')\n").expect("staged change");
+    git(&repo, &["add", "tracked.py"]);
+
+    let output = kcmt_command(env!("CARGO_BIN_EXE_kcmt"))
+        .env("OPENAI_TEST_KEY", "test-key")
+        .args([
+            "--file",
+            "tracked.py",
+            "--provider",
+            "openai",
+            "--endpoint",
+            &endpoint,
+            "--api-key-env",
+            "OPENAI_TEST_KEY",
+            "--model",
+            "gpt-mock",
+            "--no-auto-push",
+            "--repo-path",
+        ])
+        .arg(&repo)
+        .output()
+        .expect("kcmt binary should run");
+
+    assert!(
+        output.status.success(),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let request = request_rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("provider request should be sent");
+    assert!(request.contains("tracked.py"));
+    assert!(request.contains("-print('seed')"));
+    assert!(request.contains("+print('staged')"));
+    assert!(!request.contains("New or changed file: tracked.py"));
+
+    let log = git(&repo, &["log", "--pretty=%s", "-1"]);
+    assert_eq!(log, "fix(core): commit staged change");
+    assert!(git(&repo, &["status", "--short"]).is_empty());
+}
+
+#[test]
+fn file_mode_pathspec_leaves_other_staged_file_uncommitted() {
+    let repo = init_repo();
+    fs::write(repo.join("target.py"), "print('target')\n").expect("target seed");
+    fs::write(repo.join("other.py"), "print('other')\n").expect("other seed");
+    git(&repo, &["add", "target.py", "other.py"]);
+    git(&repo, &["commit", "-m", "chore(repo): seed"]);
+    fs::write(repo.join("target.py"), "print('target changed')\n").expect("target change");
+    fs::write(repo.join("other.py"), "print('other changed')\n").expect("other change");
+    git(&repo, &["add", "other.py"]);
+
+    let output = kcmt_command(env!("CARGO_BIN_EXE_kcmt"))
+        .args(["--file", "target.py", "--no-auto-push", "--repo-path"])
+        .arg(&repo)
+        .output()
+        .expect("kcmt binary should run");
+
+    assert!(
+        output.status.success(),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("✓ target.py"));
+    assert!(!stdout.contains("✓ other.py"));
+    let committed = git(&repo, &["show", "--name-only", "--pretty=format:", "HEAD"]);
+    assert!(committed.lines().any(|line| line == "target.py"));
+    assert!(!committed.lines().any(|line| line == "other.py"));
+    assert_eq!(git(&repo, &["status", "--short"]), "M  other.py");
 }
 
 #[test]

--- a/rust/crates/kcmt-core/src/git/commit_file.rs
+++ b/rust/crates/kcmt-core/src/git/commit_file.rs
@@ -129,6 +129,76 @@ pub fn commit_file_with_staging(
     }
 }
 
+pub fn commit_paths_with_staging(
+    repo_path: &Path,
+    file_paths: &[&str],
+    message: &str,
+    dry_run: bool,
+    staging: CommitStaging,
+) -> Result<CommitFileOutcome> {
+    if dry_run {
+        return Ok(CommitFileOutcome::default());
+    }
+    if file_paths.is_empty() {
+        return Err(KcmtError::Message(
+            "cannot commit without pathspecs".to_string(),
+        ));
+    }
+
+    let (stage_path_ms, stage_path_invoked) = match staging {
+        CommitStaging::StagePath => {
+            let stage_start = Instant::now();
+            for file_path in file_paths {
+                let status = if repo_path.join(file_path).exists() {
+                    Command::new("git")
+                        .current_dir(repo_path)
+                        .args(["add", "-A", "--", file_path])
+                        .status()?
+                } else {
+                    Command::new("git")
+                        .current_dir(repo_path)
+                        .args(["update-index", "--force-remove", "--", file_path])
+                        .status()?
+                };
+                if !status.success() {
+                    return Err(KcmtError::Message(format!(
+                        "failed to stage path for commit: {file_path}"
+                    )));
+                }
+            }
+            let stage_path_ms = stage_start.elapsed().as_secs_f64() * 1000.0;
+            (stage_path_ms, true)
+        }
+        CommitStaging::DirectPath => (0.0, false),
+    };
+
+    let commit_start = Instant::now();
+    let mut commit = Command::new("git");
+    commit
+        .current_dir(repo_path)
+        .envs(commit_env())
+        .args(["commit", "-m", message, "--"]);
+    for file_path in file_paths {
+        commit.arg(file_path);
+    }
+    let commit_status = commit.status()?;
+    let create_commit_ms = commit_start.elapsed().as_secs_f64() * 1000.0;
+
+    if commit_status.success() {
+        Ok(CommitFileOutcome {
+            stage_path_ms,
+            stage_path_invoked,
+            create_commit_ms,
+            commit_hash: None,
+        })
+    } else {
+        Err(KcmtError::Message(format!(
+            "git commit failed for pathspecs {}",
+            file_paths.join(", ")
+        )))
+    }
+}
+
 pub struct GixCommitSession {
     repo_path: PathBuf,
     repo: gix::Repository,

--- a/rust/crates/kcmt-core/src/git/repo.rs
+++ b/rust/crates/kcmt-core/src/git/repo.rs
@@ -217,7 +217,7 @@ fn status_porcelain_gix(repo_path: &Path, patterns: Vec<gix::bstr::BString>) -> 
         .map_err(|err| KcmtError::Message(format!("gix status failed: {err}")))?
         .untracked_files(gix::status::UntrackedFiles::Files)
         .index_worktree_submodules(None)
-        .tree_index_track_renames(gix::status::tree_index::TrackRenames::Disabled)
+        .tree_index_track_renames(gix::status::tree_index::TrackRenames::AsConfigured)
         .index_worktree_options_mut(|opts| {
             opts.sorting = Some(
                 gix::status::plumbing::index_as_worktree_with_renames::Sorting::ByPathCaseSensitive,
@@ -260,31 +260,41 @@ fn status_porcelain_gix(repo_path: &Path, patterns: Vec<gix::bstr::BString>) -> 
                         }
                     }
                     Item::Rewrite {
+                        source,
                         dirwalk_entry,
                         copy,
                         ..
                     } => {
                         let status = if copy { " C" } else { " R" };
                         let path = dirwalk_entry.rela_path.as_bstr().to_str_lossy();
-                        rows.push(format!("{status} {path}"));
+                        let source_path = source.rela_path().as_bstr().to_str_lossy();
+                        rows.push(format!("{status} {source_path} -> {path}"));
                     }
                 }
             }
             gix::status::Item::TreeIndex(change) => {
-                let path = change.location().to_str_lossy();
-                let status = match change {
-                    gix::diff::index::Change::Addition { .. } => "A ",
-                    gix::diff::index::Change::Deletion { .. } => "D ",
-                    gix::diff::index::Change::Modification { .. } => "M ",
-                    gix::diff::index::Change::Rewrite { copy, .. } => {
-                        if copy {
-                            "C "
+                let path = change.location().to_str_lossy().to_string();
+                let (status, source_path) = match &change {
+                    gix::diff::index::Change::Addition { .. } => ("A ", None),
+                    gix::diff::index::Change::Deletion { .. } => ("D ", None),
+                    gix::diff::index::Change::Modification { .. } => ("M ", None),
+                    gix::diff::index::Change::Rewrite {
+                        copy,
+                        source_location,
+                        ..
+                    } => {
+                        if *copy {
+                            ("C ", Some(source_location.to_str_lossy().to_string()))
                         } else {
-                            "R "
+                            ("R ", Some(source_location.to_str_lossy().to_string()))
                         }
                     }
                 };
-                rows.push(format!("{status} {path}"));
+                if let Some(source_path) = source_path {
+                    rows.push(format!("{status} {source_path} -> {path}"));
+                } else {
+                    rows.push(format!("{status} {path}"));
+                }
             }
         }
     }
@@ -312,10 +322,9 @@ fn render_porcelain_lines(raw: &str) -> String {
             entry[2..].to_string()
         };
 
-        let is_rename_or_copy = status.contains('R') || status.contains('C');
-        if is_rename_or_copy {
-            if let Some(renamed_path) = entries.next() {
-                path = renamed_path.to_string();
+        if status.contains('R') || status.contains('C') {
+            if let Some(source_path) = entries.next() {
+                path = format!("{source_path} -> {path}");
             }
         }
 
@@ -428,6 +437,34 @@ mod tests {
         let rendered = render_porcelain_lines(raw);
 
         assert_eq!(rendered, "?? src/app.py\n?? src/lib/util.py\n");
+    }
+
+    #[test]
+    fn render_porcelain_lines_keeps_rename_and_copy_destinations() {
+        let raw = "R  new_name.py\0old_name.py\0 C copied.py\0template.py\0";
+
+        let rendered = render_porcelain_lines(raw);
+
+        assert_eq!(
+            rendered,
+            "R  old_name.py -> new_name.py\n C template.py -> copied.py\n"
+        );
+    }
+
+    #[test]
+    fn cli_status_keeps_renamed_destination_path() {
+        let repo = unique_temp_dir("status-rename");
+        init_repo(&repo);
+        fs::write(repo.join("old_name.py"), "print('seed')\n").expect("old seed");
+        git(&repo, &["add", "old_name.py"]);
+        git(&repo, &["commit", "-m", "chore(repo): seed"]);
+        git(&repo, &["mv", "old_name.py", "new_name.py"]);
+
+        let status = CliGitRepository::from_path(&repo)
+            .status_porcelain_cli()
+            .expect("status should render");
+
+        assert_eq!(status, "R  old_name.py -> new_name.py\n");
     }
 
     #[test]

--- a/rust/crates/kcmt-core/src/workflow/changeset.rs
+++ b/rust/crates/kcmt-core/src/workflow/changeset.rs
@@ -13,13 +13,20 @@ pub fn collect_changes(repo: &dyn GitRepository) -> Result<Vec<ChangeSet>> {
             continue;
         }
         let code = &line[0..2];
-        let path = line[3..].trim();
+        if code == "!!" {
+            continue;
+        }
+        let path = parse_porcelain_path(&line[3..]);
         if path.is_empty() {
             continue;
         }
-        let change_type = code.chars().next().unwrap_or('M').to_string();
+        let change_type = code
+            .chars()
+            .find(|status| *status != ' ')
+            .unwrap_or('M')
+            .to_string();
         changes.push(ChangeSet {
-            file_path: path.to_string(),
+            file_path: path,
             change_type,
             diff_content: String::new(),
             staged: code.chars().next().unwrap_or(' ') != ' ',
@@ -28,4 +35,70 @@ pub fn collect_changes(repo: &dyn GitRepository) -> Result<Vec<ChangeSet>> {
     }
 
     Ok(changes)
+}
+
+fn parse_porcelain_path(raw_path: &str) -> String {
+    let path = raw_path.trim();
+    path.rsplit_once(" -> ")
+        .map(|(_, destination)| destination.trim())
+        .unwrap_or(path)
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::collect_changes;
+    use crate::error::Result;
+    use crate::git::repo::GitRepository;
+
+    struct StaticRepo {
+        status: &'static str,
+    }
+
+    impl GitRepository for StaticRepo {
+        fn staged_files(&self) -> Result<Vec<String>> {
+            Ok(Vec::new())
+        }
+
+        fn status_porcelain(&self) -> Result<String> {
+            Ok(self.status.to_string())
+        }
+
+        fn status_porcelain_for_path(&self, _file_path: &str) -> Result<String> {
+            Ok(self.status.to_string())
+        }
+    }
+
+    #[test]
+    fn collect_changes_skips_ignored_rows_and_uses_worktree_status() {
+        let repo = StaticRepo {
+            status: " M tracked.py\n!! ignored.log\n?? new.py\n",
+        };
+
+        let changes = collect_changes(&repo).expect("changes");
+
+        assert_eq!(changes.len(), 2);
+        assert_eq!(changes[0].file_path, "tracked.py");
+        assert_eq!(changes[0].change_type, "M");
+        assert!(!changes[0].staged);
+        assert_eq!(changes[1].file_path, "new.py");
+        assert_eq!(changes[1].change_type, "?");
+    }
+
+    #[test]
+    fn collect_changes_uses_rename_and_copy_destination_paths() {
+        let repo = StaticRepo {
+            status: "R  old.py -> new.py\n C template.py -> copied.py\n",
+        };
+
+        let changes = collect_changes(&repo).expect("changes");
+
+        assert_eq!(changes.len(), 2);
+        assert_eq!(changes[0].file_path, "new.py");
+        assert_eq!(changes[0].change_type, "R");
+        assert!(changes[0].staged);
+        assert_eq!(changes[1].file_path, "copied.py");
+        assert_eq!(changes[1].change_type, "C");
+        assert!(!changes[1].staged);
+    }
 }

--- a/tests/features/rust_workflow_parity.feature
+++ b/tests/features/rust_workflow_parity.feature
@@ -13,6 +13,13 @@ Feature: Rust workflow parity
     Then both changed files are committed separately
     And the repository worktree is clean
 
+  Scenario: Default workflow skips ignored files and expands untracked directories
+    Given a git repository with ignored files and an untracked directory
+    When the Rust kcmt command runs in default workflow mode
+    Then the untracked directory files are committed separately
+    And ignored files are not committed
+    And the repository worktree is clean
+
   Scenario: Worker override is recorded in runtime telemetry
     Given a git repository with two changed tracked files
     When the Rust kcmt command runs in default workflow mode with two workers

--- a/tests/test_rust_workflow_parity_bdd.py
+++ b/tests/test_rust_workflow_parity_bdd.py
@@ -285,6 +285,28 @@ def git_repository_with_two_changed_tracked_files(tmp_path: Path) -> dict[str, A
 
 
 @given(
+    "a git repository with ignored files and an untracked directory",
+    target_fixture="workflow_context",
+)
+def git_repository_with_ignored_files_and_untracked_directory(
+    tmp_path: Path,
+) -> dict[str, Any]:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_repo(repo)
+    (repo / ".gitignore").write_text("ignored_dir/\n*.log\n")
+    nested = repo / "newpkg" / "sub"
+    nested.mkdir(parents=True)
+    (nested / "alpha.py").write_text("print('alpha')\n")
+    (nested / "beta.py").write_text("print('beta')\n")
+    ignored = repo / "ignored_dir"
+    ignored.mkdir()
+    (ignored / "skip.txt").write_text("skip\n")
+    (repo / "debug.log").write_text("skip\n")
+    return {"repo": repo, "config_home": tmp_path / "config-home"}
+
+
+@given(
     "a git repository with two changed tracked files and a mocked OpenAI batch provider",
     target_fixture="workflow_context",
 )
@@ -1136,6 +1158,28 @@ def both_changed_files_are_committed_separately(
     subjects = log.splitlines()
     assert "chore(repo): update alpha" in subjects
     assert "chore(repo): update beta" in subjects
+
+
+@then("the untracked directory files are committed separately")
+def untracked_directory_files_are_committed_separately(
+    workflow_context: dict[str, Any],
+) -> None:
+    output = workflow_context["output"]
+    assert "✓ newpkg/sub/alpha.py" in output
+    assert "✓ newpkg/sub/beta.py" in output
+    log = _git(workflow_context["repo"], ["log", "--name-only", "--pretty=%s"])
+    assert "newpkg/sub/alpha.py" in log
+    assert "newpkg/sub/beta.py" in log
+
+
+@then("ignored files are not committed")
+def ignored_files_are_not_committed(workflow_context: dict[str, Any]) -> None:
+    output = workflow_context["output"]
+    assert "ignored_dir" not in output
+    assert "debug.log" not in output
+    log = _git(workflow_context["repo"], ["log", "--name-only", "--pretty=%s"])
+    assert "ignored_dir/skip.txt" not in log
+    assert "debug.log" not in log
 
 
 @then("the repository worktree is clean")


### PR DESCRIPTION
## Summary

- Align Rust Git status parsing with Git porcelain semantics for ignored rows, untracked directory files, and rename/copy destination paths.
- Select deterministic Rust diff preparation for staged-only, mixed staged/working, working-tree, and binary tracked changes using `git diff --no-color --no-ext-diff`.
- Add Rust unit/integration coverage plus executable BDD for ignored-file skips and untracked directory expansion.
- PR #37 has merged; this branch was rebased onto latest `origin/main` after that merge.

## Conventional Commit Breakdown

| Commit | Type | Scope | Summary |
| --- | --- | --- | --- |
| b90417e | fix | rust | align git status diff parity |

## Release Notes Draft

- Fixed Rust workflow parity for Git status and diff handling across ignored files, expanded untracked directories, rename/copy status rows, staged-only diffs, mixed staged/working diffs, path-scoped commits, and binary diff summaries.

## Behaviour Changes

- Rust status parsing now skips ignored porcelain rows if present and keeps rename/copy destination paths.
- Rust prompt diff preparation now uses cached diffs for staged-only changes, `HEAD` diffs for mixed changes, and deterministic no-color/no-ext-diff path-scoped diffs.
- File mode remains path-scoped when other files are staged.

## API / Schema / Contract Changes

- None. CLI contracts and configuration behavior are preserved.

## Testing Evidence

- `cargo test --manifest-path rust/Cargo.toml -p kcmt-core -- --nocapture`
- `cargo test --manifest-path rust/Cargo.toml -p kcmt-cli --test workflow_modes -- --nocapture`
- `uv run pytest tests/test_rust_workflow_parity_bdd.py -k "Default and workflow and skips" --no-cov -q`
- `make check`
- `make quality-gates`
- `git diff --check`

## Risk and Rollback

- Risk is concentrated in Rust status/diff classification. The fallback path still produces file-content summaries when Git does not return a diff.
- Rollback is a revert of the single commit if unexpected Git-status behavior appears.

## Operational Notes

- No deployment or migration steps required.

## Linked Work

- Builds on the now-merged PR #37 model preferences work.

## Reviewer Checklist

- Confirm rename/copy destination path handling matches desired Rust behavior.
- Confirm staged-only and mixed diff prompt semantics are acceptable for Rust parity.
- Confirm BDD coverage is sufficient for ignored-file and untracked-directory behavior.
