### PR TITLE
feat(provider): close Rust provider parity gaps

### DIFF
--- a/.github/workflows/rust-canary-smoke.yml
+++ b/.github/workflows/rust-canary-smoke.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Build Rust candidate
         shell: bash
         run: |
-          cargo build --release --manifest-path rust/Cargo.toml -p kcmt-cli
+          cargo build --locked --release --manifest-path rust/Cargo.toml -p kcmt-cli
 
       - name: Run canary probe scenarios
         shell: bash

--- a/.github/workflows/rust-parity-matrix.yml
+++ b/.github/workflows/rust-parity-matrix.yml
@@ -86,12 +86,12 @@ jobs:
       - name: Build Rust candidate
         shell: bash
         run: |
-          cargo build --release --manifest-path rust/Cargo.toml -p kcmt-cli
+          cargo build --locked --release --manifest-path rust/Cargo.toml -p kcmt-cli
 
       - name: Rust workspace tests
         shell: bash
         run: |
-          cargo test --manifest-path rust/Cargo.toml --workspace --no-fail-fast
+          cargo test --locked --manifest-path rust/Cargo.toml --workspace --no-fail-fast
 
       - name: Python wrapper and BDD parity tests
         shell: bash

--- a/Makefile
+++ b/Makefile
@@ -75,10 +75,10 @@ test-ink:
 	npm --prefix kcmt/ui/ink test
 
 test-rust:
-	cargo test --manifest-path rust/Cargo.toml --workspace --no-fail-fast
+	cargo test --locked --manifest-path rust/Cargo.toml --workspace --no-fail-fast
 
 test-llm-matrix:
