### PR TITLE
feat(rust): normalize model discovery catalog

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1787,6 +1787,7 @@ dependencies = [
  "kcmt-core",
  "kcmt-provider",
  "kcmt-tui",
+ "serde",
  "serde_json",
  "sha2",
  "tokio",

--- a/rust/crates/kcmt-cli/Cargo.toml
+++ b/rust/crates/kcmt-cli/Cargo.toml
@@ -28,6 +28,7 @@ kcmt-bench = { path = "../kcmt-bench" }
 kcmt-core = { path = "../kcmt-core" }
 kcmt-provider = { path = "../kcmt-provider" }
 kcmt-tui = { path = "../kcmt-tui" }
+serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 tokio.workspace = true

--- a/rust/crates/kcmt-cli/src/commands/configure.rs
+++ b/rust/crates/kcmt-cli/src/commands/configure.rs
@@ -1,48 +1,13 @@
 use std::collections::HashMap;
 use std::fs;
 use std::path::PathBuf;
-use std::time::Duration;
 
 use kcmt_core::config::loader::{config_file_path, load_config, ConfigOverrides};
 use kcmt_core::model::{ModelPreference, ProviderConfigEntry};
-use kcmt_core::preferences::{
-    default_keychain_account, load_preferences, resolve_credential, save_preferences,
-    CredentialRequest, OsKeychainStore,
-};
-use kcmt_provider::clients::{AnthropicClient, GitHubModelsClient, OpenAiClient, XaiClient};
-use kcmt_provider::transport::{AsyncTransport, RetryPolicy};
+use kcmt_core::preferences::{load_preferences, save_preferences};
 use serde_json::json;
 
-const PROVIDERS: &[(&str, &str, &str, &str, &str)] = &[
-    (
-        "openai",
-        "OpenAI",
-        "gpt-5-mini-2025-08-07",
-        "https://api.openai.com/v1",
-        "OPENAI_API_KEY",
-    ),
-    (
-        "anthropic",
-        "Anthropic",
-        "claude-3-5-haiku-latest",
-        "https://api.anthropic.com",
-        "ANTHROPIC_API_KEY",
-    ),
-    (
-        "xai",
-        "X.AI",
-        "grok-code-fast",
-        "https://api.x.ai/v1",
-        "XAI_API_KEY",
-    ),
-    (
-        "github",
-        "GitHub Models",
-        "openai/gpt-4.1-mini",
-        "https://models.github.ai/inference",
-        "GITHUB_TOKEN",
-    ),
-];
+use super::model_discovery::{default_provider_definitions, discover_model_catalog};
 
 pub fn run_configure(repo_path: PathBuf, overrides: ConfigOverrides) -> i32 {
     match write_config(repo_path, overrides) {
@@ -58,27 +23,10 @@ pub fn run_configure(repo_path: PathBuf, overrides: ConfigOverrides) -> i32 {
 }
 
 pub fn run_list_models(debug: bool) -> i32 {
-    let provider_models = resolved_provider_models();
+    let preferences = load_preferences().unwrap_or_default();
+    let catalog = discover_model_catalog(&preferences);
     if debug {
-        let payload = PROVIDERS
-            .iter()
-            .map(|(provider, name, model, endpoint, api_key_env)| {
-                let models = provider_models
-                    .get(*provider)
-                    .cloned()
-                    .unwrap_or_else(|| vec![(*model).to_string()]);
-                json!({
-                    "provider": provider,
-                    "display_name": name,
-                    "models": models.into_iter().map(|model_id| json!({
-                        "id": model_id,
-                        "endpoint": endpoint,
-                        "api_key_env": api_key_env
-                    })).collect::<Vec<_>>()
-                })
-            })
-            .collect::<Vec<_>>();
-        match serde_json::to_string_pretty(&payload) {
+        match serde_json::to_string_pretty(&catalog) {
             Ok(rendered) => println!("{rendered}"),
             Err(err) => {
                 eprintln!("{err}");
@@ -88,87 +36,31 @@ pub fn run_list_models(debug: bool) -> i32 {
         return 0;
     }
 
-    for (provider, _name, model, endpoint, _api_key_env) in PROVIDERS {
-        let models = provider_models
-            .get(*provider)
-            .cloned()
-            .unwrap_or_else(|| vec![(*model).to_string()]);
-        for model in models {
-            println!("{provider}\t{model}\t{endpoint}");
+    for provider in catalog {
+        for model in provider.models {
+            println!("{}\t{}\t{}", provider.provider, model.id, provider.endpoint);
         }
     }
     0
 }
 
-fn resolved_provider_models() -> HashMap<String, Vec<String>> {
-    PROVIDERS
-        .iter()
-        .map(|(provider, _name, model, endpoint, api_key_env)| {
-            let models = live_models_for_provider(provider, endpoint, api_key_env)
-                .filter(|models| !models.is_empty())
-                .unwrap_or_else(|| vec![(*model).to_string()]);
-            ((*provider).to_string(), models)
-        })
-        .collect()
-}
-
-fn live_models_for_provider(
-    provider: &str,
-    endpoint: &str,
-    api_key_env: &str,
-) -> Option<Vec<String>> {
-    let explicit_provider = std::env::var("KCMT_EXPLICIT_API_KEY_PROVIDER").ok();
-    let explicit_secret = if explicit_provider.as_deref().unwrap_or(provider) == provider {
-        std::env::var("KCMT_EXPLICIT_API_KEY").ok()
-    } else {
-        None
-    };
-    let request = CredentialRequest {
-        provider: provider.to_string(),
-        explicit_secret,
-        keychain_account: Some(default_keychain_account(provider)),
-        env_var: api_key_env.to_string(),
-    };
-    let api_key = resolve_credential(&request, &OsKeychainStore)
-        .ok()
-        .flatten()?
-        .secret;
-    let runtime = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .ok()?;
-    let transport = AsyncTransport::new(
-        Duration::from_secs(5),
-        RetryPolicy {
-            max_attempts: 1,
-            base_backoff: Duration::from_millis(100),
-        },
-    )
-    .ok()?;
-    runtime
-        .block_on(async {
-            match provider {
-                "anthropic" => AnthropicClient::list_models(&transport, endpoint, &api_key).await,
-                "xai" => XaiClient::list_models(&transport, endpoint, &api_key).await,
-                "github" => GitHubModelsClient::list_models(&transport, endpoint, &api_key).await,
-                _ => OpenAiClient::list_models(&transport, endpoint, &api_key).await,
-            }
-        })
-        .ok()
-        .map(|models| models.into_iter().map(|model| model.id).collect())
-}
-
 pub fn run_verify_keys() -> i32 {
     println!("API Key Verification");
     println!("provider\tenv_var\tpresent\tdetected");
-    for (provider, _name, _model, _endpoint, api_key_env) in PROVIDERS {
-        let present = std::env::var(api_key_env)
+    for definition in default_provider_definitions() {
+        let present = std::env::var(&definition.api_key_env)
             .ok()
             .map(|value| !value.trim().is_empty())
             .unwrap_or(false);
-        let detected = if present { *api_key_env } else { "-" };
+        let detected = if present {
+            definition.api_key_env.as_str()
+        } else {
+            "-"
+        };
         println!(
-            "{provider}\t{api_key_env}\t{}\t{detected}",
+            "{}\t{}\t{}\t{detected}",
+            definition.provider,
+            definition.api_key_env,
             if present { "yes" } else { "no" }
         );
     }
@@ -178,30 +70,32 @@ pub fn run_verify_keys() -> i32 {
 fn write_config(repo_path: PathBuf, overrides: ConfigOverrides) -> anyhow::Result<PathBuf> {
     let cfg = load_config(&repo_path, &overrides)?;
     let mut providers: HashMap<String, ProviderConfigEntry> = cfg.providers.clone();
-    for (provider, name, model, endpoint, api_key_env) in PROVIDERS {
+    for definition in default_provider_definitions() {
         providers
-            .entry((*provider).to_string())
+            .entry(definition.provider.to_string())
             .and_modify(|entry| {
-                entry.name.get_or_insert_with(|| (*name).to_string());
+                entry
+                    .name
+                    .get_or_insert_with(|| definition.display_name.to_string());
                 entry
                     .endpoint
-                    .get_or_insert_with(|| (*endpoint).to_string());
+                    .get_or_insert_with(|| definition.endpoint.to_string());
                 entry
                     .api_key_env
-                    .get_or_insert_with(|| (*api_key_env).to_string());
+                    .get_or_insert_with(|| definition.api_key_env.to_string());
                 entry
                     .keychain_account
-                    .get_or_insert_with(|| format!("provider/{provider}/default"));
+                    .get_or_insert_with(|| format!("provider/{}/default", definition.provider));
                 entry
                     .preferred_model
-                    .get_or_insert_with(|| (*model).to_string());
+                    .get_or_insert_with(|| definition.default_model.to_string());
             })
             .or_insert_with(|| ProviderConfigEntry {
-                name: Some((*name).to_string()),
-                endpoint: Some((*endpoint).to_string()),
-                api_key_env: Some((*api_key_env).to_string()),
-                keychain_account: Some(format!("provider/{provider}/default")),
-                preferred_model: Some((*model).to_string()),
+                name: Some(definition.display_name.to_string()),
+                endpoint: Some(definition.endpoint.to_string()),
+                api_key_env: Some(definition.api_key_env.to_string()),
+                keychain_account: Some(format!("provider/{}/default", definition.provider)),
+                preferred_model: Some(definition.default_model.to_string()),
             });
     }
 

--- a/rust/crates/kcmt-cli/src/commands/mod.rs
+++ b/rust/crates/kcmt-cli/src/commands/mod.rs
@@ -1,6 +1,7 @@
 pub mod benchmark;
 pub mod configure;
 pub mod history;
+pub mod model_discovery;
 pub mod stats;
 pub mod status;
 pub mod workflow;

--- a/rust/crates/kcmt-cli/src/commands/model_discovery.rs
+++ b/rust/crates/kcmt-cli/src/commands/model_discovery.rs
@@ -1,0 +1,701 @@
+//! Model discovery catalog, cache, and selector integration.
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use kcmt_core::config::loader::{config_home, load_config, ConfigOverrides};
+use kcmt_core::model::WorkflowConfig;
+use kcmt_core::preferences::{
+    default_keychain_account, resolve_credential, CredentialRequest, OsKeychainStore, Preferences,
+};
+use kcmt_core::selector::ModelCandidate;
+use kcmt_provider::clients::{
+    AnthropicClient, GitHubModelsClient, ListedModel, OpenAiClient, XaiClient,
+};
+use kcmt_provider::transport::{AsyncTransport, RetryPolicy};
+use serde::{Deserialize, Serialize};
+
+const CACHE_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone)]
+pub struct ProviderDefinition {
+    pub provider: String,
+    pub display_name: String,
+    pub default_model: String,
+    pub endpoint: String,
+    pub api_key_env: String,
+}
+
+impl ProviderDefinition {
+    fn new(
+        provider: &str,
+        display_name: &str,
+        default_model: &str,
+        endpoint: &str,
+        api_key_env: &str,
+    ) -> Self {
+        Self {
+            provider: provider.to_string(),
+            display_name: display_name.to_string(),
+            default_model: default_model.to_string(),
+            endpoint: endpoint.to_string(),
+            api_key_env: api_key_env.to_string(),
+        }
+    }
+}
+
+pub fn default_provider_definitions() -> Vec<ProviderDefinition> {
+    vec![
+        ProviderDefinition::new(
+            "openai",
+            "OpenAI",
+            "gpt-5-mini-2025-08-07",
+            "https://api.openai.com/v1",
+            "OPENAI_API_KEY",
+        ),
+        ProviderDefinition::new(
+            "anthropic",
+            "Anthropic",
+            "claude-3-5-haiku-latest",
+            "https://api.anthropic.com",
+            "ANTHROPIC_API_KEY",
+        ),
+        ProviderDefinition::new(
+            "xai",
+            "X.AI",
+            "grok-code-fast",
+            "https://api.x.ai/v1",
+            "XAI_API_KEY",
+        ),
+        ProviderDefinition::new(
+            "github",
+            "GitHub Models",
+            "openai/gpt-4.1-mini",
+            "https://models.github.ai/inference",
+            "GITHUB_TOKEN",
+        ),
+    ]
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum DiscoverySource {
+    Live,
+    Cache,
+    StaticFallback,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DiscoveredModel {
+    pub id: String,
+    pub provider: String,
+    pub endpoint: String,
+    pub api_key_env: String,
+    pub created: Option<String>,
+    pub family: Option<String>,
+    pub code_capable: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ProviderModelCatalog {
+    pub provider: String,
+    pub display_name: String,
+    pub endpoint: String,
+    pub api_key_env: String,
+    pub source: DiscoverySource,
+    pub error: Option<String>,
+    pub models: Vec<DiscoveredModel>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ModelCacheFile {
+    schema_version: u32,
+    generated_unix_seconds: u64,
+    providers: Vec<ProviderModelCatalog>,
+}
+
+pub fn discover_model_catalog(preferences: &Preferences) -> Vec<ProviderModelCatalog> {
+    discover_model_catalog_for_definitions(&provider_definitions_from_config(), preferences)
+}
+
+pub fn catalog_for_config(
+    config: &WorkflowConfig,
+    preferences: &Preferences,
+) -> Vec<ProviderModelCatalog> {
+    discover_model_catalog_for_definitions(&provider_definitions(config), preferences)
+}
+
+pub fn cached_or_static_catalog_for_config(
+    config: &WorkflowConfig,
+    preferences: &Preferences,
+) -> Vec<ProviderModelCatalog> {
+    provider_definitions(config)
+        .iter()
+        .map(|definition| fallback_catalog(definition, preferences, None))
+        .collect()
+}
+
+pub fn catalog_to_selector_candidates(catalog: &[ProviderModelCatalog]) -> Vec<ModelCandidate> {
+    catalog
+        .iter()
+        .flat_map(|provider| {
+            provider.models.iter().map(|model| ModelCandidate {
+                provider: model.provider.clone(),
+                id: model.id.clone(),
+                family: model.family.clone(),
+                code_capable: model.code_capable,
+                beta: model.id.to_ascii_lowercase().contains("beta"),
+                input_cost_per_million: None,
+                output_cost_per_million: None,
+                median_latency_ms: None,
+                created_at: model.created.clone(),
+            })
+        })
+        .collect()
+}
+
+fn discover_model_catalog_for_definitions(
+    definitions: &[ProviderDefinition],
+    preferences: &Preferences,
+) -> Vec<ProviderModelCatalog> {
+    let mut catalogs = Vec::new();
+    let mut live_catalogs = Vec::new();
+    for definition in definitions {
+        let live = live_models_for_provider(definition);
+        let catalog = match live {
+            Ok(models) if !models.is_empty() => {
+                let catalog = provider_catalog(definition, DiscoverySource::Live, None, models);
+                live_catalogs.push(catalog.clone());
+                catalog
+            }
+            Ok(_) => fallback_catalog(definition, preferences, Some("provider returned no models")),
+            Err(err) => fallback_catalog(definition, preferences, Some(err.as_str())),
+        };
+        catalogs.push(catalog);
+    }
+    if !live_catalogs.is_empty() {
+        let _ = save_model_cache(live_catalogs);
+    }
+    catalogs
+}
+
+fn fallback_catalog(
+    definition: &ProviderDefinition,
+    preferences: &Preferences,
+    error: Option<&str>,
+) -> ProviderModelCatalog {
+    if let Some(cached) = cached_provider_catalog(definition, preferences) {
+        let mut cached = cached;
+        cached.source = DiscoverySource::Cache;
+        cached.error = error.map(ToOwned::to_owned);
+        return cached;
+    }
+    provider_catalog(
+        definition,
+        DiscoverySource::StaticFallback,
+        error.map(ToOwned::to_owned),
+        static_models(definition),
+    )
+}
+
+fn live_models_for_provider(
+    definition: &ProviderDefinition,
+) -> Result<Vec<DiscoveredModel>, String> {
+    let explicit_provider = std::env::var("KCMT_EXPLICIT_API_KEY_PROVIDER").ok();
+    let explicit_secret = explicit_secret_for_provider(
+        &definition.provider,
+        explicit_provider.as_deref(),
+        std::env::var("KCMT_EXPLICIT_API_KEY").ok(),
+    );
+    let request = CredentialRequest {
+        provider: definition.provider.clone(),
+        explicit_secret,
+        keychain_account: Some(default_keychain_account(&definition.provider)),
+        env_var: definition.api_key_env.clone(),
+    };
+    let api_key = resolve_credential(&request, &OsKeychainStore)
+        .map_err(|err| format!("credential lookup failed: {err}"))?
+        .map(|credential| credential.secret)
+        .ok_or_else(|| format!("missing credential {}", definition.api_key_env))?;
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|err| format!("runtime unavailable: {err}"))?;
+    let transport = AsyncTransport::new(
+        Duration::from_secs(5),
+        RetryPolicy {
+            max_attempts: 1,
+            base_backoff: Duration::from_millis(100),
+        },
+    )
+    .map_err(|err| format!("transport unavailable: {err}"))?;
+    let models = runtime
+        .block_on(async {
+            match definition.provider.as_str() {
+                "anthropic" => {
+                    AnthropicClient::list_models(&transport, &definition.endpoint, &api_key).await
+                }
+                "xai" => XaiClient::list_models(&transport, &definition.endpoint, &api_key).await,
+                "github" => {
+                    GitHubModelsClient::list_models(&transport, &definition.endpoint, &api_key)
+                        .await
+                }
+                _ => OpenAiClient::list_models(&transport, &definition.endpoint, &api_key).await,
+            }
+        })
+        .map_err(|err| err.to_string())?;
+    Ok(models
+        .into_iter()
+        .map(|model| normalize_model(definition, &model))
+        .collect())
+}
+
+fn explicit_secret_for_provider(
+    provider: &str,
+    explicit_provider: Option<&str>,
+    explicit_secret: Option<String>,
+) -> Option<String> {
+    (explicit_provider == Some(provider))
+        .then_some(explicit_secret)
+        .flatten()
+}
+
+fn provider_catalog(
+    definition: &ProviderDefinition,
+    source: DiscoverySource,
+    error: Option<String>,
+    models: Vec<DiscoveredModel>,
+) -> ProviderModelCatalog {
+    ProviderModelCatalog {
+        provider: definition.provider.clone(),
+        display_name: definition.display_name.clone(),
+        endpoint: definition.endpoint.clone(),
+        api_key_env: definition.api_key_env.clone(),
+        source,
+        error,
+        models,
+    }
+}
+
+fn normalize_model(definition: &ProviderDefinition, model: &ListedModel) -> DiscoveredModel {
+    DiscoveredModel {
+        id: model.id.clone(),
+        provider: definition.provider.clone(),
+        endpoint: definition.endpoint.clone(),
+        api_key_env: definition.api_key_env.clone(),
+        created: model.created_at.clone(),
+        family: infer_family(&model.id),
+        code_capable: infer_code_capable(&model.id),
+    }
+}
+
+fn static_model(definition: &ProviderDefinition) -> DiscoveredModel {
+    normalize_model(
+        definition,
+        &ListedModel {
+            id: definition.default_model.clone(),
+            created_at: None,
+        },
+    )
+}
+
+fn static_models(definition: &ProviderDefinition) -> Vec<DiscoveredModel> {
+    let mut models = vec![static_model(definition)];
+    if let Some(default_definition) = default_provider_definitions()
+        .into_iter()
+        .find(|candidate| candidate.provider == definition.provider)
+    {
+        if default_definition.default_model != definition.default_model {
+            models.push(normalize_model(
+                definition,
+                &ListedModel {
+                    id: default_definition.default_model,
+                    created_at: None,
+                },
+            ));
+        }
+    }
+    models
+}
+
+fn cached_provider_catalog(
+    definition: &ProviderDefinition,
+    preferences: &Preferences,
+) -> Option<ProviderModelCatalog> {
+    cached_provider_catalog_from_path(definition, preferences, &model_cache_path())
+}
+
+fn cached_provider_catalog_from_path(
+    definition: &ProviderDefinition,
+    preferences: &Preferences,
+    path: &Path,
+) -> Option<ProviderModelCatalog> {
+    let ttl = preferences.model_cache.ttl_seconds;
+    if ttl == 0 {
+        return None;
+    }
+    let cache = load_model_cache_from_path(path)?;
+    if cache.schema_version != CACHE_SCHEMA_VERSION {
+        return None;
+    }
+    let now = now_unix_seconds();
+    if now.saturating_sub(cache.generated_unix_seconds) > ttl {
+        return None;
+    }
+    cache
+        .providers
+        .into_iter()
+        .find(|provider| provider.provider == definition.provider && !provider.models.is_empty())
+}
+
+fn load_model_cache_from_path(path: &Path) -> Option<ModelCacheFile> {
+    let raw = fs::read_to_string(path).ok()?;
+    serde_json::from_str(&raw).ok()
+}
+
+fn save_model_cache(providers: Vec<ProviderModelCatalog>) -> std::io::Result<()> {
+    let path = model_cache_path();
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let cache = ModelCacheFile {
+        schema_version: CACHE_SCHEMA_VERSION,
+        generated_unix_seconds: now_unix_seconds(),
+        providers,
+    };
+    fs::write(path, serde_json::to_string_pretty(&cache)?)
+}
+
+fn model_cache_path() -> PathBuf {
+    config_home().join("model-cache.json")
+}
+
+fn now_unix_seconds() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs())
+        .unwrap_or(0)
+}
+
+fn provider_definitions_from_config() -> Vec<ProviderDefinition> {
+    if !config_home().join("config.json").exists() {
+        return default_provider_definitions();
+    }
+    let config = std::env::current_dir()
+        .ok()
+        .and_then(|cwd| load_config(&cwd, &ConfigOverrides::default()).ok());
+    match config {
+        Some(config) => provider_definitions(&config),
+        None => default_provider_definitions(),
+    }
+}
+
+fn provider_definitions(config: &WorkflowConfig) -> Vec<ProviderDefinition> {
+    let mut definitions = default_provider_definitions();
+    let defaults = default_provider_definitions()
+        .iter()
+        .map(|definition| (definition.provider.clone(), definition.clone()))
+        .collect::<HashMap<_, _>>();
+    for definition in &mut definitions {
+        if definition.provider == config.provider {
+            definition.endpoint = config.llm_endpoint.clone();
+            definition.api_key_env = config.api_key_env.clone();
+            definition.default_model = config.model.clone();
+        }
+        if let Some(entry) = config.providers.get(&definition.provider) {
+            if let Some(endpoint) = entry
+                .endpoint
+                .as_ref()
+                .filter(|value| !value.trim().is_empty())
+            {
+                definition.endpoint = endpoint.clone();
+            }
+            if let Some(api_key_env) = entry
+                .api_key_env
+                .as_ref()
+                .filter(|value| !value.trim().is_empty())
+            {
+                definition.api_key_env = api_key_env.clone();
+            }
+            if let Some(model) = entry
+                .preferred_model
+                .as_ref()
+                .filter(|value| !value.trim().is_empty())
+            {
+                definition.default_model = model.clone();
+            }
+        }
+        if definition.endpoint.is_empty() {
+            definition.endpoint = defaults[&definition.provider].endpoint.clone();
+        }
+        if definition.api_key_env.is_empty() {
+            definition.api_key_env = defaults[&definition.provider].api_key_env.clone();
+        }
+        if definition.default_model.is_empty() {
+            definition.default_model = defaults[&definition.provider].default_model.clone();
+        }
+    }
+    definitions
+}
+
+fn infer_family(model_id: &str) -> Option<String> {
+    let id = model_id.to_ascii_lowercase();
+    let family = if id.contains("haiku") {
+        "haiku"
+    } else if id.contains("sonnet") {
+        "sonnet"
+    } else if id.contains("opus") {
+        "opus"
+    } else if id.contains("grok-code") {
+        "grok-code"
+    } else if id.contains("grok") {
+        "grok"
+    } else if id.contains("gpt-5") {
+        "gpt-5"
+    } else if id.contains("gpt-4.1") {
+        "gpt-4.1"
+    } else if id.contains("o4") {
+        "o4"
+    } else if id.contains("o3") {
+        "o3"
+    } else {
+        return None;
+    };
+    Some(family.to_string())
+}
+
+fn infer_code_capable(model_id: &str) -> bool {
+    let id = model_id.to_ascii_lowercase();
+    !id.contains("embedding")
+        && !id.contains("audio")
+        && !id.contains("image")
+        && !id.contains("vision")
+        && !id.contains("moderation")
+}
+
+#[cfg(test)]
+mod tests {
+    use std::env;
+    use std::fs;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use kcmt_core::preferences::Preferences;
+
+    use super::{
+        cached_provider_catalog_from_path, catalog_to_selector_candidates, fallback_catalog,
+        provider_definitions, DiscoveredModel, DiscoverySource, ModelCacheFile, ProviderDefinition,
+        ProviderModelCatalog, CACHE_SCHEMA_VERSION,
+    };
+
+    static COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+    fn temp_config_home() -> std::path::PathBuf {
+        let path = env::temp_dir().join(format!(
+            "kcmt-model-discovery-test-{}-{}",
+            std::process::id(),
+            COUNTER.fetch_add(1, Ordering::Relaxed)
+        ));
+        let _ = fs::remove_dir_all(&path);
+        fs::create_dir_all(&path).expect("temp config home");
+        path
+    }
+
+    #[test]
+    fn static_fallback_keeps_normalized_metadata_and_error() {
+        let definition = ProviderDefinition {
+            provider: "anthropic".to_string(),
+            display_name: "Anthropic".to_string(),
+            default_model: "claude-3-5-haiku-latest".to_string(),
+            endpoint: "https://api.anthropic.com".to_string(),
+            api_key_env: "ANTHROPIC_API_KEY".to_string(),
+        };
+
+        let catalog = fallback_catalog(&definition, &Preferences::default(), Some("offline"));
+
+        assert_eq!(catalog.source, DiscoverySource::StaticFallback);
+        assert_eq!(catalog.error.as_deref(), Some("offline"));
+        assert_eq!(catalog.models[0].provider, "anthropic");
+        assert_eq!(catalog.models[0].endpoint, "https://api.anthropic.com");
+        assert_eq!(catalog.models[0].api_key_env, "ANTHROPIC_API_KEY");
+        assert_eq!(catalog.models[0].family.as_deref(), Some("haiku"));
+        assert!(catalog.models[0].code_capable);
+    }
+
+    #[test]
+    fn explicit_api_key_requires_matching_provider_marker() {
+        assert_eq!(
+            super::explicit_secret_for_provider("anthropic", None, Some("secret".to_string())),
+            None
+        );
+        assert_eq!(
+            super::explicit_secret_for_provider(
+                "anthropic",
+                Some("openai"),
+                Some("secret".to_string())
+            ),
+            None
+        );
+        assert_eq!(
+            super::explicit_secret_for_provider(
+                "anthropic",
+                Some("anthropic"),
+                Some("secret".to_string())
+            )
+            .as_deref(),
+            Some("secret")
+        );
+    }
+
+    #[test]
+    fn fresh_cache_is_used_before_static_fallback() {
+        let config_home = temp_config_home();
+        let cache_path = config_home.join("model-cache.json");
+        let cache = ModelCacheFile {
+            schema_version: CACHE_SCHEMA_VERSION,
+            generated_unix_seconds: super::now_unix_seconds(),
+            providers: vec![ProviderModelCatalog {
+                provider: "openai".to_string(),
+                display_name: "OpenAI".to_string(),
+                endpoint: "https://cached.example/v1".to_string(),
+                api_key_env: "OPENAI_API_KEY".to_string(),
+                source: DiscoverySource::Live,
+                error: None,
+                models: vec![DiscoveredModel {
+                    id: "gpt-5-cached".to_string(),
+                    provider: "openai".to_string(),
+                    endpoint: "https://cached.example/v1".to_string(),
+                    api_key_env: "OPENAI_API_KEY".to_string(),
+                    created: Some("2026-01-01".to_string()),
+                    family: Some("gpt-5".to_string()),
+                    code_capable: true,
+                }],
+            }],
+        };
+        fs::write(
+            &cache_path,
+            serde_json::to_string(&cache).expect("cache json"),
+        )
+        .expect("cache write");
+
+        let definition = super::default_provider_definitions()[0].clone();
+        let cached =
+            cached_provider_catalog_from_path(&definition, &Preferences::default(), &cache_path)
+                .expect("fresh cache");
+
+        assert_eq!(cached.models[0].id, "gpt-5-cached");
+    }
+
+    #[test]
+    fn expired_cache_falls_back_to_static_models() {
+        let config_home = temp_config_home();
+        let cache_path = config_home.join("model-cache.json");
+        let cache = ModelCacheFile {
+            schema_version: CACHE_SCHEMA_VERSION,
+            generated_unix_seconds: 1,
+            providers: vec![ProviderModelCatalog {
+                provider: "openai".to_string(),
+                display_name: "OpenAI".to_string(),
+                endpoint: "https://cached.example/v1".to_string(),
+                api_key_env: "OPENAI_API_KEY".to_string(),
+                source: DiscoverySource::Live,
+                error: None,
+                models: vec![DiscoveredModel {
+                    id: "gpt-5-cached".to_string(),
+                    provider: "openai".to_string(),
+                    endpoint: "https://cached.example/v1".to_string(),
+                    api_key_env: "OPENAI_API_KEY".to_string(),
+                    created: None,
+                    family: Some("gpt-5".to_string()),
+                    code_capable: true,
+                }],
+            }],
+        };
+        fs::write(
+            &cache_path,
+            serde_json::to_string(&cache).expect("cache json"),
+        )
+        .expect("cache write");
+        let definition = super::default_provider_definitions()[0].clone();
+
+        let cached =
+            cached_provider_catalog_from_path(&definition, &Preferences::default(), &cache_path);
+        let static_models = super::static_models(&definition);
+
+        assert!(cached.is_none());
+        assert_eq!(static_models[0].id, "gpt-5-mini-2025-08-07");
+    }
+
+    #[test]
+    fn selector_candidates_preserve_discovered_metadata() {
+        let catalog = vec![ProviderModelCatalog {
+            provider: "xai".to_string(),
+            display_name: "X.AI".to_string(),
+            endpoint: "https://api.x.ai/v1".to_string(),
+            api_key_env: "XAI_API_KEY".to_string(),
+            source: DiscoverySource::Live,
+            error: None,
+            models: vec![DiscoveredModel {
+                id: "grok-code-fast".to_string(),
+                provider: "xai".to_string(),
+                endpoint: "https://api.x.ai/v1".to_string(),
+                api_key_env: "XAI_API_KEY".to_string(),
+                created: Some("2026-01-01".to_string()),
+                family: Some("grok-code".to_string()),
+                code_capable: true,
+            }],
+        }];
+
+        let candidates = catalog_to_selector_candidates(&catalog);
+
+        assert_eq!(candidates[0].provider, "xai");
+        assert_eq!(candidates[0].id, "grok-code-fast");
+        assert_eq!(candidates[0].family.as_deref(), Some("grok-code"));
+        assert_eq!(candidates[0].created_at.as_deref(), Some("2026-01-01"));
+        assert!(candidates[0].code_capable);
+    }
+
+    #[test]
+    fn static_fallback_includes_configured_and_builtin_defaults() {
+        let definition = ProviderDefinition {
+            provider: "anthropic".to_string(),
+            display_name: "Anthropic".to_string(),
+            default_model: "claude-sonnet-4-20250514".to_string(),
+            endpoint: "https://api.anthropic.com".to_string(),
+            api_key_env: "ANTHROPIC_API_KEY".to_string(),
+        };
+
+        let catalog = fallback_catalog(&definition, &Preferences::default(), Some("offline"));
+        let model_ids = catalog
+            .models
+            .iter()
+            .map(|model| model.id.as_str())
+            .collect::<Vec<_>>();
+
+        assert_eq!(catalog.source, DiscoverySource::StaticFallback);
+        assert!(model_ids.contains(&"claude-sonnet-4-20250514"));
+        assert!(model_ids.contains(&"claude-3-5-haiku-latest"));
+    }
+
+    #[test]
+    fn provider_definitions_honor_persisted_provider_metadata() {
+        let config = kcmt_core::model::WorkflowConfig {
+            provider: "openai".to_string(),
+            model: "gpt-custom".to_string(),
+            llm_endpoint: "https://custom.openai.test/v1".to_string(),
+            api_key_env: "OPENAI_TEST_KEY".to_string(),
+            ..kcmt_core::model::WorkflowConfig::default()
+        };
+
+        let definitions = provider_definitions(&config);
+        let openai = definitions
+            .iter()
+            .find(|definition| definition.provider == "openai")
+            .expect("openai definition");
+
+        assert_eq!(openai.default_model, "gpt-custom");
+        assert_eq!(openai.endpoint, "https://custom.openai.test/v1");
+        assert_eq!(openai.api_key_env, "OPENAI_TEST_KEY");
+    }
+}

--- a/rust/crates/kcmt-cli/src/commands/workflow.rs
+++ b/rust/crates/kcmt-cli/src/commands/workflow.rs
@@ -25,7 +25,7 @@ use kcmt_core::preferences::{
     default_keychain_account, load_preferences, resolve_credential, CredentialRequest,
     CredentialSource, OsKeychainStore, Preferences, PromptProfile,
 };
-use kcmt_core::selector::{default_models_for_provider, select_model, ModelSelection};
+use kcmt_core::selector::{select_model, ModelSelection};
 use kcmt_core::telemetry::{load_usage_summary, record_usage, TelemetryRunRecord};
 use kcmt_provider::clients::{
     AnthropicClient, GitHubModelsClient, OpenAiBatchJob, OpenAiClient, ProviderMessage, XaiClient,
@@ -35,6 +35,7 @@ use kcmt_provider::transport::{AsyncTransport, RetryPolicy};
 use serde_json::json;
 
 use super::history::snapshot_path;
+use super::model_discovery::{cached_or_static_catalog_for_config, catalog_to_selector_candidates};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct StatusEntry {
@@ -463,10 +464,8 @@ fn run_entries_workflow(
     let mut failures = Vec::new();
     let preferences = load_preferences().unwrap_or_else(|_| Preferences::default());
     let usage_summary = load_usage_summary(&repo_path).unwrap_or_default();
-    let model_catalog = provider_candidates(config)
-        .iter()
-        .flat_map(|candidate| default_models_for_provider(&candidate.provider))
-        .collect::<Vec<_>>();
+    let model_catalog =
+        catalog_to_selector_candidates(&cached_or_static_catalog_for_config(config, &preferences));
     let available = available_providers(config);
     let mut model_selection = select_model(
         config,
@@ -1389,7 +1388,14 @@ fn credential_for_candidate(candidate: &ProviderCandidate) -> Option<(String, Cr
 }
 
 fn available_providers(config: &kcmt_core::model::WorkflowConfig) -> Vec<String> {
-    provider_candidates(config)
+    let candidates = provider_candidates(config);
+    if fixture_provider_response().is_some() || runtime_benchmark_enabled() {
+        return candidates
+            .into_iter()
+            .map(|candidate| candidate.provider)
+            .collect();
+    }
+    candidates
         .into_iter()
         .filter(|candidate| credential_for_candidate(candidate).is_some())
         .map(|candidate| candidate.provider)

--- a/rust/crates/kcmt-cli/tests/configure_contracts.rs
+++ b/rust/crates/kcmt-cli/tests/configure_contracts.rs
@@ -116,7 +116,9 @@ fn configure_all_accepts_noninteractive_overrides() {
 
 #[test]
 fn list_models_prints_supported_provider_defaults() {
+    let config_home = unique_temp_dir("home");
     let output = kcmt_command()
+        .env("KCMT_CONFIG_HOME", &config_home)
         .args(["--list-models"])
         .output()
         .expect("kcmt list-models should run");
@@ -160,22 +162,54 @@ fn configure_writes_default_preferences_file() {
 
 #[test]
 fn list_models_debug_prints_structured_provider_json() {
+    let config_home = unique_temp_dir("home");
     let output = kcmt_command()
+        .env("KCMT_CONFIG_HOME", &config_home)
+        .env("OPENAI_API_KEY", "sk-test-secret")
         .args(["--debug", "--list-models"])
         .output()
         .expect("kcmt list-models debug should run");
 
     assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(!stdout.contains("sk-test-secret"));
     let payload: serde_json::Value =
         serde_json::from_slice(&output.stdout).expect("debug model list is json");
     let providers = payload.as_array().expect("provider array");
     assert_eq!(providers.len(), 4);
-    assert!(providers.iter().any(|provider| {
-        provider["provider"] == "openai" && provider["models"][0]["id"] == "gpt-5-mini-2025-08-07"
-    }));
-    assert!(providers.iter().any(|provider| {
-        provider["provider"] == "github" && provider["models"][0]["api_key_env"] == "GITHUB_TOKEN"
-    }));
+    let openai = providers
+        .iter()
+        .find(|provider| provider["provider"] == "openai")
+        .expect("openai provider");
+    assert!(matches!(
+        openai["source"].as_str(),
+        Some("live" | "static_fallback" | "cache")
+    ));
+    assert_eq!(openai["display_name"], "OpenAI");
+    assert_eq!(openai["endpoint"], "https://api.openai.com/v1");
+    assert_eq!(openai["api_key_env"], "OPENAI_API_KEY");
+    assert!(openai["error"].is_null() || openai["error"].is_string());
+    let openai_model = &openai["models"][0];
+    assert!(openai_model["id"].as_str().is_some());
+    assert_eq!(openai_model["provider"], "openai");
+    assert_eq!(openai_model["endpoint"], "https://api.openai.com/v1");
+    assert_eq!(openai_model["api_key_env"], "OPENAI_API_KEY");
+    assert!(openai_model["created"].is_null() || openai_model["created"].is_string());
+    assert!(openai_model["family"].is_null() || openai_model["family"].is_string());
+    assert!(openai_model["code_capable"].is_boolean());
+
+    let anthropic = providers
+        .iter()
+        .find(|provider| provider["provider"] == "anthropic")
+        .expect("anthropic provider");
+    assert_eq!(anthropic["source"], "static_fallback");
+    assert_eq!(anthropic["models"][0]["family"], "haiku");
+
+    let github = providers
+        .iter()
+        .find(|provider| provider["provider"] == "github")
+        .expect("github provider");
+    assert_eq!(github["models"][0]["api_key_env"], "GITHUB_TOKEN");
 }
 
 #[test]

--- a/rust/crates/kcmt-cli/tests/workflow_modes.rs
+++ b/rust/crates/kcmt-cli/tests/workflow_modes.rs
@@ -155,6 +155,9 @@ fn spawn_provider_responses(
                     Err(err) => panic!("mock provider connection failed: {err}"),
                 }
             };
+            stream
+                .set_nonblocking(false)
+                .expect("mock provider stream should become blocking");
             let mut buffer = [0_u8; 32768];
             let bytes = stream.read(&mut buffer).expect("mock provider read");
             sender

--- a/rust/crates/kcmt-provider/src/clients/mod.rs
+++ b/rust/crates/kcmt-provider/src/clients/mod.rs
@@ -1003,6 +1003,75 @@ mod tests {
     }
 
     #[test]
+    fn provider_models_requests_use_provider_specific_paths_and_headers() {
+        let openai = OpenAiClient::build_models_request("https://api.openai.com/v1/", "openai-key");
+        assert_eq!(openai.url, "https://api.openai.com/v1/models");
+        assert_eq!(openai.headers["Authorization"], "Bearer openai-key");
+
+        let anthropic =
+            AnthropicClient::build_models_request("https://api.anthropic.com/v1", "claude-key");
+        assert_eq!(anthropic.url, "https://api.anthropic.com/v1/models");
+        assert_eq!(anthropic.headers["x-api-key"], "claude-key");
+        assert_eq!(anthropic.headers["anthropic-version"], "2023-06-01");
+        assert!(!anthropic.headers.contains_key("Authorization"));
+
+        let xai = XaiClient::build_models_request("https://api.x.ai/v1", "xai-key");
+        assert_eq!(xai.url, "https://api.x.ai/v1/models");
+        assert_eq!(xai.headers["Authorization"], "Bearer xai-key");
+
+        let github = GitHubModelsClient::build_models_request(
+            "https://models.github.ai/inference",
+            "gh-key",
+        );
+        assert_eq!(github.url, "https://models.github.ai/inference/models");
+        assert_eq!(github.headers["Authorization"], "Bearer gh-key");
+    }
+
+    #[test]
+    fn provider_models_parsers_normalize_ids_and_created_metadata() {
+        let openai = OpenAiClient::parse_models_response(&json!({
+            "data": [
+                {"id": "gpt-5-mini", "created": 1780716000},
+                {"object": "model"},
+                {"id": "text-embedding-3-small"}
+            ]
+        }))
+        .expect("openai models should parse");
+        assert_eq!(openai.len(), 2);
+        assert_eq!(openai[0].id, "gpt-5-mini");
+        assert_eq!(openai[0].created_at.as_deref(), Some("1780716000"));
+
+        let anthropic = AnthropicClient::parse_models_response(&json!({
+            "models": [{"id": "claude-3-5-haiku-latest", "created_at": "2026-01-01"}]
+        }))
+        .expect("anthropic models should parse");
+        assert_eq!(anthropic[0].id, "claude-3-5-haiku-latest");
+        assert_eq!(anthropic[0].created_at.as_deref(), Some("2026-01-01"));
+
+        let xai = XaiClient::parse_models_response(&json!({
+            "data": [{"id": "grok-code-fast", "created": "2026-01-02"}]
+        }))
+        .expect("xai models should parse");
+        assert_eq!(xai[0].id, "grok-code-fast");
+        assert_eq!(xai[0].created_at.as_deref(), Some("2026-01-02"));
+
+        let github = GitHubModelsClient::parse_models_response(&json!({
+            "data": [{"id": "openai/gpt-4.1-mini"}]
+        }))
+        .expect("github models should parse");
+        assert_eq!(github[0].id, "openai/gpt-4.1-mini");
+        assert_eq!(github[0].created_at, None);
+    }
+
+    #[test]
+    fn provider_models_parser_reports_missing_model_ids() {
+        let err = OpenAiClient::parse_models_response(&json!({"data": [{"object": "model"}]}))
+            .expect_err("missing ids should fail");
+
+        assert!(err.contains("did not include model ids"));
+    }
+
+    #[test]
     fn xai_and_github_use_openai_compatible_chat_requests() {
         let xai = XaiClient::build_chat_request(
             "https://api.x.ai/v1/",

--- a/tests/test_rust_workflow_parity_bdd.py
+++ b/tests/test_rust_workflow_parity_bdd.py
@@ -1922,8 +1922,16 @@ def debug_model_list_is_structured_json(workflow_context: dict[str, Any]) -> Non
     payload = json.loads(workflow_context["output"])
     providers = {entry["provider"]: entry for entry in payload}
     assert providers["openai"]["models"][0]["id"] == "gpt-5-mini-2025-08-07"
+    assert providers["openai"]["source"] == "static_fallback"
+    assert providers["openai"]["error"]
     assert providers["github"]["models"][0]["api_key_env"] == "GITHUB_TOKEN"
     assert providers["anthropic"]["display_name"] == "Anthropic"
+    anthropic_model = providers["anthropic"]["models"][0]
+    assert anthropic_model["provider"] == "anthropic"
+    assert anthropic_model["endpoint"] == "https://api.anthropic.com"
+    assert anthropic_model["family"] == "haiku"
+    assert anthropic_model["code_capable"] is True
+    assert "bdd-key" not in workflow_context["output"]
 
 
 @then("the key verification output shows present and missing providers")


### PR DESCRIPTION
## Summary

- Adds a Rust model discovery catalog that normalizes provider/model metadata for live, cached, and static fallback sources.
- Preserves existing `--list-models` text output while expanding debug JSON with stable provider/model schema, source, partial-failure error, family, created, and code-capable fields.
- Feeds cached/static discovery metadata into selector ranking so PR #37 preferences can consume discovered model metadata without adding live model probes to ordinary commit workflows.
- Adds provider-specific parser/request tests, configure contract tests, BDD assertions, and a mock-provider race fix exposed by the full gate.

## Conventional Commit Breakdown

| Commit | Type | Scope | Summary |
| --- | --- | --- | --- |
| `442dd3b` | feat | rust | normalize model discovery catalog |

## Release Notes Draft

- Rust `kcmt --list-models --debug` now emits a normalized, secret-free model catalog for OpenAI-compatible providers, Anthropic, xAI, and GitHub Models.
- Model discovery now records whether provider data came from live API discovery, cache, or static fallback, with per-provider non-fatal errors.
- Selector ranking can consume cached/static model metadata for provider rules such as Anthropic latest Haiku while preserving runtime benchmark and fixture performance.

## Behaviour Changes

- `--list-models` continues to succeed when some or all providers cannot be reached; debug output now reports fallback source and error details per provider.
- Cached live discovery is reused within `preferences.model_cache.ttl_seconds`.
- Ordinary commit workflows avoid live model-listing probes and use cached/static metadata for selector rules.

## API / Schema / Contract Changes

- Debug JSON for `--list-models` is now an array of provider catalog objects with:
  - `provider`, `display_name`, `endpoint`, `api_key_env`, `source`, `error`, `models`
  - model objects containing `id`, `provider`, `endpoint`, `api_key_env`, `created`, `family`, `code_capable`
- No source, log, or debug output includes API key secret values.

## Testing Evidence

- `cargo test --manifest-path rust/Cargo.toml -p kcmt-provider provider_models -- --nocapture`: 3 passed
- `cargo test --manifest-path rust/Cargo.toml -p kcmt-cli --lib model_discovery -- --nocapture`: 6 passed
- `cargo test --manifest-path rust/Cargo.toml -p kcmt-cli --test configure_contracts list_models -- --nocapture`: 2 passed
- `uv run pytest tests/test_rust_workflow_parity_bdd.py::test_rust_listmodels_shows_supported_default_models tests/test_rust_workflow_parity_bdd.py::test_rust_listmodels_debug_emits_structured_provider_data --no-cov -q`: 2 passed
- `make check`: passed
- `make quality-gates`: passed

## Risk and Rollback

- Risk: live provider response shapes may still drift beyond the parser shapes covered here.
- Mitigation: provider-specific parser tests cover OpenAI-compatible, Anthropic, xAI, and GitHub Models `/models` shapes and malformed entries.
- Rollback: revert `442dd3b` to restore PR #37 list-models behavior.

## Operational Notes

- `--list-models` can create or refresh `model-cache.json` under the configured kcmt config home.
- Commit workflows intentionally do not perform live model discovery to avoid adding network latency to the hot path.

## Linked Work

- Builds on merged PR #37 (`feat(rust): add model preferences selector`).

## Reviewer Checklist

- [ ] Confirm debug JSON schema is stable and secret-free.
- [ ] Confirm selector behavior preserves Anthropic latest-Haiku preferences when live discovery is unavailable.
- [ ] Confirm cache/static fallback semantics do not add live network probes to ordinary commit workflows.
- [ ] Confirm provider parser/request coverage matches expected provider API differences.
