### PR TITLE
feat(credentials): prefer biometric keychain saves

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ PACKAGE_NAME = kcmt
 PYTHON = python3
 UV = uv
 PYTEST = $(UV) run pytest
+TEST_ENV = KCMT_DISABLE_KEYCHAIN=1
 PYPI_TOKEN ?=
 TEST_PYPI_TOKEN ?=
 TWINE_USER ?= __token__
@@ -69,25 +70,25 @@ ruff-fix:
 
 # Testing
 test:
-	$(PYTEST) -q
+	$(TEST_ENV) $(PYTEST) -q
 
 test-ink:
 	npm --prefix kcmt/ui/ink test
 
 test-rust:
-	cargo test --locked --manifest-path rust/Cargo.toml --workspace --no-fail-fast
+	$(TEST_ENV) cargo test --locked --manifest-path rust/Cargo.toml --workspace --no-fail-fast
 
 test-llm-matrix:
 	KCMT_LIVE_LLM_MATRIX=1 cargo test --locked --manifest-path rust/Cargo.toml -p kcmt-cli --test live_llm_matrix -- --ignored --nocapture
 
 test-verbose:
-	$(PYTEST) -v
+	$(TEST_ENV) $(PYTEST) -v
 
 test-strict:
-	$(PYTEST) -ra -vv -W default -W error::DeprecationWarning -W error::ResourceWarning --strict-config --strict-markers tests
+	$(TEST_ENV) $(PYTEST) -ra -vv -W default -W error::DeprecationWarning -W error::ResourceWarning --strict-config --strict-markers tests
 
 coverage:
-	$(PYTEST) --cov=$(PACKAGE_NAME) --cov-report=html --cov-report=term
+	$(TEST_ENV) $(PYTEST) --cov=$(PACKAGE_NAME) --cov-report=html --cov-report=term
 
 # Type checking
 typecheck:

--- a/README.md
+++ b/README.md
@@ -86,6 +86,15 @@ kcmt maintains a per-provider settings map in `~/.config/kcmt/config.json`. Each
 - `keychain_account`: OS keychain account reference; credential resolution is explicit CLI input, then OS keychain, then environment variable
 - `preferred_model`: your saved default model for that provider
 
+Use `--api-key-stdin --save-api-key` to save a provider key without putting it
+in shell history. kcmt stores the secret in the OS keychain and writes only the
+provider-specific account reference, such as `provider/anthropic/default`, to
+config. On macOS, saved keys prefer biometric-or-passcode keychain access
+control where available and fall back to normal keychain protection when the
+platform cannot apply that policy. Use `--no-biometric-keychain` to request the
+platform default policy explicitly. Linux builds keep using environment
+fallbacks until an OS keychain backend is added.
+
 Example (`~/.config/kcmt/config.json` excerpt):
 
 ```json
@@ -225,7 +234,7 @@ Additional LLM behaviour environment variables:
 - `KCMT_OPENAI_MINIMAL_PROMPT` – force minimal prompt style (adaptive toggle)
 - `KCMT_OPENAI_MAX_TOKENS` – max completion tokens for OpenAI-like providers
 - `KCMT_FAST_LOCAL_FOR_SMALL_DIFFS` – opt-in local conventional subject for tiny diffs (<=3 changed lines)
-- `KCMT_DISABLE_KEYCHAIN=1` – skip OS keychain lookup for hermetic CI/test runs
+- `KCMT_DISABLE_KEYCHAIN=1` – skip OS keychain lookup and saves for hermetic CI/test runs
 - `KLINGON_CMT_AUTO_PUSH=0|1` (disable or enable automatic `git push`; default is enabled)
 
 ## List models and pricing
@@ -251,6 +260,7 @@ messages, or secret values.
 ```shell
 kcmt stats --json --repo-path .
 printf '%s' "$ANTHROPIC_API_KEY" | kcmt --configure --provider anthropic --api-key-stdin --save-api-key