-	KCMT_LIVE_LLM_MATRIX=1 cargo test --manifest-path rust/Cargo.toml -p kcmt-cli --test live_llm_matrix -- --ignored --nocapture
+	KCMT_LIVE_LLM_MATRIX=1 cargo test --locked --manifest-path rust/Cargo.toml -p kcmt-cli --test live_llm_matrix -- --ignored --nocapture
 
 test-verbose:
 	$(PYTEST) -v

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -87,9 +87,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "block-buffer"
@@ -113,9 +113,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "byteorder"
@@ -146,9 +146,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.57"
+version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -168,9 +168,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -190,9 +190,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -223,9 +223,9 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "compact_str"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
+checksum = "7fd622ebbb56a5b2ccb651b32b911cdeb2a9b4b11776b2473bf26a26a286244e"
 dependencies = [
  "castaway",
  "cfg-if",
@@ -438,9 +438,9 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -464,9 +464,9 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "encoding_rs"
@@ -617,9 +617,22 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -629,7 +642,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce52001b946a6249d5d0d3011df0a042ac3f8a4d013460db6476577b0b9c567"
 dependencies = [
  "gix-actor",
+ "gix-archive",
  "gix-attributes",
+ "gix-blame",
  "gix-command",
  "gix-commitgraph",
  "gix-config",
@@ -647,6 +662,8 @@ dependencies = [
  "gix-ignore",
  "gix-index",
  "gix-lock",
+ "gix-merge",
+ "gix-negotiate",
  "gix-object",
  "gix-odb",
  "gix-pack",
@@ -668,6 +685,8 @@ dependencies = [
  "gix-utils",
  "gix-validate",
  "gix-worktree",
+ "gix-worktree-state",
+ "gix-worktree-stream",
  "nonempty",
  "smallvec",
  "thiserror",
@@ -682,6 +701,19 @@ dependencies = [
  "bstr",
  "gix-date",
  "gix-error",
+]
+
+[[package]]
+name = "gix-archive"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a20ec244b733338d4cb60e5e05eac700dab7fcc689647b1d1daa9396b119342"
+dependencies = [
+ "bstr",
+ "gix-date",
+ "gix-error",
+ "gix-object",
+ "gix-worktree-stream",
 ]
 
 [[package]]
@@ -708,6 +740,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52ebef0c26ad305747649e727bbcd56a7b7910754eb7cea88f6dff6f93c51283"
 dependencies = [
  "gix-error",
+]
+
+[[package]]
+name = "gix-blame"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14dab9a942ab54a9661ded7397c3bf927274e7afa94494db0d75cfcbde02ca0a"
+dependencies = [
+ "gix-commitgraph",
+ "gix-date",
+ "gix-diff",
+ "gix-error",
+ "gix-hash",
+ "gix-object",
+ "gix-revwalk",
+ "gix-trace",
+ "gix-traverse",
+ "gix-worktree",
+ "smallvec",
+ "thiserror",
 ]
 
 [[package]]
@@ -863,6 +915,7 @@ version = "0.48.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1849ae154d38bc403185be14fa871e38e3c93ee606875d94e207fdb9fba52dbc"
 dependencies = [
+ "bytes",
  "crc32fast",
  "gix-path",
  "gix-trace",
@@ -930,6 +983,7 @@ checksum = "cb0926d3819c837750b4e03c7754901e73f68b8c9b690753a6372a1bed4eedce"
 dependencies = [
  "faster-hex",
  "gix-features",
+ "sha1-checked",
  "thiserror",
 ]
 
@@ -964,7 +1018,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19753d40da53d0ec41604750eeb969097a90fb2d7f7992730d904541c04e2c19"
 dependencies = [
  "bstr",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -1004,6 +1058,46 @@ dependencies = [
  "gix-tempfile",
  "gix-utils",
  "thiserror",
+]
+
+[[package]]
+name = "gix-merge"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74bbcdcc52b70a32f0a151b024dff9d0fcf56ee48f00d9503e735af9d99ea881"
+dependencies = [
+ "bstr",
+ "gix-command",
+ "gix-diff",
+ "gix-filter",
+ "gix-fs",
+ "gix-hash",
+ "gix-imara-diff",
+ "gix-index",
+ "gix-object",
+ "gix-path",
+ "gix-quote",
+ "gix-revision",
+ "gix-revwalk",
+ "gix-tempfile",
+ "gix-trace",
+ "gix-worktree",
+ "nonempty",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-negotiate"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "103d42bfade1b8a96ca5005933127bdad461ce588d92422b2c2daa3ff20d780c"
+dependencies = [
+ "bitflags",
+ "gix-commitgraph",
+ "gix-date",
+ "gix-hash",
+ "gix-object",
+ "gix-revwalk",
 ]
 
 [[package]]
@@ -1176,6 +1270,7 @@ version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fb5288fac706d3ea3e4e2ba9ec38b78743b8c02f422e18cb342299cfd6ab7e8"
 dependencies = [
+ "bitflags",
  "bstr",
  "gix-commitgraph",
  "gix-date",
@@ -1183,6 +1278,7 @@ dependencies = [
  "gix-hash",
  "gix-object",
  "gix-revwalk",
+ "gix-trace",
  "nonempty",
 ]
 
@@ -1368,6 +1464,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "gix-worktree-state"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a96dccbcf9e8fe0291c55f06e08da93ebb2e691c1311276f541eefcc6d70800"
+dependencies = [
+ "bstr",
+ "gix-features",
+ "gix-filter",
+ "gix-fs",
+ "gix-index",
+ "gix-object",
+ "gix-path",
+ "gix-worktree",
+ "io-close",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-worktree-stream"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8444b8ed4662e1a0c97f3eceda29630001a1bbb2632201e50312623e594213"
+dependencies = [
+ "gix-attributes",
+ "gix-error",
+ "gix-features",
+ "gix-filter",
+ "gix-fs",
+ "gix-hash",
+ "gix-object",
+ "gix-path",
+ "gix-traverse",
+ "parking_lot",
+]
+
+[[package]]
 name = "hash32"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1409,6 +1541,9 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "heapless"
@@ -1428,9 +1563,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
 dependencies = [
  "bytes",
  "itoa",
@@ -1467,9 +1602,9 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1480,7 +1615,6 @@ dependencies = [
  "httparse",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -1488,15 +1622,14 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http",
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -1528,12 +1661,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -1541,9 +1675,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1554,9 +1688,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -1568,15 +1702,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -1588,15 +1722,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -1606,6 +1740,12 @@ dependencies = [
  "zerotrie",
  "zerovec",
 ]
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "ident_case"
@@ -1626,12 +1766,24 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1645,9 +1797,9 @@ dependencies = [
 
 [[package]]
 name = "instability"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357b7205c6cd18dd2c86ed312d1e70add149aea98e7ef72b9fdf0270e555c11d"
+checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
 dependencies = [
  "darling",
  "indoc",
@@ -1657,20 +1809,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-close"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cadcf447f06744f8ce713d2d6239bb5bde2c357a452397a9ed90c625da390bc"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
-
-[[package]]
-name = "iri-string"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
-dependencies = [
- "memchr",
- "serde",
-]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -1689,9 +1841,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
@@ -1736,10 +1888,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -1834,6 +1988,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1853,9 +2013,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "litrs"
@@ -1874,9 +2034,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "lru"
@@ -1906,9 +2066,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "memmap2"
@@ -1937,9 +2097,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "log",
@@ -1955,9 +2115,9 @@ checksum = "9737e026353e5cd0736f98eddae28665118eb6f6600902a7f50db585621fecb6"
 
 [[package]]
 name = "num-conv"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "once_cell"
@@ -2013,12 +2173,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2035,9 +2189,9 @@ dependencies = [
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -2055,6 +2209,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
 ]
 
 [[package]]
@@ -2144,6 +2308,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
@@ -2266,9 +2436,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
@@ -2307,9 +2477,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "once_cell",
  "ring",
@@ -2321,9 +2491,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "web-time",
  "zeroize",
@@ -2441,9 +2611,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -2465,6 +2635,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sha1-checked"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89f599ac0c323ebb1c6082821a54962b839832b03984598375bff3975b804423"
+dependencies = [
+ "digest",
+ "sha1",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2483,9 +2674,9 @@ checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook"
@@ -2532,9 +2723,9 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -2624,7 +2815,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
@@ -2683,9 +2874,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -2708,9 +2899,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -2724,9 +2915,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2760,20 +2951,20 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "bitflags",
  "bytes",
  "futures-util",
  "http",
  "http-body",
- "iri-string",
  "pin-project-lite",
  "tower",
  "tower-layer",
  "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -2827,9 +3018,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicase"
@@ -2860,9 +3051,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.12.0"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-truncate"
@@ -2886,6 +3077,12 @@ name = "unicode-width"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "untrusted"
@@ -2950,18 +3147,27 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2972,23 +3178,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.64"
+version = "0.4.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
 dependencies = [
- "cfg-if",
- "futures-util",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2996,9 +3198,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3009,18 +3211,52 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
-name = "web-sys"
-version = "0.3.91"
+name = "wasm-encoder"
+version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.99"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3038,9 +3274,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -3252,18 +3488,106 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -3272,9 +3596,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3284,18 +3608,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.42"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2578b716f8a7a858b7f02d5bd870c14bf4ddbbcf3a4c05414ba6503640505e3"
+checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.42"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
+checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3304,18 +3628,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3331,9 +3655,9 @@ checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -3342,9 +3666,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -3353,9 +3677,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -24,7 +24,7 @@ serde_json = "1.0"
 tracing = "0.1"
 sha2 = "0.10"
 time = { version = "0.3", features = ["formatting", "macros"] }
-gix = { version = "0.83", default-features = false, features = ["status"] }
+gix = { version = "0.83", default-features = false, features = ["status", "sha1"] }
 
 [profile.release]
 panic = "abort"

--- a/rust/crates/kcmt-bench/src/runner.rs
+++ b/rust/crates/kcmt-bench/src/runner.rs
@@ -853,6 +853,7 @@ fn runtime_benchmark_env(config_home: &Path, runtime: RuntimeKind) -> Vec<(Strin
             config_home.display().to_string(),
         ),
         (RUNTIME_BENCHMARK_ENV.to_string(), "1".to_string()),
+        ("KCMT_DISABLE_KEYCHAIN".to_string(), "1".to_string()),
         ("KCMT_NO_SPINNER".to_string(), "1".to_string()),
         ("PYTHONIOENCODING".to_string(), "utf-8".to_string()),
         ("PYTHONUTF8".to_string(), "1".to_string()),
@@ -961,12 +962,17 @@ fn scenario_command(
         "oneshot-repo-path" => {
             command.extend([
                 "--oneshot".to_string(),
+                "--no-auto-push".to_string(),
                 "--repo-path".to_string(),
                 repo_path.display().to_string(),
             ]);
         }
         "default-repo-path" => {
-            command.extend(["--repo-path".to_string(), repo_path.display().to_string()]);
+            command.extend([
+                "--no-auto-push".to_string(),
+                "--repo-path".to_string(),
+                repo_path.display().to_string(),
+            ]);
         }
         _ => {
             let target = scenario
@@ -977,6 +983,7 @@ fn scenario_command(
             command.extend([
                 "--file".to_string(),
                 target,
+                "--no-auto-push".to_string(),
                 "--repo-path".to_string(),
                 repo_path.display().to_string(),
             ]);

--- a/rust/crates/kcmt-cli/src/commands/workflow.rs
+++ b/rust/crates/kcmt-cli/src/commands/workflow.rs
@@ -1389,11 +1389,14 @@ fn credential_for_candidate(candidate: &ProviderCandidate) -> Option<(String, Cr
 
 fn available_providers(config: &kcmt_core::model::WorkflowConfig) -> Vec<String> {
     let candidates = provider_candidates(config);
-    if fixture_provider_response().is_some() || runtime_benchmark_enabled() {
+    if fixture_provider_response().is_some() {
         return candidates
             .into_iter()
             .map(|candidate| candidate.provider)
             .collect();
+    }
+    if runtime_benchmark_enabled() {
+        return vec![config.provider.clone()];
     }
     candidates
         .into_iter()
@@ -1407,6 +1410,7 @@ fn selected_workflow_config(
     selection: &ModelSelection,
 ) -> kcmt_core::model::WorkflowConfig {
     let mut selected = config.clone();
+    let provider_changed = selected.provider != selection.provider;
     selected.provider = selection.provider.clone();
     selected.model = selection.model.clone();
     if let Some(candidate) = provider_candidates(config)
@@ -1416,7 +1420,21 @@ fn selected_workflow_config(
         selected.llm_endpoint = candidate.endpoint;
         selected.api_key_env = candidate.api_key_env;
     }
+    if !matches!(selected.provider.as_str(), "openai" | "xai") {
+        selected.use_batch = false;
+        selected.batch_model = None;
+    } else if provider_changed {
+        selected.batch_model = default_provider_batch_model(&selected.provider).map(str::to_string);
+    }
     selected
+}
+
+fn default_provider_batch_model(provider: &str) -> Option<&'static str> {
+    match provider {
+        "openai" => Some("gpt-5-mini-2025-08-07"),
+        "xai" => Some("grok-4.3"),
+        _ => None,
+    }
 }
 
 fn invoke_provider_with_fallback(
@@ -1532,7 +1550,7 @@ fn invoke_provider_candidate_with_style(
                         ProviderMessage::system(system),
                         ProviderMessage::user(prompt),
                     ];
-                    OpenAiClient::invoke_chat(
+                    OpenAiClient::invoke_model(
                         transport,
                         &candidate.endpoint,
                         api_key,
@@ -2185,11 +2203,14 @@ fn write_run_snapshot(repo_path: &Path, snapshot: &serde_json::Value) -> Result<
 #[cfg(test)]
 mod tests {
     use super::{
-        deletion_commit_message, diff_for_entry, git_common_config_path, git_config_has_include,
-        git_config_value, heuristic_commit_message, local_origin_remote_probe,
-        parse_status_entries, select_prepare_workers, OriginRemoteProbe, StatusEntry,
+        default_provider_batch_model, deletion_commit_message, diff_for_entry,
+        git_common_config_path, git_config_has_include, git_config_value, heuristic_commit_message,
+        local_origin_remote_probe, parse_status_entries, select_prepare_workers,
+        selected_workflow_config, OriginRemoteProbe, StatusEntry,
     };
     use kcmt_core::git::commit_file::CommitStaging;
+    use kcmt_core::model::{ModelPreference, ProviderConfigEntry, WorkflowConfig};
+    use kcmt_core::selector::ModelSelection;
     use std::fs;
     use std::path::{Path, PathBuf};
     use std::sync::atomic::{AtomicU64, Ordering};
@@ -2427,6 +2448,89 @@ mod tests {
             deletion_commit_message("delete_me.txt", 72),
             "chore(delete_me-txt): file deleted"
         );
+    }
+
+    #[test]
+    fn selected_workflow_config_uses_provider_specific_batch_model_after_selection() {
+        let mut providers = std::collections::HashMap::new();
+        providers.insert(
+            "openai".to_string(),
+            ProviderConfigEntry {
+                endpoint: Some("https://api.openai.com/v1".to_string()),
+                api_key_env: Some("OPENAI_TEST_KEY".to_string()),
+                preferred_model: Some("gpt-5-mini-2025-08-07".to_string()),
+                ..ProviderConfigEntry::default()
+            },
+        );
+        providers.insert(
+            "xai".to_string(),
+            ProviderConfigEntry {
+                endpoint: Some("https://api.x.ai/v1".to_string()),
+                api_key_env: Some("XAI_TEST_KEY".to_string()),
+                preferred_model: Some("grok-code-fast".to_string()),
+                ..ProviderConfigEntry::default()
+            },
+        );
+        let config = WorkflowConfig {
+            provider: "openai".to_string(),
+            model: "gpt-5-mini-2025-08-07".to_string(),
+            llm_endpoint: "https://api.openai.com/v1".to_string(),
+            api_key_env: "OPENAI_TEST_KEY".to_string(),
+            use_batch: true,
+            batch_model: Some("gpt-5-mini-2025-08-07".to_string()),
+            providers,
+            model_priority: vec![
+                ModelPreference {
+                    provider: "openai".to_string(),
+                    model: "gpt-5-mini-2025-08-07".to_string(),
+                },
+                ModelPreference {
+                    provider: "xai".to_string(),
+                    model: "grok-code-fast".to_string(),
+                },
+            ],
+            ..WorkflowConfig::default()
+        };
+        let selection = ModelSelection {
+            provider: "xai".to_string(),
+            model: "grok-code-fast".to_string(),
+            rule_applied: None,
+            fallback_reason: None,
+        };
+
+        let selected = selected_workflow_config(&config, &selection);
+
+        assert_eq!(selected.provider, "xai");
+        assert_eq!(selected.model, "grok-code-fast");
+        assert_eq!(selected.llm_endpoint, "https://api.x.ai/v1");
+        assert_eq!(selected.api_key_env, "XAI_TEST_KEY");
+        assert_eq!(selected.batch_model.as_deref(), Some("grok-4.3"));
+        assert_eq!(default_provider_batch_model("xai"), Some("grok-4.3"));
+    }
+
+    #[test]
+    fn selected_workflow_config_disables_batch_for_non_batch_provider_selection() {
+        let config = WorkflowConfig {
+            provider: "openai".to_string(),
+            model: "gpt-5-mini-2025-08-07".to_string(),
+            llm_endpoint: "https://api.openai.com/v1".to_string(),
+            api_key_env: "OPENAI_TEST_KEY".to_string(),
+            use_batch: true,
+            batch_model: Some("gpt-5-mini-2025-08-07".to_string()),
+            ..WorkflowConfig::default()
+        };
+        let selection = ModelSelection {
+            provider: "anthropic".to_string(),
+            model: "claude-3-5-haiku-latest".to_string(),
+            rule_applied: None,
+            fallback_reason: None,
+        };
+
+        let selected = selected_workflow_config(&config, &selection);
+
+        assert_eq!(selected.provider, "anthropic");
+        assert!(!selected.use_batch);
+        assert!(selected.batch_model.is_none());
     }
 
     #[test]

--- a/rust/crates/kcmt-cli/tests/workflow_modes.rs
+++ b/rust/crates/kcmt-cli/tests/workflow_modes.rs
@@ -1230,6 +1230,102 @@ fn file_mode_invokes_openai_compatible_provider_when_api_key_is_available() {
 }
 
 #[test]
+fn file_mode_invokes_openai_responses_api_for_responses_only_models() {
+    let repo = init_repo();
+    let (endpoint, request_rx) =
+        spawn_provider_response(r#"{"output_text":"fix(openai): use responses api."}"#);
+    fs::write(repo.join("tracked.py"), "print('seed')\n").expect("tracked seed");
+    git(&repo, &["add", "tracked.py"]);
+    git(&repo, &["commit", "-m", "chore(repo): seed"]);
+    fs::write(repo.join("tracked.py"), "print('changed')\n").expect("tracked change");
+
+    let output = kcmt_command(env!("CARGO_BIN_EXE_kcmt"))
+        .env("OPENAI_TEST_KEY", "test-key")
+        .args([
+            "--file",
+            "tracked.py",
+            "--provider",
+            "openai",
+            "--endpoint",
+            &endpoint,
+            "--api-key-env",
+            "OPENAI_TEST_KEY",
+            "--model",
+            "gpt-5.1-codex",
+            "--no-auto-push",
+            "--repo-path",
+        ])
+        .arg(&repo)
+        .output()
+        .expect("kcmt binary should run");
+
+    assert!(
+        output.status.success(),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let request = request_rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("provider request should be sent");
+    assert!(request.starts_with("POST /responses HTTP/1.1"));
+    assert!(request.contains(r#""model":"gpt-5.1-codex""#));
+    assert!(request.contains(r#""input":["#));
+    assert!(!request.contains("/chat/completions"));
+
+    let log = git(&repo, &["log", "--pretty=%s", "-1"]);
+    assert_eq!(log, "fix(openai): use responses api");
+}
+
+#[test]
+fn file_mode_provider_prompt_and_subject_respect_max_commit_length() {
+    let repo = init_repo();
+    let (endpoint, request_rx) = spawn_provider_response(
+        r#"{"choices":[{"message":{"content":"fix(provider): trim this intentionally long provider subject."}}]}"#,
+    );
+    fs::write(repo.join("tracked.py"), "print('seed')\n").expect("tracked seed");
+    git(&repo, &["add", "tracked.py"]);
+    git(&repo, &["commit", "-m", "chore(repo): seed"]);
+    fs::write(repo.join("tracked.py"), "print('changed')\n").expect("tracked change");
+
+    let output = kcmt_command(env!("CARGO_BIN_EXE_kcmt"))
+        .env("OPENAI_TEST_KEY", "test-key")
+        .args([
+            "--file",
+            "tracked.py",
+            "--provider",
+            "openai",
+            "--endpoint",
+            &endpoint,
+            "--api-key-env",
+            "OPENAI_TEST_KEY",
+            "--model",
+            "gpt-mock",
+            "--max-commit-length",
+            "42",
+            "--no-auto-push",
+            "--repo-path",
+        ])
+        .arg(&repo)
+        .output()
+        .expect("kcmt binary should run");
+
+    assert!(
+        output.status.success(),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let request = request_rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("provider request should be sent");
+    assert!(request.contains("Keep the subject <=42 characters"));
+    let log = git(&repo, &["log", "--pretty=%s", "-1"]);
+    assert_eq!(log.len(), 42);
+    assert_eq!(log, "fix(provider): trim this intentionally lon");
+}
+
+#[test]
 fn file_mode_provider_prompt_uses_staged_diff_for_staged_only_change() {
     let repo = init_repo();
     let (endpoint, request_rx) = spawn_provider_response(

--- a/rust/crates/kcmt-core/src/git/repo.rs
+++ b/rust/crates/kcmt-core/src/git/repo.rs
@@ -249,7 +249,7 @@ fn status_porcelain_gix(repo_path: &Path, patterns: Vec<gix::bstr::BString>) -> 
                         | EntryStatus::Change(Change::Type { .. }) => {
                             rows.push(format!(" M {}", rela_path.as_bstr().to_str_lossy()));
                         }
-                        EntryStatus::Conflict(_) => {
+                        EntryStatus::Conflict { .. } => {
                             rows.push(format!("UU {}", rela_path.as_bstr().to_str_lossy()));
                         }
                         EntryStatus::IntentToAdd | EntryStatus::NeedsUpdate(_) => {}

--- a/rust/crates/kcmt-provider/src/clients/mod.rs
+++ b/rust/crates/kcmt-provider/src/clients/mod.rs
@@ -99,6 +99,13 @@ impl ProviderClient for OpenAiClient {
 }
 
 impl OpenAiClient {
+    pub fn requires_responses(model: &str) -> bool {
+        model
+            .trim()
+            .to_ascii_lowercase()
+            .starts_with("gpt-5.1-codex")
+    }
+
     pub fn build_chat_request(
         endpoint: &str,
         api_key: &str,
@@ -108,8 +115,35 @@ impl OpenAiClient {
         build_openai_compatible_request(endpoint, api_key, model, messages)
     }
 
+    pub fn build_responses_request(
+        endpoint: &str,
+        api_key: &str,
+        model: &str,
+        messages: &[ProviderMessage],
+    ) -> ProviderRequest {
+        let mut headers = BTreeMap::new();
+        headers.insert("Authorization".to_string(), format!("Bearer {api_key}"));
+        headers.insert("content-type".to_string(), "application/json".to_string());
+
+        ProviderRequest {
+            url: format!("{}/responses", trim_endpoint(endpoint)),
+            headers,
+            payload: json!({
+                "model": model,
+                "input": messages.iter().map(|message| json!({
+                    "role": message.role,
+                    "content": message.content,
+                })).collect::<Vec<_>>(),
+            }),
+        }
+    }
+
     pub fn parse_chat_response(payload: &Value) -> Result<String, String> {
         parse_openai_compatible_response(payload)
+    }
+
+    pub fn parse_responses_response(payload: &Value) -> Result<String, String> {
+        parse_responses_compatible_response(payload)
     }
 
     pub async fn invoke_chat(
@@ -124,6 +158,34 @@ impl OpenAiClient {
             .post_json(&request.url, request.header_map()?, &request.payload)
             .await?;
         Self::parse_chat_response(&response).map_err(|err| anyhow!(err))
+    }
+
+    pub async fn invoke_responses(
+        transport: &AsyncTransport,
+        endpoint: &str,
+        api_key: &str,
+        model: &str,
+        messages: &[ProviderMessage],
+    ) -> Result<String> {
+        let request = Self::build_responses_request(endpoint, api_key, model, messages);
+        let response = transport
+            .post_json(&request.url, request.header_map()?, &request.payload)
+            .await?;
+        Self::parse_responses_response(&response).map_err(|err| anyhow!(err))
+    }
+
+    pub async fn invoke_model(
+        transport: &AsyncTransport,
+        endpoint: &str,
+        api_key: &str,
+        model: &str,
+        messages: &[ProviderMessage],
+    ) -> Result<String> {
+        if Self::requires_responses(model) {
+            Self::invoke_responses(transport, endpoint, api_key, model, messages).await
+        } else {
+            Self::invoke_chat(transport, endpoint, api_key, model, messages).await
+        }
     }
 
     pub fn build_models_request(endpoint: &str, api_key: &str) -> ProviderRequest {
@@ -847,6 +909,70 @@ fn parse_openai_compatible_models_response(payload: &Value) -> Result<Vec<Listed
     }
 }
 
+fn parse_responses_compatible_response(payload: &Value) -> Result<String, String> {
+    for key in ["output_text", "content", "text"] {
+        if let Some(text) = payload
+            .get(key)
+            .and_then(provider_content_text)
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty())
+        {
+            return Ok(text);
+        }
+    }
+
+    let Some(output) = payload.get("output").and_then(Value::as_array) else {
+        return Err("provider responses output missing content".to_string());
+    };
+    let text = output
+        .iter()
+        .filter_map(responses_output_text)
+        .filter(|part| !part.trim().is_empty())
+        .collect::<Vec<_>>()
+        .join("");
+    if text.trim().is_empty() {
+        Err("provider responses output missing content".to_string())
+    } else {
+        Ok(text.trim().to_string())
+    }
+}
+
+fn responses_output_text(item: &Value) -> Option<String> {
+    if let Some(parts) = item.get("content").and_then(Value::as_array) {
+        let text = parts
+            .iter()
+            .filter_map(|part| {
+                part.get("text")
+                    .or_else(|| part.get("content"))
+                    .or_else(|| part.get("value"))
+                    .and_then(provider_content_text)
+            })
+            .collect::<Vec<_>>()
+            .join("");
+        if !text.trim().is_empty() {
+            return Some(text);
+        }
+    }
+    if let Some(text) = item
+        .get("text")
+        .or_else(|| item.get("content"))
+        .or_else(|| item.get("value"))
+        .and_then(provider_content_text)
+    {
+        return Some(text);
+    }
+    item.get("content")
+        .and_then(Value::as_array)
+        .map(|parts| {
+            parts
+                .iter()
+                .filter_map(provider_content_text)
+                .collect::<Vec<_>>()
+                .join("")
+        })
+        .filter(|text| !text.trim().is_empty())
+}
+
 fn provider_content_text(value: &Value) -> Option<String> {
     match value {
         Value::String(text) => Some(text.clone()),
@@ -929,6 +1055,51 @@ mod tests {
 
         assert_eq!(request.payload["max_completion_tokens"], 4096);
         assert!(request.payload.get("max_tokens").is_none());
+    }
+
+    #[test]
+    fn openai_responses_models_build_responses_request_and_extract_output_text() {
+        let request = OpenAiClient::build_responses_request(
+            "https://api.openai.com/v1/",
+            "sk-test",
+            "gpt-5.1-codex",
+            &[
+                ProviderMessage::system("system"),
+                ProviderMessage::user("prompt"),
+            ],
+        );
+
+        assert!(OpenAiClient::requires_responses("gpt-5.1-codex-mini"));
+        assert_eq!(request.url, "https://api.openai.com/v1/responses");
+        assert_eq!(request.headers["Authorization"], "Bearer sk-test");
+        assert_eq!(request.payload["model"], "gpt-5.1-codex");
+        assert_eq!(request.payload["input"][0]["role"], "system");
+        assert_eq!(request.payload["input"][1]["content"], "prompt");
+        assert!(request.payload.get("messages").is_none());
+
+        let content = OpenAiClient::parse_responses_response(&json!({
+            "output_text": "fix(openai): use responses api"
+        }))
+        .expect("output_text should parse");
+        assert_eq!(content, "fix(openai): use responses api");
+    }
+
+    #[test]
+    fn openai_responses_parser_extracts_nested_text_parts() {
+        let content = OpenAiClient::parse_responses_response(&json!({
+            "output": [
+                {
+                    "type": "message",
+                    "content": [
+                        {"type": "output_text", "text": "fix(openai): parse nested"},
+                        {"type": "output_text", "text": " response"}
+                    ]
+                }
+            ]
+        }))
+        .expect("nested responses content should parse");
+
+        assert_eq!(content, "fix(openai): parse nested response");
     }
 
     #[test]
@@ -1237,6 +1408,34 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn openai_invoke_model_posts_responses_payload_for_responses_only_model() {
+        let (endpoint, received) =
+            spawn_json_server(r#"{"output_text":"fix(openai): invoke responses"}"#);
+        let transport =
+            AsyncTransport::new(Duration::from_secs(2), RetryPolicy::default()).unwrap();
+
+        let content = OpenAiClient::invoke_model(
+            &transport,
+            &endpoint,
+            "sk-test",
+            "gpt-5.1-codex",
+            &[ProviderMessage::user("prompt")],
+        )
+        .await
+        .expect("responses invoke should parse provider response");
+
+        assert_eq!(content, "fix(openai): invoke responses");
+        let request = received.recv_timeout(Duration::from_secs(2)).unwrap();
+        assert!(request.contains("POST /responses HTTP/1.1"));
+        assert!(request.contains("authorization: Bearer sk-test"));
+        assert!(request.contains(r#""model":"gpt-5.1-codex""#));
+        assert!(request.contains(r#""input":["#));
+        assert!(request.contains(r#""role":"user""#));
+        assert!(request.contains(r#""content":"prompt""#));
+        assert!(!request.contains("/chat/completions"));
+    }
+
+    #[tokio::test]
     async fn anthropic_invoke_messages_posts_payload_and_parses_text_chunks() {
         let (endpoint, received) = spawn_json_server(
             r#"{"content":[{"type":"text","text":"feat(core): invoke anthropic"}]}"#,
@@ -1311,6 +1510,53 @@ mod tests {
         assert!(requests[3].contains("GET /files/output_1/content HTTP/1.1"));
     }
 
+    #[tokio::test]
+    async fn xai_invoke_batch_creates_polls_and_downloads_results() {
+        let (endpoint, received) = spawn_xai_batch_server();
+        let transport =
+            AsyncTransport::new(Duration::from_secs(2), RetryPolicy::default()).unwrap();
+
+        let output = XaiClient::invoke_batch(
+            &transport,
+            &endpoint,
+            "xai-test",
+            "grok-4.3",
+            &[
+                OpenAiBatchJob {
+                    custom_id: "alpha.py".to_string(),
+                    messages: vec![ProviderMessage::user("prompt alpha")],
+                },
+                OpenAiBatchJob {
+                    custom_id: "beta.py".to_string(),
+                    messages: vec![ProviderMessage::user("prompt beta")],
+                },
+            ],
+            Duration::from_secs(2),
+            Duration::from_millis(5),
+        )
+        .await
+        .expect("xAI batch should complete");
+
+        assert_eq!(output.results.len(), 2);
+        assert!(output.failures.is_empty());
+        assert_eq!(output.results[0].custom_id, "alpha.py");
+        assert_eq!(output.results[0].content, "fix(alpha): batch alpha");
+        assert_eq!(output.results[1].custom_id, "beta.py");
+        assert_eq!(output.results[1].content, "fix(beta): batch beta");
+
+        let requests: Vec<String> = (0..4)
+            .map(|_| received.recv_timeout(Duration::from_secs(2)).unwrap())
+            .collect();
+        assert!(requests[0].contains("POST /batches HTTP/1.1"));
+        assert!(requests[0].contains("authorization: Bearer xai-test"));
+        assert!(requests[1].contains("POST /batches/batch_1/requests HTTP/1.1"));
+        assert!(requests[1].contains(r#""model":"grok-4.3""#));
+        assert!(requests[1].contains("prompt alpha"));
+        assert!(requests[1].contains("prompt beta"));
+        assert!(requests[2].contains("GET /batches/batch_1 HTTP/1.1"));
+        assert!(requests[3].contains("GET /batches/batch_1/results?limit=100 HTTP/1.1"));
+    }
+
     fn spawn_json_server(body: &'static str) -> (String, mpsc::Receiver<String>) {
         let listener = TcpListener::bind("127.0.0.1:0").expect("bind mock server");
         let endpoint = format!("http://{}", listener.local_addr().expect("local addr"));
@@ -1330,6 +1576,38 @@ mod tests {
             stream
                 .write_all(response.as_bytes())
                 .expect("write response");
+        });
+
+        (endpoint, receiver)
+    }
+
+    fn spawn_xai_batch_server() -> (String, mpsc::Receiver<String>) {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind mock server");
+        let endpoint = format!("http://{}", listener.local_addr().expect("local addr"));
+        let (sender, receiver) = mpsc::channel();
+
+        thread::spawn(move || {
+            let responses = [
+                r#"{"batch_id":"batch_1"}"#,
+                r#"{"status":"accepted"}"#,
+                r#"{"status":"completed","state":{"num_pending":0,"num_requests":2}}"#,
+                r#"{"results":[{"batch_request_id":"alpha.py","batch_result":{"response":{"chat_get_completion":{"choices":[{"message":{"content":"fix(alpha): batch alpha"}}]}}}},{"batch_request_id":"beta.py","batch_result":{"response":{"chat_get_completion":{"choices":[{"message":{"content":"fix(beta): batch beta"}}]}}}}]}"#,
+            ];
+            for body in responses {
+                let (mut stream, _) = listener.accept().expect("accept request");
+                let mut buffer = [0_u8; 16384];
+                let read = stream.read(&mut buffer).expect("read request");
+                let request = String::from_utf8_lossy(&buffer[..read]).to_string();
+                sender.send(request).expect("send captured request");
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+                    body.len(),
+                    body
+                );
+                stream
+                    .write_all(response.as_bytes())
+                    .expect("write response");
+            }
         });
 
         (endpoint, receiver)

--- a/tests/features/rust_workflow_parity.feature
+++ b/tests/features/rust_workflow_parity.feature
@@ -113,6 +113,12 @@ Feature: Rust workflow parity
     And only the valid batch file is committed
     And provider output and status remain secret-free
 
+  Scenario: Default xAI batch queues all file prompts before committing
+    Given a git repository with two changed tracked files and a mocked xAI batch provider
+    When the Rust kcmt command runs in default xAI batch mode
+    Then the xAI batch provider receives both file prompts before commits are written
+    And both files are committed with the batch provider messages
+
   Scenario: File workflow falls back to the next configured provider
     Given a git repository with one changed tracked file and a fallback provider chain
     When the Rust kcmt command commits the file using configured provider fallback

--- a/tests/test_rust_workflow_parity_bdd.py
+++ b/tests/test_rust_workflow_parity_bdd.py
@@ -347,6 +347,7 @@ def _rust_bin(binary: str) -> Path:
         [
             "cargo",
             "build",
+            "--locked",
             "--manifest-path",
             str(RUST_MANIFEST),
             "-p",

--- a/tests/test_rust_workflow_parity_bdd.py
+++ b/tests/test_rust_workflow_parity_bdd.py
@@ -149,6 +149,62 @@ def _start_partial_batch_provider() -> tuple[str, type[_BatchHandler], HTTPServe
     return f"http://127.0.0.1:{server.server_port}", Handler, server
 
 
+class _XaiBatchHandler(BaseHTTPRequestHandler):
+    requests: list[tuple[str, str, str]] = []
+
+    def _record(self) -> str:
+        length = int(self.headers.get("content-length", "0") or "0")
+        body = self.rfile.read(length).decode("utf-8", "ignore") if length else ""
+        self.__class__.requests.append((self.command, self.path, body))
+        return body
+
+    def _json(self, body: str) -> None:
+        payload = body.encode()
+        self.send_response(200)
+        self.send_header("content-type", "application/json")
+        self.send_header("content-length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def do_POST(self) -> None:  # noqa: N802
+        self._record()
+        if self.path == "/batches":
+            self._json('{"batch_id":"batch_1"}')
+        elif self.path == "/batches/batch_1/requests":
+            self._json('{"status":"accepted"}')
+        else:
+            self.send_error(404)
+
+    def do_GET(self) -> None:  # noqa: N802
+        self._record()
+        if self.path == "/batches/batch_1":
+            self._json(
+                '{"status":"completed","state":{"num_pending":0,"num_requests":2}}'
+            )
+        elif self.path == "/batches/batch_1/results?limit=100":
+            self._json(
+                '{"results":['
+                '{"batch_request_id":"alpha.py","batch_result":{"response":{"chat_get_completion":{"choices":[{"message":{"content":"fix(alpha): batch alpha."}}]}}}},'
+                '{"batch_request_id":"beta.py","batch_result":{"response":{"chat_get_completion":{"choices":[{"message":{"content":"fix(beta): batch beta."}}]}}}}'
+                "]}"
+            )
+        else:
+            self.send_error(404)
+
+    def log_message(self, format: str, *args: Any) -> None:  # noqa: A002
+        return
+
+
+def _start_xai_batch_provider() -> tuple[str, type[_XaiBatchHandler], HTTPServer]:
+    class Handler(_XaiBatchHandler):
+        requests: list[tuple[str, str, str]] = []
+
+    server = HTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return f"http://127.0.0.1:{server.server_port}", Handler, server
+
+
 class _FallbackHandler(BaseHTTPRequestHandler):
     requests: list[tuple[str, str, str]] = []
 
@@ -375,6 +431,21 @@ def git_repository_with_two_changed_files_and_partial_batch_provider(
     context["endpoint"] = endpoint
     context["batch_handler"] = handler
     context["batch_server"] = server
+    return context
+
+
+@given(
+    "a git repository with two changed tracked files and a mocked xAI batch provider",
+    target_fixture="workflow_context",
+)
+def git_repository_with_two_changed_files_and_mocked_xai_batch_provider(
+    tmp_path: Path,
+) -> dict[str, Any]:
+    context = git_repository_with_two_changed_tracked_files(tmp_path)
+    endpoint, handler, server = _start_xai_batch_provider()
+    context["xai_batch_endpoint"] = endpoint
+    context["xai_batch_handler"] = handler
+    context["xai_batch_server"] = server
     return context
 
 
@@ -816,6 +887,39 @@ def rust_kcmt_runs_in_default_batch_mode(workflow_context: dict[str, Any]) -> No
     )
     workflow_context["output"] = output
     workflow_context["batch_server"].shutdown()
+
+
+@when("the Rust kcmt command runs in default xAI batch mode")
+def rust_kcmt_runs_in_default_xai_batch_mode(
+    workflow_context: dict[str, Any],
+) -> None:
+    env = _clean_env(workflow_context["config_home"])
+    env["XAI_TEST_KEY"] = "test-key"
+    output = _run(
+        [
+            str(_rust_bin("kcmt")),
+            "--provider",
+            "xai",
+            "--endpoint",
+            workflow_context["xai_batch_endpoint"],
+            "--api-key-env",
+            "XAI_TEST_KEY",
+            "--model",
+            "grok-code-fast",
+            "--batch",
+            "--batch-model",
+            "grok-4.3",
+            "--batch-timeout",
+            "900",
+            "--no-auto-push",
+            "--repo-path",
+            str(workflow_context["repo"]),
+        ],
+        REPO_ROOT,
+        env=env,
+    )
+    workflow_context["output"] = output
+    workflow_context["xai_batch_server"].shutdown()
 
 
 @when("the Rust kcmt command commits the file using configured provider fallback")
@@ -1706,6 +1810,26 @@ def batch_provider_receives_both_file_prompts_before_commits_are_written(
     assert "beta.py" in upload_body
     assert "print('alpha updated')" in upload_body
     assert "print('beta updated')" in upload_body
+    assert all(request[1] != "/chat/completions" for request in requests)
+
+
+@then("the xAI batch provider receives both file prompts before commits are written")
+def xai_batch_provider_receives_both_file_prompts_before_commits_are_written(
+    workflow_context: dict[str, Any],
+) -> None:
+    requests = workflow_context["xai_batch_handler"].requests
+    assert [request[1] for request in requests] == [
+        "/batches",
+        "/batches/batch_1/requests",
+        "/batches/batch_1",
+        "/batches/batch_1/results?limit=100",
+    ]
+    requests_body = requests[1][2]
+    assert "alpha.py" in requests_body
+    assert "beta.py" in requests_body
+    assert "print('alpha updated')" in requests_body
+    assert "print('beta updated')" in requests_body
+    assert '"model":"grok-4.3"' in requests_body
     assert all(request[1] != "/chat/completions" for request in requests)
 
 


### PR DESCRIPTION
## Summary

Closes the Rust provider-support parity gap with executable provider contracts and BDD coverage across OpenAI, Anthropic/xAI selection behavior, xAI batch, fallback-safe provider mode gating, and max commit length enforcement.

PR #37 (`codex/rust-model-preferences-tui`) was inspected and confirmed merged into `main` on 2026-06-06, so this branch is based directly on current `origin/main` rather than stacked on PR #37.

## Conventional Commit Breakdown

| Commit | Type | Scope | Summary |
| --- | --- | --- | --- |
| `6cfdfc1` | feat | provider | add OpenAI responses contracts |
| `2d4d3c1` | fix | workflow | select provider modes consistently |
| `bd0bde6` | fix | bench | keep runtime benchmarks hermetic |
| `6cfe9f5` | test | workflow | cover provider mode contracts |
| `1032e59` | test | bdd | specify xAI batch provider parity |
| `43736d9` | test | bdd | implement xAI batch provider steps |

## Release Notes Draft

- Add Rust OpenAI Responses API support for responses-only Codex models while preserving chat-completions behavior for existing OpenAI-compatible models.
- Preserve provider-specific batch model selection when switching between OpenAI and xAI provider modes.
- Disable batch mode automatically for providers without batch support during workflow provider selection.
- Add executable xAI batch parity BDD coverage.
- Keep runtime benchmark contract tests hermetic by avoiding interactive keychain credential resolution.

## Behaviour Changes

- `gpt-5.1-codex*` OpenAI models use `/v1/responses` in Rust provider workflows.
- Selected provider modes now recalculate compatible batch models instead of leaking OpenAI batch defaults into xAI runs.
- Anthropic and GitHub Models provider selections no longer keep batch mode enabled from unrelated config state.
- Provider prompt generation continues to respect configured `max_commit_length`, including generated subject text.

## API / Schema / Contract Changes

No public CLI flag, config schema, or JSON contract changes are intended.

Provider HTTP contract coverage was expanded for:

- OpenAI chat and Responses API request/response handling
- xAI batch create, poll, and results handling
- Provider mode and batch gating behavior
- Max commit length prompt and subject constraints

## Testing Evidence

- `rtk cargo test --manifest-path rust/Cargo.toml -p kcmt-provider` passed: 22 tests.
- `rtk cargo test --manifest-path rust/Cargo.toml -p kcmt-cli --test workflow_modes` passed: 44 tests.
- `rtk uv run pytest tests/test_rust_workflow_parity_bdd.py -k "xAI and batch" --no-cov -q` passed: 1 selected BDD scenario, 32 deselected.
- `rtk timeout 180 cargo test --manifest-path rust/Cargo.toml -p kcmt-cli --test benchmark_contracts -- --nocapture --test-threads=1` passed: 6 tests.
- `rtk make check` passed.
- `rtk make quality-gates` passed.
- `rtk git diff --check` passed.
- `rtk make test-llm-matrix` was attempted but terminated manually after several minutes without a live matrix scoreboard; output showed the matrix test still running past 60 seconds.

## Risk and Rollback

Risk is concentrated in provider dispatch path selection for OpenAI responses-only models and batch-mode config normalization. Rollback is to revert this PR; existing OpenAI chat-completions, Anthropic, GitHub Models, and non-batch provider paths are covered by focused unit tests and workflow-mode contract tests.

## Operational Notes

- This PR is not stacked on PR #37 because #37 is already merged into `main`.
- Runtime benchmark tests now set `KCMT_DISABLE_KEYCHAIN=1` for child CLI invocations to avoid local keychain prompts during hermetic contract tests.
- Existing branch protection, review, and CI requirements should remain unchanged.

## Linked Work

- Related prior work: #37

## Reviewer Checklist

- [ ] Confirm OpenAI Responses API routing is limited to responses-only Codex model prefixes.
- [ ] Confirm xAI batch support uses xAI batch defaults and does not inherit OpenAI batch defaults.
- [ ] Confirm provider mode selection still preserves PR #37 preferences/selector behavior.
- [ ] Confirm BDD coverage captures user-visible xAI batch provider behavior.
