### PR TITLE
feat(rust): align llm prompt output handling

### DIFF
--- a/rust/crates/kcmt-cli/src/commands/workflow.rs
+++ b/rust/crates/kcmt-cli/src/commands/workflow.rs
@@ -18,7 +18,8 @@ use kcmt_core::git::commit_file::{
 };
 use kcmt_core::git::repo::{CliGitRepository, GitRepository};
 use kcmt_core::message::{
-    build_prompt_with_profile, sanitize_commit_output, selected_prompt_profile,
+    build_prompt_with_profile, build_prompt_with_profile_style, sanitize_commit_output,
+    selected_prompt_profile,
 };
 use kcmt_core::preferences::{
     default_keychain_account, load_preferences, resolve_credential, CredentialRequest,
@@ -1367,12 +1368,7 @@ fn invoke_provider_with_fallback(
             runtime_context,
             max_attempts,
             config.max_commit_length,
-        )
-        .and_then(|raw| {
-            sanitize_commit_output(&raw)
-                .map(|message| limit_subject(message, config.max_commit_length))
-                .map_err(KcmtError::Message)
-        }) {
+        ) {
             Ok(message) => return Ok(message),
             Err(err) => last_error = Some(err),
         }
@@ -1393,7 +1389,6 @@ fn invoke_provider_candidate(
 ) -> Result<String> {
     let diff = diff_for_entry(repo_path, entry)?;
     let context = format!("File: {}", entry.path);
-    let prompt = build_prompt_with_profile(&diff, &context, &runtime_context.prompt_profile);
     let system = system_prompt_for_runtime(runtime_context, max_commit_length);
     let runtime = tokio::runtime::Builder::new_current_thread()
         .enable_all()
@@ -1409,16 +1404,65 @@ fn invoke_provider_candidate(
         },
     )
     .map_err(|err| KcmtError::Message(format!("failed to initialize provider transport: {err}")))?;
+    let raw = invoke_provider_candidate_with_style(
+        &runtime,
+        &transport,
+        candidate,
+        api_key,
+        runtime_context,
+        &diff,
+        &context,
+        &system,
+        "conventional",
+    )?;
+    match sanitize_commit_output(&raw) {
+        Ok(message) => Ok(limit_subject(message, max_commit_length)),
+        Err(first_error) => {
+            let retry_raw = invoke_provider_candidate_with_style(
+                &runtime,
+                &transport,
+                candidate,
+                api_key,
+                runtime_context,
+                &diff,
+                &context,
+                &system,
+                "simple",
+            )?;
+            sanitize_commit_output(&retry_raw)
+                .map(|message| limit_subject(message, max_commit_length))
+                .map_err(|retry_error| {
+                    KcmtError::Message(format!(
+                        "{first_error}; simplified prompt retry failed: {retry_error}"
+                    ))
+                })
+        }
+    }
+}
+
+fn invoke_provider_candidate_with_style(
+    runtime: &tokio::runtime::Runtime,
+    transport: &AsyncTransport,
+    candidate: &ProviderCandidate,
+    api_key: &str,
+    runtime_context: &WorkflowRuntime,
+    diff: &str,
+    context: &str,
+    system: &str,
+    style: &str,
+) -> Result<String> {
+    let prompt =
+        build_prompt_with_profile_style(diff, context, style, &runtime_context.prompt_profile);
     runtime
         .block_on(async {
             match candidate.provider.as_str() {
                 "openai" => {
                     let messages = vec![
-                        ProviderMessage::system(system.as_str()),
+                        ProviderMessage::system(system),
                         ProviderMessage::user(prompt),
                     ];
                     OpenAiClient::invoke_chat(
-                        &transport,
+                        transport,
                         &candidate.endpoint,
                         api_key,
                         &candidate.model,
@@ -1428,11 +1472,11 @@ fn invoke_provider_candidate(
                 }
                 "xai" => {
                     let messages = vec![
-                        ProviderMessage::system(system.as_str()),
+                        ProviderMessage::system(system),
                         ProviderMessage::user(prompt),
                     ];
                     XaiClient::invoke_chat(
-                        &transport,
+                        transport,
                         &candidate.endpoint,
                         api_key,
                         &candidate.model,
@@ -1442,11 +1486,11 @@ fn invoke_provider_candidate(
                 }
                 "github" => {
                     let messages = vec![
-                        ProviderMessage::system(system.as_str()),
+                        ProviderMessage::system(system),
                         ProviderMessage::user(prompt),
                     ];
                     GitHubModelsClient::invoke_chat(
-                        &transport,
+                        transport,
                         &candidate.endpoint,
                         api_key,
                         &candidate.model,
@@ -1456,11 +1500,11 @@ fn invoke_provider_candidate(
                 }
                 "anthropic" => {
                     AnthropicClient::invoke_messages(
-                        &transport,
+                        transport,
                         &candidate.endpoint,
                         api_key,
                         &candidate.model,
-                        system.as_str(),
+                        system,
                         &prompt,
                     )
                     .await

--- a/rust/crates/kcmt-cli/tests/workflow_modes.rs
+++ b/rust/crates/kcmt-cli/tests/workflow_modes.rs
@@ -131,6 +131,33 @@ fn spawn_provider_response(response_body: &'static str) -> (String, mpsc::Receiv
     (format!("http://{address}"), receiver)
 }
 
+fn spawn_provider_responses(
+    response_bodies: Vec<&'static str>,
+) -> (String, mpsc::Receiver<String>) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("mock provider listener");
+    let address = listener.local_addr().expect("mock provider address");
+    let (sender, receiver) = mpsc::channel();
+    thread::spawn(move || {
+        for response_body in response_bodies {
+            let (mut stream, _) = listener.accept().expect("mock provider connection");
+            let mut buffer = [0_u8; 32768];
+            let bytes = stream.read(&mut buffer).expect("mock provider read");
+            sender
+                .send(String::from_utf8_lossy(&buffer[..bytes]).to_string())
+                .expect("request should be recorded");
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nconnection: close\r\n\r\n{}",
+                response_body.len(),
+                response_body
+            );
+            stream
+                .write_all(response.as_bytes())
+                .expect("mock provider write");
+        }
+    });
+    (format!("http://{address}"), receiver)
+}
+
 fn spawn_provider_status_response(
     status: u16,
     response_body: &'static str,
@@ -1548,6 +1575,109 @@ fn default_openai_batch_reports_partial_invalid_outputs_without_leaking_keys() {
     let raw_snapshot = serde_json::to_string(&snapshot).expect("snapshot json");
     assert!(!raw_snapshot.contains("test-key"));
     assert!(raw_snapshot.contains("OPENAI_TEST_KEY"));
+}
+
+#[test]
+fn file_mode_summarizes_binary_diff_in_provider_prompt() {
+    let repo = init_repo();
+    let config_home = unique_temp_dir("config-home");
+    let (endpoint, request_rx) = spawn_provider_response(
+        r#"{"choices":[{"message":{"content":"chore(assets): update logo."}}]}"#,
+    );
+    fs::create_dir_all(repo.join("assets")).expect("assets dir");
+    fs::write(repo.join("assets/logo.png"), b"\0PNG seed").expect("binary seed");
+    git(&repo, &["add", "assets/logo.png"]);
+    git(&repo, &["commit", "-m", "chore(assets): seed logo"]);
+    fs::write(repo.join("assets/logo.png"), b"\0PNG changed").expect("binary change");
+
+    let output = kcmt_command(env!("CARGO_BIN_EXE_kcmt"))
+        .env("KCMT_CONFIG_HOME", &config_home)
+        .env("OPENAI_TEST_KEY", "test-key")
+        .args([
+            "--file",
+            "assets/logo.png",
+            "--provider",
+            "openai",
+            "--endpoint",
+            &endpoint,
+            "--api-key-env",
+            "OPENAI_TEST_KEY",
+            "--model",
+            "gpt-direct",
+            "--no-auto-push",
+            "--repo-path",
+        ])
+        .arg(&repo)
+        .output()
+        .expect("kcmt binary should run");
+
+    assert!(
+        output.status.success(),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let request = request_rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("provider request should be recorded");
+    assert!(request.contains("Binary diff detected."));
+    assert!(request.contains("File hint: assets/logo.png"));
+    assert!(request.contains("Git reported:"));
+    let log = git(&repo, &["log", "--pretty=%s", "-1"]);
+    assert_eq!(log, "chore(assets): update logo");
+}
+
+#[test]
+fn file_mode_retries_invalid_output_with_simple_prompt() {
+    let repo = init_repo();
+    let config_home = unique_temp_dir("config-home");
+    let (endpoint, request_rx) = spawn_provider_responses(vec![
+        r#"{"choices":[{"message":{"content":"This changes a few files"}}]}"#,
+        r#"{"choices":[{"message":{"content":"fix(core): retry simplified prompt."}}]}"#,
+    ]);
+    fs::write(repo.join("tracked.py"), "print('seed')\n").expect("tracked seed");
+    git(&repo, &["add", "tracked.py"]);
+    git(&repo, &["commit", "-m", "chore(repo): seed"]);
+    fs::write(repo.join("tracked.py"), "print('changed')\n").expect("tracked change");
+
+    let output = kcmt_command(env!("CARGO_BIN_EXE_kcmt"))
+        .env("KCMT_CONFIG_HOME", &config_home)
+        .env("OPENAI_TEST_KEY", "test-key")
+        .args([
+            "--file",
+            "tracked.py",
+            "--provider",
+            "openai",
+            "--endpoint",
+            &endpoint,
+            "--api-key-env",
+            "OPENAI_TEST_KEY",
+            "--model",
+            "gpt-direct",
+            "--no-auto-push",
+            "--repo-path",
+        ])
+        .arg(&repo)
+        .output()
+        .expect("kcmt binary should run");
+
+    assert!(
+        output.status.success(),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let first_request = request_rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("first provider request should be recorded");
+    let retry_request = request_rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("retry provider request should be recorded");
+    assert!(first_request.contains("STRICT REQUIREMENTS"));
+    assert!(retry_request.contains("Keep it simple but include mandatory scope."));
+    assert!(!retry_request.contains("STRICT REQUIREMENTS"));
+    let log = git(&repo, &["log", "--pretty=%s", "-1"]);
+    assert_eq!(log, "fix(core): retry simplified prompt");
 }
 
 #[test]

--- a/rust/crates/kcmt-cli/tests/workflow_modes.rs
+++ b/rust/crates/kcmt-cli/tests/workflow_modes.rs
@@ -1,5 +1,5 @@
 use std::fs;
-use std::io::{Read, Write};
+use std::io::{ErrorKind, Read, Write};
 use std::net::TcpListener;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -135,11 +135,26 @@ fn spawn_provider_responses(
     response_bodies: Vec<&'static str>,
 ) -> (String, mpsc::Receiver<String>) {
     let listener = TcpListener::bind("127.0.0.1:0").expect("mock provider listener");
+    listener
+        .set_nonblocking(true)
+        .expect("mock provider listener should become nonblocking");
     let address = listener.local_addr().expect("mock provider address");
     let (sender, receiver) = mpsc::channel();
     thread::spawn(move || {
         for response_body in response_bodies {
-            let (mut stream, _) = listener.accept().expect("mock provider connection");
+            let deadline = std::time::Instant::now() + Duration::from_secs(10);
+            let (mut stream, _) = loop {
+                match listener.accept() {
+                    Ok(connection) => break connection,
+                    Err(err) if err.kind() == ErrorKind::WouldBlock => {
+                        if std::time::Instant::now() >= deadline {
+                            return;
+                        }
+                        thread::sleep(Duration::from_millis(10));
+                    }
+                    Err(err) => panic!("mock provider connection failed: {err}"),
+                }
+            };
             let mut buffer = [0_u8; 32768];
             let bytes = stream.read(&mut buffer).expect("mock provider read");
             sender

--- a/rust/crates/kcmt-core/src/message.rs
+++ b/rust/crates/kcmt-core/src/message.rs
@@ -49,13 +49,62 @@ pub fn selected_prompt_profile(preferences: &Preferences) -> PromptProfile {
 }
 
 pub fn build_prompt_with_profile(diff: &str, context: &str, profile: &PromptProfile) -> String {
-    let mut prompt = build_prompt(diff, context, "conventional");
+    build_prompt_with_profile_style(diff, context, "conventional", profile)
+}
+
+pub fn build_prompt_with_profile_style(
+    diff: &str,
+    context: &str,
+    style: &str,
+    profile: &PromptProfile,
+) -> String {
+    let prepared_diff = prepare_diff_for_prompt(diff, context);
+    let mut prompt = build_prompt(&prepared_diff, context, style);
     let instruction = profile.user_instruction.trim();
     if !instruction.is_empty() {
         prompt.push_str("\n\nUSER PREFERENCES:\n");
         prompt.push_str(instruction);
     }
     prompt
+}
+
+pub fn prepare_diff_for_prompt(diff: &str, context: &str) -> String {
+    let file_path_hint = context
+        .split_once("File:")
+        .map(|(_, value)| value.trim())
+        .unwrap_or_default();
+    let mut diff_for_prompt = diff.to_string();
+    let binary_summary = if is_binary_diff(diff) && !looks_like_text_file(file_path_hint) {
+        let snippet = diff.chars().take(400).collect::<String>();
+        Some(format!(
+            "Binary diff detected.\nFile hint: {}\nGit reported: {}",
+            if file_path_hint.is_empty() {
+                "unknown"
+            } else {
+                file_path_hint
+            },
+            if snippet.trim().is_empty() {
+                "<no additional details>"
+            } else {
+                snippet.trim()
+            }
+        ))
+    } else {
+        None
+    };
+
+    if diff_for_prompt.len() > 12_000 {
+        let head = take_chars(&diff_for_prompt, 8_000);
+        let tail = take_last_chars(&diff_for_prompt, 2_000);
+        diff_for_prompt = format!("{head}\n...\n{tail}");
+    }
+
+    let cleaned_diff = clean_diff_for_llm(&diff_for_prompt);
+    if let Some(summary) = binary_summary {
+        format!("{summary}\n\n{cleaned_diff}").trim().to_string()
+    } else {
+        cleaned_diff
+    }
 }
 
 pub fn sanitize_commit_output(raw: &str) -> Result<String, String> {
@@ -150,6 +199,59 @@ fn clean_candidate_header(line: &str) -> String {
     stripped.split_whitespace().collect::<Vec<_>>().join(" ")
 }
 
+fn is_binary_diff(diff: &str) -> bool {
+    diff.lines().any(|line| {
+        (line.starts_with("Binary files") && line.contains(" differ"))
+            || line.contains("GIT binary patch")
+    })
+}
+
+fn looks_like_text_file(file_path: &str) -> bool {
+    if file_path.is_empty() {
+        return false;
+    }
+    const TEXT_EXTENSIONS: &[&str] = &[
+        ".py", ".pyi", ".pyx", ".pxd", ".js", ".ts", ".jsx", ".tsx", ".css", ".scss", ".sass",
+        ".less", ".html", ".htm", ".xml", ".json", ".yaml", ".yml", ".toml", ".ini", ".cfg", ".md",
+        ".rst", ".txt", ".csv", ".tsv", ".java", ".c", ".cpp", ".h", ".hpp", ".go", ".rs", ".rb",
+        ".php", ".sh", ".bash", ".zsh", ".ps1", ".bat", ".cmd", ".gradle", ".make", ".mk",
+        ".cmake",
+    ];
+    let lower = file_path.to_ascii_lowercase();
+    TEXT_EXTENSIONS
+        .iter()
+        .any(|extension| lower.ends_with(extension))
+        || ["/src/", "/lib/", "/app/", "/kcmt/"]
+            .iter()
+            .any(|directory| lower.contains(directory))
+}
+
+fn clean_diff_for_llm(diff: &str) -> String {
+    diff.trim()
+        .lines()
+        .map(|line| {
+            if line.contains("--- /dev/null") {
+                "--- (new file)"
+            } else if line.contains("+++ /dev/null") {
+                "+++ (deleted)"
+            } else {
+                line
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn take_chars(value: &str, count: usize) -> String {
+    value.chars().take(count).collect()
+}
+
+fn take_last_chars(value: &str, count: usize) -> String {
+    let mut tail = value.chars().rev().take(count).collect::<Vec<_>>();
+    tail.reverse();
+    tail.into_iter().collect()
+}
+
 fn is_conventional_type(value: &str) -> bool {
     CONVENTIONAL_TYPES.contains(&value)
 }
@@ -161,7 +263,7 @@ fn is_wrapped(value: &str, delimiter: char) -> bool {
 #[cfg(test)]
 mod tests {
     use super::{
-        build_prompt, build_prompt_with_profile, sanitize_commit_output,
+        build_prompt, build_prompt_with_profile, prepare_diff_for_prompt, sanitize_commit_output,
         validate_conventional_commit,
     };
     use crate::preferences::PromptProfile;
@@ -204,6 +306,37 @@ mod tests {
 
         assert!(prompt.contains("STRICT REQUIREMENTS"));
         assert!(prompt.contains("USER PREFERENCES:\nPrefer repo-specific scopes."));
+    }
+
+    #[test]
+    fn prepare_diff_summarizes_binary_changes_for_prompt() {
+        let prepared = prepare_diff_for_prompt(
+            "Binary files a/assets/logo.png and b/assets/logo.png differ",
+            "File: assets/logo.png",
+        );
+
+        assert!(prepared.contains("Binary diff detected."));
+        assert!(prepared.contains("File hint: assets/logo.png"));
+        assert!(prepared.contains("Git reported: Binary files"));
+    }
+
+    #[test]
+    fn prepare_diff_preserves_text_file_binary_markers() {
+        let diff = "Binary files a/src/generated.py and b/src/generated.py differ";
+        let prepared = prepare_diff_for_prompt(diff, "File: src/generated.py");
+
+        assert!(!prepared.contains("Binary diff detected."));
+        assert_eq!(prepared, diff);
+    }
+
+    #[test]
+    fn prepare_diff_truncates_large_diffs_and_cleans_null_paths() {
+        let large = format!("--- /dev/null\n+++ b/generated.txt\n{}", "x".repeat(13_000));
+        let prepared = prepare_diff_for_prompt(&large, "File: generated.txt");
+
+        assert!(prepared.len() < large.len());
+        assert!(prepared.contains("--- (new file)"));
+        assert!(prepared.contains("\n...\n"));
     }
 
     #[test]

--- a/rust/crates/kcmt-core/src/message.rs
+++ b/rust/crates/kcmt-core/src/message.rs
@@ -221,6 +221,9 @@ fn looks_like_text_file(file_path: &str) -> bool {
     TEXT_EXTENSIONS
         .iter()
         .any(|extension| lower.ends_with(extension))
+        || ["src/", "lib/", "app/", "kcmt/"]
+            .iter()
+            .any(|directory| lower.starts_with(directory))
         || ["/src/", "/lib/", "/app/", "/kcmt/"]
             .iter()
             .any(|directory| lower.contains(directory))
@@ -324,6 +327,15 @@ mod tests {
     fn prepare_diff_preserves_text_file_binary_markers() {
         let diff = "Binary files a/src/generated.py and b/src/generated.py differ";
         let prepared = prepare_diff_for_prompt(diff, "File: src/generated.py");
+
+        assert!(!prepared.contains("Binary diff detected."));
+        assert_eq!(prepared, diff);
+    }
+
+    #[test]
+    fn prepare_diff_treats_extensionless_code_dir_files_as_text() {
+        let diff = "Binary files a/src/tool and b/src/tool differ";
+        let prepared = prepare_diff_for_prompt(diff, "File: src/tool");
 
         assert!(!prepared.contains("Binary diff detected."));
         assert_eq!(prepared, diff);

--- a/tests/features/rust_workflow_parity.feature
+++ b/tests/features/rust_workflow_parity.feature
@@ -47,6 +47,18 @@ Feature: Rust workflow parity
     When the Rust kcmt command commits the file with wrapped provider output
     Then the latest commit uses the sanitized provider message
 
+  Scenario: File workflow summarizes binary diffs for provider prompts
+    Given a git repository with one changed binary file and a mocked OpenAI provider
+    When the Rust kcmt command commits the binary file with the mocked provider
+    Then the mocked provider prompt includes the binary diff summary
+    And the latest commit uses the binary provider message
+
+  Scenario: File workflow retries malformed provider output with a simplified prompt
+    Given a git repository with one changed tracked file and a malformed-then-valid OpenAI provider
+    When the Rust kcmt command commits the file with malformed then valid provider output
+    Then the mocked provider receives a simplified retry prompt
+    And the latest commit uses the simplified retry provider message
+
   Scenario: File workflow rejects invalid provider output
     Given a git repository with one changed tracked file
     When the Rust kcmt command receives invalid provider output

--- a/tests/test_rust_workflow_parity_bdd.py
+++ b/tests/test_rust_workflow_parity_bdd.py
@@ -281,6 +281,11 @@ def _start_direct_provider(
     return f"http://127.0.0.1:{server.server_port}", Handler, server
 
 
+def _stop_server(server: HTTPServer) -> None:
+    server.shutdown()
+    server.server_close()
+
+
 def _rust_bin(binary: str) -> Path:
     subprocess.run(
         [
@@ -1137,28 +1142,30 @@ def rust_kcmt_commits_binary_file_with_mocked_provider(
 ) -> None:
     env = _clean_env(workflow_context["config_home"])
     env["OPENAI_TEST_KEY"] = "bdd-openai-key"
-    output = _run(
-        [
-            str(_rust_bin("kcmt")),
-            "--file",
-            "assets/logo.png",
-            "--provider",
-            "openai",
-            "--endpoint",
-            workflow_context["endpoint"],
-            "--api-key-env",
-            "OPENAI_TEST_KEY",
-            "--model",
-            "gpt-bdd",
-            "--no-auto-push",
-            "--repo-path",
-            str(workflow_context["repo"]),
-        ],
-        REPO_ROOT,
-        env=env,
-    )
-    workflow_context["output"] = output
-    workflow_context["direct_server"].shutdown()
+    try:
+        output = _run(
+            [
+                str(_rust_bin("kcmt")),
+                "--file",
+                "assets/logo.png",
+                "--provider",
+                "openai",
+                "--endpoint",
+                workflow_context["endpoint"],
+                "--api-key-env",
+                "OPENAI_TEST_KEY",
+                "--model",
+                "gpt-bdd",
+                "--no-auto-push",
+                "--repo-path",
+                str(workflow_context["repo"]),
+            ],
+            REPO_ROOT,
+            env=env,
+        )
+        workflow_context["output"] = output
+    finally:
+        _stop_server(workflow_context["direct_server"])
 
 
 @when(
@@ -1169,28 +1176,30 @@ def rust_kcmt_commits_file_with_malformed_then_valid_provider_output(
 ) -> None:
     env = _clean_env(workflow_context["config_home"])
     env["OPENAI_TEST_KEY"] = "bdd-openai-key"
-    output = _run(
-        [
-            str(_rust_bin("kcmt")),
-            "--file",
-            "tracked.py",
-            "--provider",
-            "openai",
-            "--endpoint",
-            workflow_context["endpoint"],
-            "--api-key-env",
-            "OPENAI_TEST_KEY",
-            "--model",
-            "gpt-bdd",
-            "--no-auto-push",
-            "--repo-path",
-            str(workflow_context["repo"]),
-        ],
-        REPO_ROOT,
-        env=env,
-    )
-    workflow_context["output"] = output
-    workflow_context["direct_server"].shutdown()
+    try:
+        output = _run(
+            [
+                str(_rust_bin("kcmt")),
+                "--file",
+                "tracked.py",
+                "--provider",
+                "openai",
+                "--endpoint",
+                workflow_context["endpoint"],
+                "--api-key-env",
+                "OPENAI_TEST_KEY",
+                "--model",
+                "gpt-bdd",
+                "--no-auto-push",
+                "--repo-path",
+                str(workflow_context["repo"]),
+            ],
+            REPO_ROOT,
+            env=env,
+        )
+        workflow_context["output"] = output
+    finally:
+        _stop_server(workflow_context["direct_server"])
 
 
 @when("the Rust kcmt command receives invalid provider output")

--- a/tests/test_rust_workflow_parity_bdd.py
+++ b/tests/test_rust_workflow_parity_bdd.py
@@ -244,6 +244,43 @@ def _start_retry_limited_provider() -> tuple[str, type[_RetryLimitHandler], HTTP
     return f"http://127.0.0.1:{server.server_port}", Handler, server
 
 
+class _DirectProviderHandler(BaseHTTPRequestHandler):
+    requests: list[tuple[str, str, str]] = []
+    responses: list[bytes] = []
+
+    def do_POST(self) -> None:  # noqa: N802
+        length = int(self.headers.get("content-length", "0") or "0")
+        body = self.rfile.read(length).decode("utf-8", "ignore") if length else ""
+        self.__class__.requests.append((self.command, self.path, body))
+        payload = (
+            self.__class__.responses.pop(0)
+            if self.__class__.responses
+            else b'{"choices":[{"message":{"content":"fix(core): default response."}}]}'
+        )
+        self.send_response(200)
+        self.send_header("content-type", "application/json")
+        self.send_header("content-length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def log_message(self, format: str, *args: Any) -> None:  # noqa: A002
+        return
+
+
+def _start_direct_provider(
+    responses: list[bytes],
+) -> tuple[str, type[_DirectProviderHandler], HTTPServer]:
+    class Handler(_DirectProviderHandler):
+        requests: list[tuple[str, str, str]] = []
+
+    Handler.responses = responses.copy()
+
+    server = HTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return f"http://127.0.0.1:{server.server_port}", Handler, server
+
+
 def _rust_bin(binary: str) -> Path:
     subprocess.run(
         [
@@ -364,6 +401,54 @@ def git_repository_with_one_changed_tracked_file(tmp_path: Path) -> dict[str, An
 
     (repo / "tracked.py").write_text("print('changed')\n")
     return {"repo": repo, "config_home": tmp_path / "config-home"}
+
+
+@given(
+    "a git repository with one changed binary file and a mocked OpenAI provider",
+    target_fixture="workflow_context",
+)
+def git_repository_with_one_changed_binary_file_and_mocked_provider(
+    tmp_path: Path,
+) -> dict[str, Any]:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_repo(repo)
+    assets = repo / "assets"
+    assets.mkdir()
+    (assets / "logo.png").write_bytes(b"\0PNG seed")
+    _git(repo, ["add", "assets/logo.png"])
+    _git(repo, ["commit", "-m", "chore(assets): seed logo"])
+    (assets / "logo.png").write_bytes(b"\0PNG changed")
+    endpoint, handler, server = _start_direct_provider(
+        [b'{"choices":[{"message":{"content":"chore(assets): update logo."}}]}']
+    )
+    return {
+        "repo": repo,
+        "config_home": tmp_path / "config-home",
+        "endpoint": endpoint,
+        "direct_handler": handler,
+        "direct_server": server,
+    }
+
+
+@given(
+    "a git repository with one changed tracked file and a malformed-then-valid OpenAI provider",
+    target_fixture="workflow_context",
+)
+def git_repository_with_malformed_then_valid_openai_provider(
+    tmp_path: Path,
+) -> dict[str, Any]:
+    context = git_repository_with_one_changed_tracked_file(tmp_path)
+    endpoint, handler, server = _start_direct_provider(
+        [
+            b'{"choices":[{"message":{"content":"This changes a few files"}}]}',
+            b'{"choices":[{"message":{"content":"fix(core): retry simplified prompt."}}]}',
+        ]
+    )
+    context["endpoint"] = endpoint
+    context["direct_handler"] = handler
+    context["direct_server"] = server
+    return context
 
 
 @given(
@@ -1046,6 +1131,68 @@ def rust_kcmt_commits_the_file_with_wrapped_provider_output(
     workflow_context["output"] = output
 
 
+@when("the Rust kcmt command commits the binary file with the mocked provider")
+def rust_kcmt_commits_binary_file_with_mocked_provider(
+    workflow_context: dict[str, Any],
+) -> None:
+    env = _clean_env(workflow_context["config_home"])
+    env["OPENAI_TEST_KEY"] = "bdd-openai-key"
+    output = _run(
+        [
+            str(_rust_bin("kcmt")),
+            "--file",
+            "assets/logo.png",
+            "--provider",
+            "openai",
+            "--endpoint",
+            workflow_context["endpoint"],
+            "--api-key-env",
+            "OPENAI_TEST_KEY",
+            "--model",
+            "gpt-bdd",
+            "--no-auto-push",
+            "--repo-path",
+            str(workflow_context["repo"]),
+        ],
+        REPO_ROOT,
+        env=env,
+    )
+    workflow_context["output"] = output
+    workflow_context["direct_server"].shutdown()
+
+
+@when(
+    "the Rust kcmt command commits the file with malformed then valid provider output"
+)
+def rust_kcmt_commits_file_with_malformed_then_valid_provider_output(
+    workflow_context: dict[str, Any],
+) -> None:
+    env = _clean_env(workflow_context["config_home"])
+    env["OPENAI_TEST_KEY"] = "bdd-openai-key"
+    output = _run(
+        [
+            str(_rust_bin("kcmt")),
+            "--file",
+            "tracked.py",
+            "--provider",
+            "openai",
+            "--endpoint",
+            workflow_context["endpoint"],
+            "--api-key-env",
+            "OPENAI_TEST_KEY",
+            "--model",
+            "gpt-bdd",
+            "--no-auto-push",
+            "--repo-path",
+            str(workflow_context["repo"]),
+        ],
+        REPO_ROOT,
+        env=env,
+    )
+    workflow_context["output"] = output
+    workflow_context["direct_server"].shutdown()
+
+
 @when("the Rust kcmt command receives invalid provider output")
 def rust_kcmt_receives_invalid_provider_output(
     workflow_context: dict[str, Any],
@@ -1323,6 +1470,49 @@ def latest_commit_uses_the_sanitized_provider_message(
     assert "fix(core): handle provider output" in workflow_context["output"]
     log = _git(workflow_context["repo"], ["log", "--pretty=%s", "-1"])
     assert log == "fix(core): handle provider output"
+
+
+@then("the mocked provider prompt includes the binary diff summary")
+def mocked_provider_prompt_includes_binary_diff_summary(
+    workflow_context: dict[str, Any],
+) -> None:
+    requests = workflow_context["direct_handler"].requests
+    assert len(requests) == 1
+    body = requests[0][2]
+    assert "Binary diff detected." in body
+    assert "File hint: assets/logo.png" in body
+    assert "Git reported:" in body
+
+
+@then("the latest commit uses the binary provider message")
+def latest_commit_uses_the_binary_provider_message(
+    workflow_context: dict[str, Any],
+) -> None:
+    assert "chore(assets): update logo" in workflow_context["output"]
+    log = _git(workflow_context["repo"], ["log", "--pretty=%s", "-1"])
+    assert log == "chore(assets): update logo"
+
+
+@then("the mocked provider receives a simplified retry prompt")
+def mocked_provider_receives_a_simplified_retry_prompt(
+    workflow_context: dict[str, Any],
+) -> None:
+    requests = workflow_context["direct_handler"].requests
+    assert len(requests) == 2
+    first_body = requests[0][2]
+    retry_body = requests[1][2]
+    assert "STRICT REQUIREMENTS" in first_body
+    assert "Keep it simple but include mandatory scope." in retry_body
+    assert "STRICT REQUIREMENTS" not in retry_body
+
+
+@then("the latest commit uses the simplified retry provider message")
+def latest_commit_uses_the_simplified_retry_provider_message(
+    workflow_context: dict[str, Any],
+) -> None:
+    assert "fix(core): retry simplified prompt" in workflow_context["output"]
+    log = _git(workflow_context["repo"], ["log", "--pretty=%s", "-1"])
+    assert log == "fix(core): retry simplified prompt"
 
 
 @then("the workflow fails before committing the file")


### PR DESCRIPTION
## Summary

This PR closes the Rust LLM prompt/output handling parity slice for the file workflow. Rust now prepares provider prompts with Python-parity diff cleanup, binary diff summaries, and large-diff truncation, then retries malformed provider output once with a simplified prompt before failing or falling through provider handling.

PR #37 had already merged into `main`, so this branch was rebased onto `origin/main` instead of stacked on the former PR branch.

## Conventional Commit Breakdown

| Commit | Type | Scope | Summary | Behaviour impact |
| --- | --- | --- | --- | --- |
| `7a104b6` | `feat` | `rust` | align llm prompt output handling | Adds Rust prompt preparation parity and simplified retry behaviour. |
| `591931e` | `fix` | `rust` | harden prompt parity review fixes | Addresses Copilot review feedback for text-file heuristics and test server cleanup. |

## Release Notes Draft

- Rust file workflow provider prompts now summarize binary diffs instead of sending unusable binary patch content.
- Rust provider prompts now clean `/dev/null` diff headers and truncate very large diffs before model invocation.
- Rust direct-provider file workflow now retries malformed model output once with a simplified prompt.

## Behaviour Changes

- Binary diffs for non-text files are converted into a concise prompt summary that preserves file context and Git binary marker details.
- Large diffs are truncated to a bounded prompt payload while preserving the beginning and end of the diff.
- New-file and deleted-file diff headers are cleaned before prompt construction.
- Malformed provider responses now get one simplified-prompt retry in the Rust direct-provider file workflow.

## API / Schema / Contract Changes

No public CLI flags, provider API contracts, persisted schemas, or configuration formats changed.

## Testing Evidence

| Command | Result |
| --- | --- |
| `cargo test --manifest-path rust/Cargo.toml -p kcmt-core message::tests -- --nocapture` | Passed: `10 passed` |
| `cargo test --manifest-path rust/Cargo.toml -p kcmt-cli --test workflow_modes -- --nocapture` | Passed: `38 passed` |
| `uv run pytest -q --no-cov tests/test_rust_workflow_parity_bdd.py` | Passed: `31 passed` |
| `rtk proxy make check` | Passed: Python `155 passed, 1 skipped`, coverage `93.88%`; Rust and Ink checks passed |
| `rtk proxy make quality-gates` | Passed: Python `155 passed, 1 skipped`, coverage `93.88%`; Rust and Ink gates passed |

CI after the review-fix push: `6 passed, 0 failed`.

## Risk and Rollback

Risk is limited to Rust direct-provider prompt construction and retry handling in file workflow mode. Rollback is to revert the two commits in this PR. Existing Python behavior and provider configuration contracts are unchanged.

## Operational Notes

- Copilot generated four comments. Each was fixed in commit `591931e`, replied to, and resolved through GitHub review threads.
- The PR is ready for review, not draft.
- Merge state after final verification: `CLEAN`.

## Linked Work

- Follows the Rust parity work merged in PR #37.
- No issue ID was provided.

## Reviewer Checklist

- [ ] Confirm binary diff prompt summaries preserve useful file context.
- [ ] Confirm simplified retry semantics are acceptable for direct providers.
- [ ] Confirm no PR #37 prompt-profile or provider-selector behavior regressed.
- [ ] Confirm BDD scenarios cover the user-visible parity slice.