+printf '%s' "$ANTHROPIC_API_KEY" | kcmt --configure --provider anthropic --api-key-stdin --save-api-key --no-biometric-keychain
 ```
 
 ## Benchmarking

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1933,6 +1933,7 @@ dependencies = [
  "anyhow",
  "gix",
  "keyring",
+ "security-framework 3.7.0",
  "serde",
  "serde_json",
  "sha2",

--- a/rust/crates/kcmt-bench/src/runner.rs
+++ b/rust/crates/kcmt-bench/src/runner.rs
@@ -1119,6 +1119,7 @@ fn runtime_benchmark_env(config_home: &Path, runtime: RuntimeKind) -> Vec<(Strin
             "OPENAI_API_KEY".to_string(),
             "kcmt-runtime-benchmark".to_string(),
         ),
+        ("KCMT_DISABLE_KEYCHAIN".to_string(), "1".to_string()),
         ("KCMT_RUNTIME_BENCHMARK".to_string(), "1".to_string()),
         ("KCMT_ALLOW_LOCAL_SYNTHESIS".to_string(), "1".to_string()),
         (

--- a/rust/crates/kcmt-cli/src/args.rs
+++ b/rust/crates/kcmt-cli/src/args.rs
@@ -33,14 +33,26 @@ pub struct CliArgs {
     #[arg(long = "github-token")]
     pub github_token: Option<String>,
 
-    #[arg(long = "api-key")]
+    #[arg(
+        long = "api-key",
+        help = "API key to use for this invocation; prefer --api-key-stdin"
+    )]
     pub api_key: Option<String>,
 
-    #[arg(long = "save-api-key")]
+    #[arg(long = "save-api-key", help = "Save API key input to the OS keychain")]
     pub save_api_key: bool,
 
-    #[arg(long = "api-key-stdin")]
+    #[arg(
+        long = "api-key-stdin",
+        help = "Read API key from stdin instead of the shell history"
+    )]
     pub api_key_stdin: bool,
+
+    #[arg(
+        long = "no-biometric-keychain",
+        help = "Save API keys with the platform-default keychain policy instead of biometric-preferred macOS access control"
+    )]
+    pub no_biometric_keychain: bool,
 
     #[arg(long, alias = "summary")]
     pub compact: bool,

--- a/rust/crates/kcmt-cli/src/args.rs
+++ b/rust/crates/kcmt-cli/src/args.rs
@@ -328,6 +328,22 @@ mod tests {
     }
 
     #[test]
+    fn parses_biometric_keychain_opt_out_flag() {
+        let args = CliArgs::parse_from([
+            "kcmt",
+            "--configure",
+            "--api-key-stdin",
+            "--save-api-key",
+            "--no-biometric-keychain",
+        ]);
+
+        assert!(args.configure);
+        assert!(args.api_key_stdin);
+        assert!(args.save_api_key);
+        assert!(args.no_biometric_keychain);
+    }
+
+    #[test]
     fn parses_legacy_non_tui_control_flags() {
         let args = CliArgs::parse_from([
             "kcmt",

--- a/rust/crates/kcmt-cli/src/lib.rs
+++ b/rust/crates/kcmt-cli/src/lib.rs
@@ -10,7 +10,10 @@ use std::time::Instant;
 
 use kcmt_core::config::loader::ConfigOverrides;
 use kcmt_core::git::repo::find_git_repo_root;
-use kcmt_core::preferences::{default_keychain_account, OsKeychainStore, SecretStore};
+use kcmt_core::preferences::{
+    default_keychain_account, save_keychain_secret, KeychainProtection, KeychainSaveMode,
+    OsKeychainStore,
+};
 
 use args::{CliArgs, CliCommand, StatusArgs};
 use commands::configure::ConfigureMode;
@@ -135,11 +138,31 @@ fn dispatch(_entrypoint: &str, args: CliArgs, arg_parse_ms: f64) -> i32 {
             };
             let provider = args.provider.as_deref().unwrap_or("openai");
             let account = default_keychain_account(provider);
-            if let Err(err) = OsKeychainStore.set_secret(&account, api_key) {
-                eprintln!("failed to save API key to OS keychain: {err}");
-                return 1;
+            let mode = if args.no_biometric_keychain {
+                KeychainSaveMode::PlatformDefault
+            } else {
+                KeychainSaveMode::BiometricPreferred
+            };
+            let save_result = match save_keychain_secret(&OsKeychainStore, &account, api_key, mode)
+            {
+                Ok(result) => result,
+                Err(err) => {
+                    eprintln!("failed to save API key to OS keychain: {err}");
+                    return 1;
+                }
+            };
+            let protection = match save_result.protection {
+                KeychainProtection::BiometricPreferred => {
+                    "biometric authentication preferred where supported"
+                }
+                KeychainProtection::PlatformDefault => "platform-default keychain protection",
+            };
+            println!(
+                "Saved {provider} credentials to OS keychain account {account} ({protection})"
+            );
+            if let Some(reason) = save_result.fallback_reason {
+                eprintln!("biometric-preferred keychain save unavailable; used platform default: {reason}");
             }
-            println!("Saved {provider} credentials to OS keychain account {account}");
         }
         let mode = if args.configure_all {
             ConfigureMode::All

--- a/rust/crates/kcmt-cli/tests/configure_contracts.rs
+++ b/rust/crates/kcmt-cli/tests/configure_contracts.rs
@@ -1,6 +1,7 @@
 use std::fs;
+use std::io::Write;
 use std::path::PathBuf;
-use std::process::Command;
+use std::process::{Command, Stdio};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -72,8 +73,14 @@ fn configure_writes_python_compatible_config_file() {
         config["providers"]["anthropic"]["api_key_env"],
         "ANTHROPIC_TEST_KEY"
     );
+    assert_eq!(
+        config["providers"]["anthropic"]["keychain_account"],
+        "provider/anthropic/default"
+    );
     assert_eq!(config["model_priority"][0]["provider"], "anthropic");
     assert_eq!(config["model_priority"][0]["model"], "claude-test");
+    let rendered = serde_json::to_string(&config).expect("config serializes");
+    assert!(!rendered.contains("secret"));
 }
 
 #[test]
@@ -432,4 +439,44 @@ fn verify_keys_prints_provider_env_presence() {
     assert!(stdout.contains("anthropic\tANTHROPIC_API_KEY\tno\t-"));
     assert!(stdout.contains("xai\tXAI_API_KEY\tno\t-"));
     assert!(stdout.contains("github\tGITHUB_TOKEN\tno\t-"));
+}
+
+#[test]
+fn save_api_key_respects_disabled_keychain_without_printing_secret() {
+    let config_home = unique_temp_dir("home");
+    let repo = unique_temp_dir("repo");
+    let secret = "linux-unavailable-secret";
+
+    let mut child = kcmt_command()
+        .env("KCMT_CONFIG_HOME", &config_home)
+        .args([
+            "--configure",
+            "--provider",
+            "anthropic",
+            "--api-key-stdin",
+            "--save-api-key",
+            "--repo-path",
+        ])
+        .arg(&repo)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("kcmt configure should spawn");
+    child
+        .stdin
+        .as_mut()
+        .expect("stdin")
+        .write_all(secret.as_bytes())
+        .expect("secret written");
+    let output = child
+        .wait_with_output()
+        .expect("kcmt configure should exit");
+
+    assert!(!output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("OS keychain access is disabled by KCMT_DISABLE_KEYCHAIN"));
+    assert!(!stdout.contains(secret));
+    assert!(!stderr.contains(secret));
 }

--- a/rust/crates/kcmt-cli/tests/workflow_modes.rs
+++ b/rust/crates/kcmt-cli/tests/workflow_modes.rs
@@ -156,13 +156,22 @@ fn spawn_provider_responses(
                 }
             };
             stream
-                .set_nonblocking(false)
-                .expect("mock provider stream should become blocking");
-            stream
-                .set_read_timeout(Some(Duration::from_secs(5)))
-                .expect("mock provider stream should have read timeout");
+                .set_nonblocking(true)
+                .expect("mock provider stream should become nonblocking");
             let mut buffer = [0_u8; 32768];
-            let bytes = stream.read(&mut buffer).expect("mock provider read");
+            let deadline = std::time::Instant::now() + Duration::from_secs(10);
+            let bytes = loop {
+                match stream.read(&mut buffer) {
+                    Ok(bytes) => break bytes,
+                    Err(err) if err.kind() == ErrorKind::WouldBlock => {
+                        if std::time::Instant::now() >= deadline {
+                            panic!("mock provider read timed out");
+                        }
+                        thread::sleep(Duration::from_millis(10));
+                    }
+                    Err(err) => panic!("mock provider read failed: {err}"),
+                }
+            };
             sender
                 .send(String::from_utf8_lossy(&buffer[..bytes]).to_string())
                 .expect("request should be recorded");

--- a/rust/crates/kcmt-core/Cargo.toml
+++ b/rust/crates/kcmt-core/Cargo.toml
@@ -21,6 +21,7 @@ tracing.workspace = true
 
 [target.'cfg(target_os = "macos")'.dependencies]
 keyring = { version = "3.6", features = ["apple-native"] }
+security-framework = "3.7"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 keyring = { version = "3.6", features = ["windows-native"] }

--- a/rust/crates/kcmt-core/src/preferences.rs
+++ b/rust/crates/kcmt-core/src/preferences.rs
@@ -174,9 +174,61 @@ pub enum CredentialSource {
     Environment,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KeychainSaveMode {
+    PlatformDefault,
+    BiometricPreferred,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KeychainProtection {
+    PlatformDefault,
+    BiometricPreferred,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SecretSaveResult {
+    pub protection: KeychainProtection,
+    pub fallback_reason: Option<String>,
+}
+
+impl SecretSaveResult {
+    fn platform_default() -> Self {
+        Self {
+            protection: KeychainProtection::PlatformDefault,
+            fallback_reason: None,
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    fn biometric_preferred() -> Self {
+        Self {
+            protection: KeychainProtection::BiometricPreferred,
+            fallback_reason: None,
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    fn biometric_fallback(reason: String) -> Self {
+        Self {
+            protection: KeychainProtection::PlatformDefault,
+            fallback_reason: Some(reason),
+        }
+    }
+}
+
 pub trait SecretStore {
     fn get_secret(&self, account: &str) -> std::result::Result<Option<String>, String>;
     fn set_secret(&self, account: &str, secret: &str) -> std::result::Result<(), String>;
+    fn set_secret_with_mode(
+        &self,
+        account: &str,
+        secret: &str,
+        _mode: KeychainSaveMode,
+    ) -> std::result::Result<SecretSaveResult, String> {
+        self.set_secret(account, secret)
+            .map(|()| SecretSaveResult::platform_default())
+    }
 }
 
 #[derive(Debug, Clone, Copy, Default)]
@@ -199,6 +251,23 @@ impl SecretStore for OsKeychainStore {
         let entry =
             keyring::Entry::new(KEYCHAIN_SERVICE, account).map_err(|err| err.to_string())?;
         entry.set_password(secret).map_err(|err| err.to_string())
+    }
+
+    fn set_secret_with_mode(
+        &self,
+        account: &str,
+        secret: &str,
+        mode: KeychainSaveMode,
+    ) -> std::result::Result<SecretSaveResult, String> {
+        match mode {
+            KeychainSaveMode::PlatformDefault => {
+                self.set_secret(account, secret)?;
+                Ok(SecretSaveResult::platform_default())
+            }
+            KeychainSaveMode::BiometricPreferred => {
+                self.set_secret_biometric_preferred(account, secret)
+            }
+        }
     }
 }
 
@@ -290,8 +359,24 @@ pub fn resolve_credential(
     Ok(None)
 }
 
+pub fn save_keychain_secret(
+    store: &dyn SecretStore,
+    account: &str,
+    secret: &str,
+    mode: KeychainSaveMode,
+) -> std::result::Result<SecretSaveResult, String> {
+    if keychain_disabled() {
+        return Err("OS keychain access is disabled by KCMT_DISABLE_KEYCHAIN".to_string());
+    }
+    store.set_secret_with_mode(account, secret, mode)
+}
+
 fn keychain_disabled() -> bool {
-    env::var("KCMT_DISABLE_KEYCHAIN")
+    env_truthy("KCMT_DISABLE_KEYCHAIN") || env_truthy("KCMT_RUNTIME_BENCHMARK")
+}
+
+fn env_truthy(key: &str) -> bool {
+    env::var(key)
         .ok()
         .map(|value| {
             let normalized = value.trim().to_ascii_lowercase();
@@ -304,10 +389,79 @@ pub fn default_keychain_account(provider: &str) -> String {
     format!("provider/{provider}/default")
 }
 
+#[cfg(target_os = "macos")]
+impl OsKeychainStore {
+    fn set_secret_biometric_preferred(
+        &self,
+        account: &str,
+        secret: &str,
+    ) -> std::result::Result<SecretSaveResult, String> {
+        match set_macos_biometric_secret(account, secret) {
+            Ok(()) => Ok(SecretSaveResult::biometric_preferred()),
+            Err(err) => {
+                self.set_secret(account, secret)?;
+                Ok(SecretSaveResult::biometric_fallback(err))
+            }
+        }
+    }
+}
+
+#[cfg(target_os = "windows")]
+impl OsKeychainStore {
+    fn set_secret_biometric_preferred(
+        &self,
+        account: &str,
+        secret: &str,
+    ) -> std::result::Result<SecretSaveResult, String> {
+        self.set_secret(account, secret)?;
+        Ok(SecretSaveResult::platform_default())
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn set_macos_biometric_secret(account: &str, secret: &str) -> std::result::Result<(), String> {
+    use security_framework::access_control::{ProtectionMode, SecAccessControl};
+    use security_framework::passwords::{
+        delete_generic_password, set_generic_password_options, AccessControlOptions,
+        PasswordOptions,
+    };
+
+    const ERR_SEC_ITEM_NOT_FOUND: i32 = -25300;
+
+    fn biometric_access_control() -> security_framework::base::Result<SecAccessControl> {
+        SecAccessControl::create_with_protection(
+            Some(ProtectionMode::AccessibleWhenUnlockedThisDeviceOnly),
+            (AccessControlOptions::BIOMETRY_ANY
+                | AccessControlOptions::OR
+                | AccessControlOptions::DEVICE_PASSCODE)
+                .bits(),
+        )
+    }
+
+    fn add_biometric_secret(
+        account: &str,
+        secret: &str,
+        access_control: SecAccessControl,
+    ) -> security_framework::base::Result<()> {
+        let mut options = PasswordOptions::new_generic_password(KEYCHAIN_SERVICE, account);
+        options.set_access_control(access_control);
+        set_generic_password_options(secret.as_bytes(), options)
+    }
+
+    let access_control = biometric_access_control().map_err(|err| err.to_string())?;
+    match delete_generic_password(KEYCHAIN_SERVICE, account) {
+        Ok(()) => {}
+        Err(err) if err.code() == ERR_SEC_ITEM_NOT_FOUND => {}
+        Err(err) => return Err(err.to_string()),
+    }
+    add_biometric_secret(account, secret, access_control).map_err(|err| err.to_string())
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
-        resolve_credential, CredentialRequest, CredentialSource, Preferences, SecretStore,
+        resolve_credential, save_keychain_secret, CredentialRequest, CredentialSource,
+        KeychainProtection, KeychainSaveMode, Preferences, SecretSaveResult, SecretStore,
     };
     use std::collections::BTreeMap;
     use std::sync::{Mutex, OnceLock};
@@ -324,6 +478,40 @@ mod tests {
 
         fn set_secret(&self, _account: &str, _secret: &str) -> std::result::Result<(), String> {
             Ok(())
+        }
+    }
+
+    #[derive(Default)]
+    struct CapturingStore {
+        modes: Mutex<Vec<KeychainSaveMode>>,
+    }
+
+    impl SecretStore for CapturingStore {
+        fn get_secret(&self, _account: &str) -> std::result::Result<Option<String>, String> {
+            Ok(None)
+        }
+
+        fn set_secret(&self, _account: &str, _secret: &str) -> std::result::Result<(), String> {
+            Ok(())
+        }
+
+        fn set_secret_with_mode(
+            &self,
+            _account: &str,
+            _secret: &str,
+            mode: KeychainSaveMode,
+        ) -> std::result::Result<SecretSaveResult, String> {
+            self.modes
+                .lock()
+                .unwrap_or_else(|err| err.into_inner())
+                .push(mode);
+            Ok(SecretSaveResult {
+                protection: match mode {
+                    KeychainSaveMode::PlatformDefault => KeychainProtection::PlatformDefault,
+                    KeychainSaveMode::BiometricPreferred => KeychainProtection::BiometricPreferred,
+                },
+                fallback_reason: None,
+            })
         }
     }
 
@@ -411,6 +599,117 @@ mod tests {
         assert_eq!(credential.source, CredentialSource::Environment);
         assert_eq!(credential.secret, "env-secret");
         std::env::remove_var("KCMT_TEST_API_KEY");
+        std::env::remove_var("KCMT_DISABLE_KEYCHAIN");
+    }
+
+    #[test]
+    fn credential_resolution_skips_keychain_in_runtime_benchmark_mode() {
+        let _guard = env_lock().lock().unwrap_or_else(|err| err.into_inner());
+        std::env::remove_var("KCMT_DISABLE_KEYCHAIN");
+        std::env::set_var("KCMT_RUNTIME_BENCHMARK", "1");
+        std::env::set_var("KCMT_TEST_API_KEY", "env-secret");
+        let mut store = FakeStore::default();
+        store.secrets.insert(
+            "provider/openai/default".to_string(),
+            "keychain-secret".to_string(),
+        );
+        let request = CredentialRequest {
+            provider: "openai".to_string(),
+            explicit_secret: None,
+            keychain_account: None,
+            env_var: "KCMT_TEST_API_KEY".to_string(),
+        };
+
+        let credential = resolve_credential(&request, &store)
+            .expect("credential")
+            .expect("present");
+
+        assert_eq!(credential.source, CredentialSource::Environment);
+        assert_eq!(credential.secret, "env-secret");
+        std::env::remove_var("KCMT_TEST_API_KEY");
+        std::env::remove_var("KCMT_RUNTIME_BENCHMARK");
+    }
+
+    #[test]
+    fn credential_resolution_uses_configured_keychain_account() {
+        let _guard = env_lock().lock().unwrap_or_else(|err| err.into_inner());
+        std::env::remove_var("KCMT_DISABLE_KEYCHAIN");
+        std::env::remove_var("KCMT_TEST_API_KEY");
+        let mut store = FakeStore::default();
+        store
+            .secrets
+            .insert("custom/account".to_string(), "custom-secret".to_string());
+        let request = CredentialRequest {
+            provider: "openai".to_string(),
+            explicit_secret: None,
+            keychain_account: Some("custom/account".to_string()),
+            env_var: "KCMT_TEST_API_KEY".to_string(),
+        };
+
+        let credential = resolve_credential(&request, &store)
+            .expect("credential")
+            .expect("present");
+
+        assert_eq!(credential.source, CredentialSource::Keychain);
+        assert_eq!(credential.secret, "custom-secret");
+    }
+
+    #[test]
+    fn default_keychain_save_mode_uses_platform_protection() {
+        let _guard = env_lock().lock().unwrap_or_else(|err| err.into_inner());
+        std::env::remove_var("KCMT_DISABLE_KEYCHAIN");
+        let store = FakeStore::default();
+
+        let result = save_keychain_secret(
+            &store,
+            "provider/openai/default",
+            "secret-value",
+            KeychainSaveMode::PlatformDefault,
+        )
+        .expect("saved");
+
+        assert_eq!(result.protection, KeychainProtection::PlatformDefault);
+        assert!(result.fallback_reason.is_none());
+    }
+
+    #[test]
+    fn keychain_save_can_request_biometric_preferred_protection() {
+        let _guard = env_lock().lock().unwrap_or_else(|err| err.into_inner());
+        std::env::remove_var("KCMT_DISABLE_KEYCHAIN");
+        let store = CapturingStore::default();
+
+        let result = save_keychain_secret(
+            &store,
+            "provider/openai/default",
+            "secret-value",
+            KeychainSaveMode::BiometricPreferred,
+        )
+        .expect("saved");
+
+        assert_eq!(result.protection, KeychainProtection::BiometricPreferred);
+        assert_eq!(
+            store.modes.lock().unwrap_or_else(|err| err.into_inner())[0],
+            KeychainSaveMode::BiometricPreferred
+        );
+    }
+
+    #[test]
+    fn keychain_save_respects_disabled_keychain_flag() {
+        let _guard = env_lock().lock().unwrap_or_else(|err| err.into_inner());
+        std::env::set_var("KCMT_DISABLE_KEYCHAIN", "1");
+        let store = CapturingStore::default();
+
+        let result = save_keychain_secret(
+            &store,
+            "provider/openai/default",
+            "secret-value",
+            KeychainSaveMode::BiometricPreferred,
+        );
+
+        assert_eq!(
+            result.expect_err("save should be disabled"),
+            "OS keychain access is disabled by KCMT_DISABLE_KEYCHAIN"
+        );
         std::env::remove_var("KCMT_DISABLE_KEYCHAIN");
     }
 }

--- a/rust/crates/kcmt-core/src/preferences.rs
+++ b/rust/crates/kcmt-core/src/preferences.rs
@@ -365,14 +365,24 @@ pub fn save_keychain_secret(
     secret: &str,
     mode: KeychainSaveMode,
 ) -> std::result::Result<SecretSaveResult, String> {
-    if keychain_disabled() {
-        return Err("OS keychain access is disabled by KCMT_DISABLE_KEYCHAIN".to_string());
+    if let Some(reason) = keychain_disabled_reason() {
+        return Err(reason.to_string());
     }
     store.set_secret_with_mode(account, secret, mode)
 }
 
 fn keychain_disabled() -> bool {
-    env_truthy("KCMT_DISABLE_KEYCHAIN") || env_truthy("KCMT_RUNTIME_BENCHMARK")
+    keychain_disabled_reason().is_some()
+}
+
+fn keychain_disabled_reason() -> Option<&'static str> {
+    if env_truthy("KCMT_DISABLE_KEYCHAIN") {
+        return Some("OS keychain access is disabled by KCMT_DISABLE_KEYCHAIN");
+    }
+    if env_truthy("KCMT_RUNTIME_BENCHMARK") {
+        return Some("OS keychain access is disabled during KCMT_RUNTIME_BENCHMARK");
+    }
+    None
 }
 
 fn env_truthy(key: &str) -> bool {
@@ -711,5 +721,26 @@ mod tests {
             "OS keychain access is disabled by KCMT_DISABLE_KEYCHAIN"
         );
         std::env::remove_var("KCMT_DISABLE_KEYCHAIN");
+    }
+
+    #[test]
+    fn keychain_save_reports_runtime_benchmark_disable_reason() {
+        let _guard = env_lock().lock().unwrap_or_else(|err| err.into_inner());
+        std::env::remove_var("KCMT_DISABLE_KEYCHAIN");
+        std::env::set_var("KCMT_RUNTIME_BENCHMARK", "1");
+        let store = CapturingStore::default();
+
+        let result = save_keychain_secret(
+            &store,
+            "provider/openai/default",
+            "secret-value",
+            KeychainSaveMode::BiometricPreferred,
+        );
+
+        assert_eq!(
+            result.expect_err("save should be disabled"),
+            "OS keychain access is disabled during KCMT_RUNTIME_BENCHMARK"
+        );
+        std::env::remove_var("KCMT_RUNTIME_BENCHMARK");
     }
 }

--- a/tests/features/rust_workflow_parity.feature
+++ b/tests/features/rust_workflow_parity.feature
@@ -182,6 +182,12 @@ Feature: Rust workflow parity
     And the Rust configuration file contains the Anthropic configure-all provider settings
     And the Rust preferences file contains default selector preferences
 
+  Scenario: Rust configure keeps saved credential input secret-free
+    Given an empty runtime configuration home
+    When the Rust kcmt command tries to save an Anthropic API key from stdin
+    Then the keychain save response does not print the API key
+    And no saved configuration file contains the API key
+
   Scenario: Anthropic latest Haiku rule selects the Haiku model
     Given a git repository with one changed tracked file and Anthropic latest Haiku preferences
     When the Rust kcmt command commits the file with Anthropic preferences

--- a/tests/test_rust_workflow_parity_bdd.py
+++ b/tests/test_rust_workflow_parity_bdd.py
@@ -1269,6 +1269,36 @@ def rust_kcmt_configures_all_providers_with_anthropic_overrides(
     )
     workflow_context["output"] = output
 
+@when("the Rust kcmt command tries to save an Anthropic API key from stdin")
+def rust_kcmt_tries_to_save_anthropic_api_key_from_stdin(
+    workflow_context: dict[str, Any],
+) -> None:
+    env = _clean_env(workflow_context["config_home"])
+    secret = "bdd-anthropic-secret"
+    result = subprocess.run(
+        [
+            str(_rust_bin("kcmt")),
+            "--configure",
+            "--provider",
+            "anthropic",
+            "--api-key-stdin",
+            "--save-api-key",
+            "--repo-path",
+            str(workflow_context["repo"]),
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        input=secret,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=False,
+    )
+    workflow_context["secret"] = secret
+    workflow_context["output"] = result.stdout
+    workflow_context["stderr"] = result.stderr
+    workflow_context["returncode"] = result.returncode
+
 
 @when("the Rust kcmt command commits the file with Anthropic preferences")
 def rust_kcmt_commits_file_with_anthropic_preferences(
@@ -2219,6 +2249,28 @@ def rust_preferences_file_contains_default_selector_preferences(
     assert preferences["provider_rules"]["anthropic"]["preset"] == "none"
     assert preferences["provider_rules"]["xai"]["preset"] == "none"
     assert preferences["provider_rules"]["github"]["preset"] == "none"
+
+
+@then("the keychain save response does not print the API key")
+def keychain_save_response_does_not_print_api_key(
+    workflow_context: dict[str, Any],
+) -> None:
+    combined = workflow_context.get("output", "") + workflow_context.get("stderr", "")
+    assert workflow_context["secret"] not in combined
+    assert workflow_context["returncode"] == 1
+    assert "OS keychain access is disabled by KCMT_DISABLE_KEYCHAIN" in combined
+
+
+@then("no saved configuration file contains the API key")
+def no_saved_configuration_file_contains_api_key(
+    workflow_context: dict[str, Any],
+) -> None:
+    config_home = workflow_context["config_home"]
+    if not config_home.exists():
+        return
+    for path in config_home.rglob("*"):
+        if path.is_file():
+            assert workflow_context["secret"] not in path.read_text(errors="ignore")
 
 
 @then("the Anthropic provider receives the latest Haiku model")

--- a/tests/test_rust_workflow_parity_bdd.py
+++ b/tests/test_rust_workflow_parity_bdd.py
@@ -1269,6 +1269,7 @@ def rust_kcmt_configures_all_providers_with_anthropic_overrides(
     )
     workflow_context["output"] = output
 
+
 @when("the Rust kcmt command tries to save an Anthropic API key from stdin")
 def rust_kcmt_tries_to_save_anthropic_api_key_from_stdin(
     workflow_context: dict[str, Any],


### PR DESCRIPTION
## Summary

- Adds Rust keychain save modes so `kcmt --configure --save-api-key` prefers macOS biometric-or-passcode keychain access control where supported.
- Preserves credential precedence from merged PR #37: explicit CLI/stdin input, then OS keychain, then environment fallback.
- Keeps config secret-free by storing provider-specific keychain account references only.
- Makes `make check` and `make quality-gates` force `KCMT_DISABLE_KEYCHAIN=1` so test gates never prompt the real OS keychain.

## Conventional Commit Breakdown

| Commit | Type | Scope | Summary |
|---|---|---|---|
| `933f488` | `feat` | `credentials` | prefer biometric keychain saves |
| `bb0d8b9` | `fix` | `credentials` | clarify keychain disable modes |

## Release Notes Draft

- `kcmt --configure --save-api-key` now prefers biometric-or-passcode protected keychain storage on macOS.
- `--no-biometric-keychain` opts back into platform-default keychain save behavior.
- CI and local quality gates now disable real OS keychain access to avoid interactive prompts.

## Behaviour Changes

- macOS keychain saves attempt access-control protection first, then fall back to the existing platform-default keychain write with a user-facing warning when biometric-preferred protection is unavailable.
- Runtime benchmark and test gate paths bypass OS keychain lookups and saves, using configured environment credentials instead.
- `KCMT_DISABLE_KEYCHAIN=1` now disables keychain lookup and saves.
- Linux behavior remains environment-fallback only until an OS keychain backend is added.

## API / Schema / Contract Changes

- Adds CLI flag: `--no-biometric-keychain`.
- Extends Rust credential internals with keychain save modes and save result metadata.
- No config schema secret storage is added; provider configs continue to store `keychain_account` references only.

## Testing Evidence

- `rtk cargo test --manifest-path rust/Cargo.toml -p kcmt-core preferences` -> 9 passed, 46 filtered.
- `rtk cargo test --manifest-path rust/Cargo.toml -p kcmt-cli args::tests::parses_biometric_keychain_opt_out_flag` -> 1 passed.
- `rtk cargo test --manifest-path rust/Cargo.toml -p kcmt-cli --test configure_contracts save_api_key_respects_disabled_keychain_without_printing_secret` -> 1 passed.
- `rtk cargo test --manifest-path rust/Cargo.toml -p kcmt-cli --test benchmark_contracts` -> 6 passed.
- `rtk cargo test --manifest-path rust/Cargo.toml -p kcmt-cli --test workflow_modes` -> 42 passed.
- `rtk uv run pytest -q tests/test_rust_workflow_parity_bdd.py -k "credential and secret" --no-cov` -> 1 passed, 32 deselected.
- `rtk make check` -> passed with `KCMT_DISABLE_KEYCHAIN=1` in Python/Rust test targets.

## Coverage Evidence

- `rtk make quality-gates` -> passed.
- Coverage threshold reached: 93.88% total coverage, required 80%.

## Quality Gate Evidence

- `rtk make quality-gates` reran lint, formatting, mypy, strict Python tests, Rust workspace tests, doc tests, Ink tests, and coverage with keychain access disabled for test commands.

## Demo Evidence

- BDD scenario added: `Rust configure keeps saved credential input secret-free`.
- Contract test added for `--api-key-stdin --save-api-key` with `KCMT_DISABLE_KEYCHAIN=1`, verifying the secret is not printed.

## Versioning / SemVer Impact

- Minor: adds a CLI option and improves credential save behavior without removing existing contracts.

## Risk and Rollback

- Risk: macOS protected save deletes and recreates the target keychain item only after access-control creation succeeds; fallback writes use the previous platform-default keychain behavior and report fallback on stderr.
- Rollback: revert this PR to restore PR #37 keychain save behavior and previous Makefile test environment.

## Operational Notes

- Use `printf '%s' "$ANTHROPIC_API_KEY" | kcmt --configure --provider anthropic --api-key-stdin --save-api-key` to avoid shell history.
- Use `--no-biometric-keychain` when platform-default keychain behavior is required.
- Test and quality-gate commands intentionally disable real keychain access to prevent user interaction.

## Linked Work

- Builds on merged PR #37: https://github.com/djh00t/kcmt/pull/37

## Reviewer Checklist

- [ ] Confirm credential precedence remains explicit input, OS keychain, environment fallback.
- [ ] Confirm config stores keychain account references only.
- [ ] Confirm macOS biometric-preferred behavior degrades cleanly when unavailable.
- [ ] Confirm test gates cannot prompt the real OS keychain.
- [ ] Confirm no secrets are logged, stored in config, snapshots, docs, or PR content.

## Adversarial Review Result

- PASS_WITH_FOLLOWUPS: local adversarial review found no merge blocker after tightening macOS migration order and making test gates hermetic for OS keychain access.
