### PR TITLE
feat(rust): add workflow TUI state model

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1963,6 +1963,8 @@ dependencies = [
  "anyhow",
  "crossterm 0.29.0",
  "ratatui",
+ "serde",
+ "serde_json",
  "tracing",
 ]
 

--- a/rust/crates/kcmt-cli/src/args.rs
+++ b/rust/crates/kcmt-cli/src/args.rs
@@ -348,6 +348,7 @@ mod tests {
         let args = CliArgs::parse_from([
             "kcmt",
             "--oneshot",
+            "--tui",
             "--no-progress",
             "--limit",
             "2",
@@ -363,6 +364,7 @@ mod tests {
             "--compact",
         ]);
 
+        assert!(args.tui);
         assert!(args.no_progress);
         assert_eq!(args.limit, Some(2));
         assert_eq!(args.workers, Some(4));
@@ -372,6 +374,14 @@ mod tests {
         assert_eq!(args.max_retries, Some(5));
         assert_eq!(args.github_token.as_deref(), Some("gh-test"));
         assert!(args.compact);
+    }
+
+    #[test]
+    fn parses_configure_tui_flag() {
+        let args = CliArgs::parse_from(["kcmt", "--configure", "--tui"]);
+
+        assert!(args.configure);
+        assert!(args.tui);
     }
 
     #[test]

--- a/rust/crates/kcmt-cli/src/commands/workflow.rs
+++ b/rust/crates/kcmt-cli/src/commands/workflow.rs
@@ -5,6 +5,7 @@ use std::process::Command;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::mpsc;
 use std::sync::Arc;
+use std::sync::Mutex;
 use std::thread;
 use std::time::Duration;
 use std::time::Instant;
@@ -32,6 +33,7 @@ use kcmt_provider::clients::{
 };
 use kcmt_provider::error_map::normalize_error;
 use kcmt_provider::transport::{AsyncTransport, RetryPolicy};
+use kcmt_tui::{WorkflowTuiContext, WorkflowTuiEvent, WorkflowTuiState};
 use serde_json::json;
 use time::format_description::well_known::Rfc3339;
 use time::OffsetDateTime;
@@ -167,22 +169,38 @@ struct PreparationResult {
 #[derive(Debug, Clone)]
 struct WorkflowProgress {
     enabled: bool,
+    tui_echo: bool,
     mode: &'static str,
     total: usize,
     queued: Arc<AtomicUsize>,
     completed: Arc<AtomicUsize>,
     failed: Arc<AtomicUsize>,
+    tui_state: Option<Arc<Mutex<WorkflowTuiState>>>,
 }
 
 impl WorkflowProgress {
-    fn new(mode: &'static str, total: usize, options: &WorkflowOutputOptions) -> Self {
+    fn new(
+        mode: &'static str,
+        total: usize,
+        options: &WorkflowOutputOptions,
+        context: WorkflowTuiContext,
+    ) -> Self {
+        let tui_state = if options.tui || options.tui_model_export {
+            let mut state = WorkflowTuiState::new(context);
+            state.apply(WorkflowTuiEvent::Discovered { total_files: total });
+            Some(Arc::new(Mutex::new(state)))
+        } else {
+            None
+        };
         let progress = Self {
             enabled: progress_enabled(options) && total > 0,
+            tui_echo: options.tui && !options.tui_model_export,
             mode,
             total,
             queued: Arc::new(AtomicUsize::new(0)),
             completed: Arc::new(AtomicUsize::new(0)),
             failed: Arc::new(AtomicUsize::new(0)),
+            tui_state,
         };
         progress.summary("start");
         progress
@@ -190,21 +208,88 @@ impl WorkflowProgress {
 
     fn queued(&self, stage: &'static str, file_path: &str) {
         self.queued.fetch_add(1, Ordering::Relaxed);
+        self.apply_tui(WorkflowTuiEvent::Queued {
+            file_path: file_path.to_string(),
+            stage: stage.to_string(),
+        });
         self.render(stage, Some(file_path), None);
     }
 
     fn event(&self, stage: &'static str, file_path: &str) {
+        if stage == "llm" {
+            self.apply_tui(WorkflowTuiEvent::RequestSent {
+                file_path: file_path.to_string(),
+            });
+        }
         self.render(stage, Some(file_path), None);
     }
 
-    fn completed(&self, file_path: &str) {
+    fn prepared(&self, file_path: &str, subject: &str) {
         self.completed.fetch_add(1, Ordering::Relaxed);
+        self.apply_tui(WorkflowTuiEvent::Prepared {
+            file_path: file_path.to_string(),
+            subject: subject.to_string(),
+        });
         self.render("done", Some(file_path), Some("ok"));
     }
 
-    fn failed(&self, file_path: &str) {
+    fn prepare_failed(&self, file_path: &str, error: &str) {
         self.failed.fetch_add(1, Ordering::Relaxed);
+        self.apply_tui(WorkflowTuiEvent::PrepareFailed {
+            file_path: file_path.to_string(),
+            error: error.to_string(),
+        });
         self.render("done", Some(file_path), Some("failed"));
+    }
+
+    fn commit_started(&self, file_path: &str) {
+        self.apply_tui(WorkflowTuiEvent::CommitStarted {
+            file_path: file_path.to_string(),
+        });
+        self.render("commit", Some(file_path), None);
+    }
+
+    fn commit_succeeded(&self, file_path: &str, subject: &str, commit_hash: Option<&str>) {
+        self.apply_tui(WorkflowTuiEvent::CommitSucceeded {
+            file_path: file_path.to_string(),
+            subject: subject.to_string(),
+            commit_hash: commit_hash.map(str::to_string),
+        });
+        self.render("committed", Some(file_path), Some("ok"));
+    }
+
+    fn commit_failed(&self, file_path: &str, error: &str) {
+        self.apply_tui(WorkflowTuiEvent::CommitFailed {
+            file_path: file_path.to_string(),
+            error: error.to_string(),
+        });
+        self.render("committed", Some(file_path), Some("failed"));
+    }
+
+    fn push_started(&self) {
+        self.apply_tui(WorkflowTuiEvent::PushStarted);
+        self.summary("push");
+    }
+
+    fn push_finished(&self, state: &str) {
+        self.apply_tui(WorkflowTuiEvent::PushFinished {
+            state: state.to_string(),
+        });
+        self.summary("push");
+    }
+
+    fn finished(&self) {
+        self.apply_tui(WorkflowTuiEvent::Finished);
+        self.summary("finished");
+    }
+
+    fn snapshot_json(&self) -> Option<String> {
+        self.tui_state.as_ref().and_then(|state| {
+            state
+                .lock()
+                .ok()
+                .and_then(|state| state.to_json_line().ok())
+        })
     }
 
     fn summary(&self, stage: &'static str) {
@@ -230,6 +315,22 @@ impl WorkflowProgress {
             line.push_str(&format!(" file={file_path}"));
         }
         eprintln!("{line}");
+    }
+
+    fn apply_tui(&self, event: WorkflowTuiEvent) {
+        let Some(state) = &self.tui_state else {
+            return;
+        };
+        let Ok(mut state) = state.lock() else {
+            return;
+        };
+        state.apply(event);
+        if self.tui_echo {
+            let lines = state.render_lines();
+            if let Some(summary) = lines.get(1) {
+                eprintln!("kcmt tui: {summary}");
+            }
+        }
     }
 }
 
@@ -282,6 +383,8 @@ pub struct WorkflowOutputOptions {
     pub compact: bool,
     pub verbose: bool,
     pub no_progress: bool,
+    pub tui: bool,
+    pub tui_model_export: bool,
     pub profile_startup: bool,
     pub startup_stages: Vec<WorkflowStageTiming>,
 }
@@ -500,7 +603,19 @@ fn run_entries_workflow(
     } else {
         "direct"
     };
-    let progress = WorkflowProgress::new(progress_mode, entries.len(), &output_options);
+    let progress = WorkflowProgress::new(
+        progress_mode,
+        entries.len(),
+        &output_options,
+        WorkflowTuiContext {
+            repo_path: repo_path.display().to_string(),
+            provider: config.provider.clone(),
+            model: config.model.clone(),
+            mode: progress_mode.to_string(),
+            total_files: entries.len(),
+            last_screen: preferences.tui.last_screen.clone(),
+        },
+    );
     let wait_start = Instant::now();
     let preparation = prepare_messages_for_entries(
         &repo_path,
@@ -509,7 +624,7 @@ fn run_entries_workflow(
         &runtime,
         max_attempts,
         prepare_workers,
-        progress,
+        progress.clone(),
     )?;
     telemetry.record_duration(
         "diff_preparation",
@@ -560,6 +675,7 @@ fn run_entries_workflow(
         let entry = prepared_entry.entry;
         let message = prepared_entry.message;
         let staging = entry.commit_staging();
+        progress.commit_started(&entry.path);
         let commit_outcome = match gix_session.as_mut() {
             Some(session) => session.commit_path(&entry.path, &message, staging),
             None if entry.source_path.is_some() => {
@@ -575,6 +691,7 @@ fn run_entries_workflow(
                     unstage_path(&repo_path, source_path);
                 }
                 unstage_path(&repo_path, &entry.path);
+                progress.commit_failed(&entry.path, &err.to_string());
                 failures.push(WorkflowFailure::commit(&entry, err.to_string()));
                 continue;
             }
@@ -594,6 +711,7 @@ fn run_entries_workflow(
             commit_hash
         };
 
+        progress.commit_succeeded(&entry.path, &message, commit_hash.as_deref());
         commits.push(WorkflowCommit {
             file_path: entry.path,
             message,
@@ -621,7 +739,9 @@ fn run_entries_workflow(
     telemetry.record_since("commit", commit_start, commits.len());
 
     let push_start = Instant::now();
+    progress.push_started();
     let push_outcome = auto_push_if_configured(&repo_path, config, !commits.is_empty());
+    progress.push_finished(push_outcome.state);
     telemetry.record_since("push", push_start, usize::from(push_outcome.pushed));
     telemetry.record_empty("output_render");
 
@@ -655,6 +775,8 @@ fn run_entries_workflow(
 
     if commits.is_empty() && total_entries <= 1 {
         if let Some(failure) = failures.first() {
+            progress.finished();
+            emit_tui_model_to_stderr(&progress, &output_options);
             return Err(KcmtError::Message(failure.error.clone()));
         }
     }
@@ -662,6 +784,11 @@ fn run_entries_workflow(
     if commits.is_empty() && total_entries <= 1 {
         Ok("No changes to commit.\n".to_string())
     } else {
+        progress.finished();
+        let tui_model_json = output_options
+            .tui_model_export
+            .then(|| progress.snapshot_json())
+            .flatten();
         Ok(render_workflow_output(
             config,
             &commits,
@@ -669,7 +796,16 @@ fn run_entries_workflow(
             &push_outcome,
             &telemetry,
             output_options,
+            tui_model_json.as_deref(),
         ))
+    }
+}
+
+fn emit_tui_model_to_stderr(progress: &WorkflowProgress, output_options: &WorkflowOutputOptions) {
+    if output_options.tui_model_export {
+        if let Some(model_json) = progress.snapshot_json() {
+            eprintln!("[kcmt-tui-model] {model_json}");
+        }
     }
 }
 
@@ -717,6 +853,7 @@ fn render_workflow_output(
     push_outcome: &PushOutcome,
     telemetry: &WorkflowTelemetry,
     options: WorkflowOutputOptions,
+    tui_model_json: Option<&str>,
 ) -> String {
     let mut lines = Vec::new();
     if options.compact {
@@ -759,6 +896,11 @@ fn render_workflow_output(
                 stage.stage, stage.duration_ms, stage.items
             ));
         }
+    }
+
+    if let Some(model_json) = tui_model_json {
+        lines.push(String::new());
+        lines.push(format!("[kcmt-tui-model] {model_json}"));
     }
 
     let mut output = lines.join("\n");
@@ -934,12 +1076,13 @@ fn prepare_messages_for_entries(
                 progress.event("llm", &entry.path);
                 match commit_message_for_entry(repo_path, &entry, config, runtime, max_attempts) {
                     Ok(message) => {
-                        progress.completed(&entry.path);
+                        progress.prepared(&entry.path, &message);
                         Ok(PreparedEntry { entry, message })
                     }
                     Err(err) => {
-                        progress.failed(&entry.path);
-                        Err(WorkflowFailure::prepare(&entry, err.to_string()))
+                        let error = err.to_string();
+                        progress.prepare_failed(&entry.path, &error);
+                        Err(WorkflowFailure::prepare(&entry, error))
                     }
                 }
             })
@@ -1004,12 +1147,13 @@ fn prepare_messages_in_workers(
                             max_attempts,
                         ) {
                             Ok(message) => {
-                                progress.completed(&entry.path);
+                                progress.prepared(&entry.path, &message);
                                 Ok(PreparedEntry { entry, message })
                             }
                             Err(err) => {
-                                progress.failed(&entry.path);
-                                Err(WorkflowFailure::prepare(&entry, err.to_string()))
+                                let error = err.to_string();
+                                progress.prepare_failed(&entry.path, &error);
+                                Err(WorkflowFailure::prepare(&entry, error))
                             }
                         };
                         (index, outcome)
@@ -1088,7 +1232,7 @@ fn prepare_provider_batch_messages(
         if entry.is_deletion() {
             let message = deletion_commit_message(&entry.path, config.max_commit_length);
             progress.queued("local", &entry.path);
-            progress.completed(&entry.path);
+            progress.prepared(&entry.path, &message);
             outcomes.push(Ok(PreparedEntry { entry, message }));
             continue;
         }
@@ -1100,8 +1244,9 @@ fn prepare_provider_batch_messages(
             Err(err) => {
                 telemetry.diff_preparation_ms += diff_start.elapsed().as_secs_f64() * 1000.0;
                 telemetry.diff_preparation_items += 1;
-                progress.failed(&entry.path);
-                outcomes.push(Err(WorkflowFailure::prepare(&entry, err.to_string())));
+                let error = err.to_string();
+                progress.prepare_failed(&entry.path, &error);
+                outcomes.push(Err(WorkflowFailure::prepare(&entry, error)));
                 continue;
             }
         };
@@ -1236,7 +1381,7 @@ fn prepare_provider_batch_messages(
             }
             let error = provider_error_message("provider batch request failed", &err.to_string());
             outcomes.extend(batch_entries.into_iter().map(|entry| {
-                progress.failed(&entry.path);
+                progress.prepare_failed(&entry.path, &error);
                 Err(WorkflowFailure::prepare(&entry, error.clone()))
             }));
             progress.summary("results");
@@ -1270,17 +1415,15 @@ fn prepare_provider_batch_messages(
 
     for entry in batch_entries {
         if let Some(message) = messages_by_id.remove(&entry.path) {
-            progress.completed(&entry.path);
+            progress.prepared(&entry.path, &message);
             outcomes.push(Ok(PreparedEntry { entry, message }));
         } else if let Some(error) = errors_by_id.remove(&entry.path) {
-            progress.failed(&entry.path);
+            progress.prepare_failed(&entry.path, &error);
             outcomes.push(Err(WorkflowFailure::prepare(&entry, error)));
         } else {
-            progress.failed(&entry.path);
-            outcomes.push(Err(WorkflowFailure::prepare(
-                &entry,
-                format!("batch response missing {}", entry.path),
-            )));
+            let error = format!("batch response missing {}", entry.path);
+            progress.prepare_failed(&entry.path, &error);
+            outcomes.push(Err(WorkflowFailure::prepare(&entry, error)));
         }
     }
     progress.summary("results");

--- a/rust/crates/kcmt-cli/src/commands/workflow.rs
+++ b/rust/crates/kcmt-cli/src/commands/workflow.rs
@@ -194,7 +194,7 @@ impl WorkflowProgress {
         };
         let progress = Self {
             enabled: progress_enabled(options) && total > 0,
-            tui_echo: options.tui && !options.tui_model_export,
+            tui_echo: options.tui && !options.tui_model_export && progress_enabled(options),
             mode,
             total,
             queued: Arc::new(AtomicUsize::new(0)),
@@ -2395,10 +2395,12 @@ mod tests {
         git_common_config_path, git_config_has_include, git_config_value, heuristic_commit_message,
         local_origin_remote_probe, parse_status_entries, select_prepare_workers,
         selected_workflow_config, OriginRemoteProbe, StatusEntry,
+        WorkflowOutputOptions, WorkflowProgress,
     };
     use kcmt_core::git::commit_file::CommitStaging;
     use kcmt_core::model::{ModelPreference, ProviderConfigEntry, WorkflowConfig};
     use kcmt_core::selector::ModelSelection;
+    use kcmt_tui::WorkflowTuiContext;
     use std::fs;
     use std::path::{Path, PathBuf};
     use std::sync::atomic::{AtomicU64, Ordering};
@@ -2420,6 +2422,17 @@ mod tests {
         let git_dir = repo.join(".git");
         fs::create_dir_all(&git_dir).expect("git dir should be created");
         fs::write(git_dir.join("config"), config).expect("git config should be written");
+    }
+
+    fn tui_context(total_files: usize) -> WorkflowTuiContext {
+        WorkflowTuiContext {
+            repo_path: "/repo".to_string(),
+            provider: "openai".to_string(),
+            model: "gpt-test".to_string(),
+            mode: "direct".to_string(),
+            total_files,
+            last_screen: None,
+        }
     }
 
     fn git(repo: &Path, args: &[&str]) {
@@ -2459,6 +2472,20 @@ mod tests {
                 },
             ]
         );
+    }
+
+    #[test]
+    fn workflow_tui_echo_respects_no_progress() {
+        let options = WorkflowOutputOptions {
+            tui: true,
+            no_progress: true,
+            ..WorkflowOutputOptions::default()
+        };
+
+        let progress = WorkflowProgress::new("direct", 1, &options, tui_context(1));
+
+        assert!(!progress.enabled);
+        assert!(!progress.tui_echo);
     }
 
     #[test]

--- a/rust/crates/kcmt-cli/src/lib.rs
+++ b/rust/crates/kcmt-cli/src/lib.rs
@@ -11,8 +11,8 @@ use std::time::Instant;
 use kcmt_core::config::loader::ConfigOverrides;
 use kcmt_core::git::repo::find_git_repo_root;
 use kcmt_core::preferences::{
-    default_keychain_account, save_keychain_secret, KeychainProtection, KeychainSaveMode,
-    OsKeychainStore,
+    default_keychain_account, load_preferences, save_keychain_secret, save_preferences,
+    KeychainProtection, KeychainSaveMode, OsKeychainStore,
 };
 
 use args::{CliArgs, CliCommand, StatusArgs};
@@ -59,6 +59,8 @@ fn output_options(args: &CliArgs) -> WorkflowOutputOptions {
         compact: args.compact,
         verbose: args.verbose || args.debug,
         no_progress: args.no_progress,
+        tui: args.tui,
+        tui_model_export: args.tui && env_truthy("KCMT_TUI_MODEL_EXPORT"),
         profile_startup: args.profile_startup || args.debug,
         startup_stages: Vec::new(),
     }
@@ -194,6 +196,10 @@ fn dispatch(_entrypoint: &str, args: CliArgs, arg_parse_ms: f64) -> i32 {
             commands::benchmark::run_benchmark_command(repo_path, benchmark)
         }
         None => {
+            let workflow_tui_active = match prepare_workflow_tui(&args) {
+                Ok(active) => active,
+                Err(code) => return code,
+            };
             if let Some(path) = args.file.clone() {
                 let repo_path = match repo_discovery.found_repo_path.clone() {
                     Some(repo_path) => repo_path,
@@ -207,6 +213,7 @@ fn dispatch(_entrypoint: &str, args: CliArgs, arg_parse_ms: f64) -> i32 {
                 };
                 let overrides = config_overrides(&args, repo_path.clone());
                 let mut output_options = output_options(&args);
+                output_options.tui = workflow_tui_active;
                 add_dispatch_telemetry(
                     &mut output_options,
                     &repo_discovery,
@@ -242,6 +249,7 @@ fn dispatch(_entrypoint: &str, args: CliArgs, arg_parse_ms: f64) -> i32 {
                 };
                 let overrides = config_overrides(&args, repo_path.clone());
                 let mut output_options = output_options(&args);
+                output_options.tui = workflow_tui_active;
                 add_dispatch_telemetry(
                     &mut output_options,
                     &repo_discovery,
@@ -275,6 +283,7 @@ fn dispatch(_entrypoint: &str, args: CliArgs, arg_parse_ms: f64) -> i32 {
             };
             let overrides = config_overrides(&args, repo_path.clone());
             let mut output_options = output_options(&args);
+            output_options.tui = workflow_tui_active;
             add_dispatch_telemetry(
                 &mut output_options,
                 &repo_discovery,
@@ -293,6 +302,43 @@ fn dispatch(_entrypoint: &str, args: CliArgs, arg_parse_ms: f64) -> i32 {
             }
         }
     }
+}
+
+fn prepare_workflow_tui(args: &CliArgs) -> std::result::Result<bool, i32> {
+    if !args.tui {
+        return Ok(false);
+    }
+    if env_truthy("KCMT_TUI_MODEL_EXPORT") {
+        persist_tui_last_screen("workflow");
+        return Ok(true);
+    }
+    if kcmt_tui::should_enable_tui(false) {
+        persist_tui_last_screen("workflow");
+        return Ok(true);
+    }
+    eprintln!(
+        "--tui workflow mode requires an interactive terminal; omit --tui for non-interactive CLI use"
+    );
+    Err(1)
+}
+
+fn persist_tui_last_screen(screen: &str) {
+    let mut preferences = load_preferences().unwrap_or_default();
+    preferences.tui.last_screen = Some(screen.to_string());
+    if let Err(err) = save_preferences(&preferences) {
+        eprintln!("warning: failed to save TUI preferences: {err}");
+    }
+}
+
+fn env_truthy(key: &str) -> bool {
+    std::env::var(key)
+        .map(|value| {
+            matches!(
+                value.trim().to_ascii_lowercase().as_str(),
+                "1" | "true" | "yes" | "on"
+            )
+        })
+        .unwrap_or(false)
 }
 
 fn read_secret_from_stdin() -> Option<String> {

--- a/rust/crates/kcmt-cli/tests/workflow_modes.rs
+++ b/rust/crates/kcmt-cli/tests/workflow_modes.rs
@@ -90,6 +90,19 @@ fn raw_status_snapshot(repo: &Path, config_home: &Path) -> serde_json::Value {
     serde_json::from_slice(&status_output.stdout).expect("raw status is json")
 }
 
+fn tui_model_from_stdout(stdout: &[u8]) -> serde_json::Value {
+    let stdout = String::from_utf8_lossy(stdout);
+    tui_model_from_text(&stdout)
+}
+
+fn tui_model_from_text(output: &str) -> serde_json::Value {
+    let model_line = output
+        .lines()
+        .find_map(|line| line.strip_prefix("[kcmt-tui-model] "))
+        .unwrap_or_else(|| panic!("missing TUI model line in output: {output}"));
+    serde_json::from_str(model_line).expect("TUI model line is json")
+}
+
 fn telemetry_stage_items(snapshot: &serde_json::Value, stage_name: &str) -> u64 {
     snapshot["telemetry"]["stages"]
         .as_array()
@@ -100,6 +113,114 @@ fn telemetry_stage_items(snapshot: &serde_json::Value, stage_name: &str) -> u64 
         .get("items")
         .and_then(serde_json::Value::as_u64)
         .expect("stage items should be an integer")
+}
+
+#[test]
+fn explicit_tui_workflow_rejects_non_tty_without_committing() {
+    let repo = init_repo();
+    let config_home = unique_temp_dir("config-home");
+    fs::write(repo.join("tracked.py"), "print('seed')\n").expect("tracked seed");
+    git(&repo, &["add", "tracked.py"]);
+    git(&repo, &["commit", "-m", "chore(repo): seed"]);
+    let initial_head = git(&repo, &["rev-parse", "HEAD"]);
+
+    fs::write(repo.join("tracked.py"), "print('changed')\n").expect("tracked change");
+
+    let output = kcmt_command(env!("CARGO_BIN_EXE_kcmt"))
+        .env("KCMT_CONFIG_HOME", &config_home)
+        .args(["--tui", "--no-auto-push", "--repo-path"])
+        .arg(&repo)
+        .output()
+        .expect("kcmt binary should run");
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("--tui workflow mode requires an interactive terminal"),
+        "stderr: {stderr}"
+    );
+    assert_eq!(git(&repo, &["rev-parse", "HEAD"]), initial_head);
+    assert_eq!(git(&repo, &["status", "--short"]), "M tracked.py");
+}
+
+#[test]
+fn explicit_tui_workflow_exports_model_and_persists_screen() {
+    let repo = init_repo();
+    let config_home = unique_temp_dir("config-home");
+    fs::write(repo.join("tracked.py"), "print('seed')\n").expect("tracked seed");
+    git(&repo, &["add", "tracked.py"]);
+    git(&repo, &["commit", "-m", "chore(repo): seed"]);
+
+    fs::write(repo.join("tracked.py"), "print('changed')\n").expect("tracked change");
+
+    let output = kcmt_command(env!("CARGO_BIN_EXE_kcmt"))
+        .env("KCMT_CONFIG_HOME", &config_home)
+        .env("KCMT_TUI_MODEL_EXPORT", "1")
+        .args(["--tui", "--no-auto-push", "--repo-path"])
+        .arg(&repo)
+        .output()
+        .expect("kcmt binary should run");
+
+    assert!(
+        output.status.success(),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let model = tui_model_from_stdout(&output.stdout);
+    assert_eq!(model["screen"], "workflow");
+    assert_eq!(model["provider"], "openai");
+    assert_eq!(model["model"], "gpt-5-mini-2025-08-07");
+    assert_eq!(model["current_phase"], "complete");
+    assert_eq!(model["total_files"], 1);
+    assert_eq!(model["committed"], 1);
+    assert_eq!(model["files"]["tracked.py"]["status"], "committed");
+    assert_eq!(
+        model["files"]["tracked.py"]["subject"],
+        "chore(repo): update tracked"
+    );
+
+    let preferences: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(config_home.join("preferences.json")).unwrap())
+            .expect("preferences json");
+    assert_eq!(preferences["tui"]["last_screen"], "workflow");
+}
+
+#[test]
+fn explicit_tui_workflow_exports_prepare_failure_model() {
+    let repo = init_repo();
+    let config_home = unique_temp_dir("config-home");
+    fs::write(repo.join("tracked.py"), "print('seed')\n").expect("tracked seed");
+    git(&repo, &["add", "tracked.py"]);
+    git(&repo, &["commit", "-m", "chore(repo): seed"]);
+
+    fs::write(repo.join("tracked.py"), "print('changed')\n").expect("tracked change");
+
+    let output = kcmt_command(env!("CARGO_BIN_EXE_kcmt"))
+        .env("KCMT_CONFIG_HOME", &config_home)
+        .env("KCMT_TUI_MODEL_EXPORT", "1")
+        .env("KCMT_ALLOW_PROVIDER_RESPONSE_FIXTURE", "1")
+        .env("KCMT_PROVIDER_RESPONSE", "not a conventional commit")
+        .args([
+            "--tui",
+            "--file",
+            "tracked.py",
+            "--no-auto-push",
+            "--repo-path",
+        ])
+        .arg(&repo)
+        .output()
+        .expect("kcmt binary should run");
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let model = tui_model_from_text(&stderr);
+    assert_eq!(model["current_phase"], "complete_with_failures");
+    assert_eq!(model["committed"], 0);
+    assert_eq!(model["failed"], 1);
+    assert_eq!(model["files"]["tracked.py"]["status"], "failed");
+    assert_eq!(model["files"]["tracked.py"]["stage"], "prepare_failed");
+    assert_eq!(git(&repo, &["status", "--short"]), "M tracked.py");
 }
 
 fn init_bare_remote() -> PathBuf {

--- a/rust/crates/kcmt-tui/Cargo.toml
+++ b/rust/crates/kcmt-tui/Cargo.toml
@@ -13,4 +13,6 @@ path = "src/lib.rs"
 anyhow.workspace = true
 crossterm = "0.29"
 ratatui = "0.29"
+serde.workspace = true
+serde_json.workspace = true
 tracing.workspace = true

--- a/rust/crates/kcmt-tui/src/lib.rs
+++ b/rust/crates/kcmt-tui/src/lib.rs
@@ -1,5 +1,6 @@
-//! Optional Ratatui configure shell gated behind terminal checks.
+//! Optional Ratatui shells and testable state models.
 
+use std::collections::BTreeMap;
 use std::io::{self, IsTerminal};
 use std::time::Duration;
 
@@ -13,6 +14,7 @@ use ratatui::layout::{Constraint, Direction, Layout};
 use ratatui::style::{Modifier, Style};
 use ratatui::widgets::{Block, Borders, List, ListItem, Paragraph};
 use ratatui::Terminal;
+use serde::{Deserialize, Serialize};
 
 /// Minimal TUI placeholder used until interactive workflows are implemented.
 pub struct TuiApp;
@@ -29,6 +31,241 @@ pub fn should_enable_tui(explicit_no_tui: bool) -> bool {
         return false;
     }
     io::stdin().is_terminal() && io::stdout().is_terminal()
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WorkflowTuiContext {
+    pub repo_path: String,
+    pub provider: String,
+    pub model: String,
+    pub mode: String,
+    pub total_files: usize,
+    pub last_screen: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WorkflowTuiState {
+    pub screen: String,
+    pub repo_path: String,
+    pub provider: String,
+    pub model: String,
+    pub mode: String,
+    pub current_phase: String,
+    pub total_files: usize,
+    pub queued: usize,
+    pub prepared: usize,
+    pub committed: usize,
+    pub failed: usize,
+    pub push_state: String,
+    pub active_file: Option<String>,
+    pub files: BTreeMap<String, WorkflowTuiFileState>,
+}
+
+impl WorkflowTuiState {
+    pub fn new(context: WorkflowTuiContext) -> Self {
+        Self {
+            screen: context
+                .last_screen
+                .filter(|screen| !screen.trim().is_empty())
+                .unwrap_or_else(|| "workflow".to_string()),
+            repo_path: context.repo_path,
+            provider: context.provider,
+            model: context.model,
+            mode: context.mode,
+            current_phase: "starting".to_string(),
+            total_files: context.total_files,
+            queued: 0,
+            prepared: 0,
+            committed: 0,
+            failed: 0,
+            push_state: "not triggered".to_string(),
+            active_file: None,
+            files: BTreeMap::new(),
+        }
+    }
+
+    pub fn apply(&mut self, event: WorkflowTuiEvent) {
+        match event {
+            WorkflowTuiEvent::Discovered { total_files } => {
+                self.total_files = total_files;
+                self.current_phase = "discovered".to_string();
+            }
+            WorkflowTuiEvent::Queued { file_path, stage } => {
+                self.queued += 1;
+                self.active_file = Some(file_path.clone());
+                self.current_phase = stage.clone();
+                let file = self.file_mut(&file_path);
+                file.stage = stage;
+                file.status = "queued".to_string();
+            }
+            WorkflowTuiEvent::RequestSent { file_path } => {
+                self.active_file = Some(file_path.clone());
+                self.current_phase = "llm_wait".to_string();
+                let file = self.file_mut(&file_path);
+                file.stage = "llm_wait".to_string();
+                file.status = "request_sent".to_string();
+            }
+            WorkflowTuiEvent::Prepared { file_path, subject } => {
+                self.prepared += 1;
+                self.active_file = Some(file_path.clone());
+                self.current_phase = "prepared".to_string();
+                let file = self.file_mut(&file_path);
+                file.stage = "prepared".to_string();
+                file.status = "ready".to_string();
+                file.subject = Some(subject);
+            }
+            WorkflowTuiEvent::PrepareFailed { file_path, error } => {
+                self.failed += 1;
+                self.active_file = Some(file_path.clone());
+                self.current_phase = "failed".to_string();
+                let file = self.file_mut(&file_path);
+                file.stage = "prepare_failed".to_string();
+                file.status = "failed".to_string();
+                file.error = Some(error);
+            }
+            WorkflowTuiEvent::CommitStarted { file_path } => {
+                self.active_file = Some(file_path.clone());
+                self.current_phase = "commit".to_string();
+                let file = self.file_mut(&file_path);
+                file.stage = "commit".to_string();
+                file.status = "in_progress".to_string();
+            }
+            WorkflowTuiEvent::CommitSucceeded {
+                file_path,
+                subject,
+                commit_hash,
+            } => {
+                self.committed += 1;
+                self.active_file = Some(file_path.clone());
+                self.current_phase = "committed".to_string();
+                let file = self.file_mut(&file_path);
+                file.stage = "done".to_string();
+                file.status = "committed".to_string();
+                file.subject = Some(subject);
+                file.commit_hash = commit_hash;
+            }
+            WorkflowTuiEvent::CommitFailed { file_path, error } => {
+                self.failed += 1;
+                self.active_file = Some(file_path.clone());
+                self.current_phase = "failed".to_string();
+                let file = self.file_mut(&file_path);
+                file.stage = "commit_failed".to_string();
+                file.status = "failed".to_string();
+                file.error = Some(error);
+            }
+            WorkflowTuiEvent::PushStarted => {
+                self.current_phase = "push".to_string();
+                self.push_state = "in_progress".to_string();
+            }
+            WorkflowTuiEvent::PushFinished { state } => {
+                self.current_phase = "push".to_string();
+                self.push_state = state;
+            }
+            WorkflowTuiEvent::Finished => {
+                self.current_phase = if self.failed > 0 {
+                    "complete_with_failures".to_string()
+                } else {
+                    "complete".to_string()
+                };
+                self.active_file = None;
+            }
+        }
+    }
+
+    pub fn render_lines(&self) -> Vec<String> {
+        let mut lines = vec![
+            format!(
+                "kcmt workflow [{}] provider={} model={}",
+                self.mode, self.provider, self.model
+            ),
+            format!(
+                "phase={} files={} queued={} prepared={} committed={} failed={} push={}",
+                self.current_phase,
+                self.total_files,
+                self.queued,
+                self.prepared,
+                self.committed,
+                self.failed,
+                self.push_state
+            ),
+        ];
+        if let Some(active_file) = &self.active_file {
+            lines.push(format!("active={active_file}"));
+        }
+        lines.extend(self.files.iter().map(|(path, file)| {
+            let subject = file.subject.as_deref().unwrap_or("-");
+            let error = file.error.as_deref().unwrap_or("-");
+            format!(
+                "{}\t{}\t{}\t{}\t{}",
+                path, file.stage, file.status, subject, error
+            )
+        }));
+        lines
+    }
+
+    pub fn to_json_line(&self) -> anyhow::Result<String> {
+        Ok(serde_json::to_string(self)?)
+    }
+
+    fn file_mut(&mut self, path: &str) -> &mut WorkflowTuiFileState {
+        self.files
+            .entry(path.to_string())
+            .or_insert_with(|| WorkflowTuiFileState {
+                stage: "pending".to_string(),
+                status: "pending".to_string(),
+                subject: None,
+                commit_hash: None,
+                error: None,
+            })
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WorkflowTuiFileState {
+    pub stage: String,
+    pub status: String,
+    pub subject: Option<String>,
+    pub commit_hash: Option<String>,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WorkflowTuiEvent {
+    Discovered {
+        total_files: usize,
+    },
+    Queued {
+        file_path: String,
+        stage: String,
+    },
+    RequestSent {
+        file_path: String,
+    },
+    Prepared {
+        file_path: String,
+        subject: String,
+    },
+    PrepareFailed {
+        file_path: String,
+        error: String,
+    },
+    CommitStarted {
+        file_path: String,
+    },
+    CommitSucceeded {
+        file_path: String,
+        subject: String,
+        commit_hash: Option<String>,
+    },
+    CommitFailed {
+        file_path: String,
+        error: String,
+    },
+    PushStarted,
+    PushFinished {
+        state: String,
+    },
+    Finished,
 }
 
 #[derive(Debug, Clone)]
@@ -148,5 +385,100 @@ mod tests {
         assert_eq!(state.provider, "anthropic");
         assert!(matches!(outcome, ConfigureTuiOutcome::Save));
         assert_ne!(outcome, ConfigureTuiOutcome::Cancel);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{WorkflowTuiContext, WorkflowTuiEvent, WorkflowTuiState};
+
+    fn context(total_files: usize) -> WorkflowTuiContext {
+        WorkflowTuiContext {
+            repo_path: "/repo".to_string(),
+            provider: "openai".to_string(),
+            model: "gpt-test".to_string(),
+            mode: "direct".to_string(),
+            total_files,
+            last_screen: None,
+        }
+    }
+
+    #[test]
+    fn workflow_model_tracks_commit_lifecycle() {
+        let mut state = WorkflowTuiState::new(context(1));
+        state.apply(WorkflowTuiEvent::Discovered { total_files: 1 });
+        state.apply(WorkflowTuiEvent::Queued {
+            file_path: "alpha.py".to_string(),
+            stage: "diff".to_string(),
+        });
+        state.apply(WorkflowTuiEvent::RequestSent {
+            file_path: "alpha.py".to_string(),
+        });
+        state.apply(WorkflowTuiEvent::Prepared {
+            file_path: "alpha.py".to_string(),
+            subject: "fix(alpha): update alpha".to_string(),
+        });
+        state.apply(WorkflowTuiEvent::CommitStarted {
+            file_path: "alpha.py".to_string(),
+        });
+        state.apply(WorkflowTuiEvent::CommitSucceeded {
+            file_path: "alpha.py".to_string(),
+            subject: "fix(alpha): update alpha".to_string(),
+            commit_hash: Some("abcdef1".to_string()),
+        });
+        state.apply(WorkflowTuiEvent::PushFinished {
+            state: "not triggered".to_string(),
+        });
+        state.apply(WorkflowTuiEvent::Finished);
+
+        assert_eq!(state.current_phase, "complete");
+        assert_eq!(state.queued, 1);
+        assert_eq!(state.prepared, 1);
+        assert_eq!(state.committed, 1);
+        assert_eq!(state.failed, 0);
+        let file = state.files.get("alpha.py").expect("file state");
+        assert_eq!(file.stage, "done");
+        assert_eq!(file.status, "committed");
+        assert_eq!(file.commit_hash.as_deref(), Some("abcdef1"));
+        assert!(state.render_lines()[1].contains("committed=1"));
+    }
+
+    #[test]
+    fn workflow_model_tracks_prepare_and_commit_failures_by_path() {
+        let mut state = WorkflowTuiState::new(context(2));
+        state.apply(WorkflowTuiEvent::PrepareFailed {
+            file_path: "alpha.py".to_string(),
+            error: "missing conventional commit header".to_string(),
+        });
+        state.apply(WorkflowTuiEvent::Prepared {
+            file_path: "beta.py".to_string(),
+            subject: "fix(beta): update beta".to_string(),
+        });
+        state.apply(WorkflowTuiEvent::CommitStarted {
+            file_path: "beta.py".to_string(),
+        });
+        state.apply(WorkflowTuiEvent::CommitFailed {
+            file_path: "beta.py".to_string(),
+            error: "index lock".to_string(),
+        });
+        state.apply(WorkflowTuiEvent::Finished);
+
+        assert_eq!(state.current_phase, "complete_with_failures");
+        assert_eq!(state.failed, 2);
+        assert_eq!(
+            state.files["alpha.py"].error.as_deref(),
+            Some("missing conventional commit header")
+        );
+        assert_eq!(state.files["beta.py"].stage, "commit_failed");
+    }
+
+    #[test]
+    fn workflow_model_uses_persisted_last_screen() {
+        let mut context = context(0);
+        context.last_screen = Some("workflow".to_string());
+
+        let state = WorkflowTuiState::new(context);
+
+        assert_eq!(state.screen, "workflow");
     }
 }

--- a/rust/crates/kcmt-tui/src/lib.rs
+++ b/rust/crates/kcmt-tui/src/lib.rs
@@ -369,28 +369,7 @@ fn run_loop(
 
 #[cfg(test)]
 mod tests {
-    use super::{ConfigureTuiOutcome, ConfigureTuiState};
-
-    #[test]
-    fn configure_tui_state_names_save_and_cancel_outcomes() {
-        let state = ConfigureTuiState {
-            provider: "anthropic".to_string(),
-            model: "claude-test".to_string(),
-            rule: "provider presets enabled".to_string(),
-            credential_status: "keychain first, environment fallback".to_string(),
-        };
-
-        let outcome = ConfigureTuiOutcome::Save;
-
-        assert_eq!(state.provider, "anthropic");
-        assert!(matches!(outcome, ConfigureTuiOutcome::Save));
-        assert_ne!(outcome, ConfigureTuiOutcome::Cancel);
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::{WorkflowTuiContext, WorkflowTuiEvent, WorkflowTuiState};
+    use super::{ConfigureTuiOutcome, ConfigureTuiState, WorkflowTuiContext, WorkflowTuiEvent, WorkflowTuiState};
 
     fn context(total_files: usize) -> WorkflowTuiContext {
         WorkflowTuiContext {
@@ -480,5 +459,21 @@ mod tests {
         let state = WorkflowTuiState::new(context);
 
         assert_eq!(state.screen, "workflow");
+    }
+
+    #[test]
+    fn configure_tui_state_names_save_and_cancel_outcomes() {
+        let state = ConfigureTuiState {
+            provider: "anthropic".to_string(),
+            model: "claude-test".to_string(),
+            rule: "provider presets enabled".to_string(),
+            credential_status: "keychain first, environment fallback".to_string(),
+        };
+
+        let outcome = ConfigureTuiOutcome::Save;
+
+        assert_eq!(state.provider, "anthropic");
+        assert!(matches!(outcome, ConfigureTuiOutcome::Save));
+        assert_ne!(outcome, ConfigureTuiOutcome::Cancel);
     }
 }

--- a/tests/features/rust_workflow_parity.feature
+++ b/tests/features/rust_workflow_parity.feature
@@ -200,6 +200,12 @@ Feature: Rust workflow parity
     When the Rust kcmt command runs in oneshot mode
     Then the Rust stats command reports usage telemetry
 
+  Scenario: Explicit Rust workflow TUI exports a state model
+    Given a git repository with one changed tracked file
+    When the Rust kcmt command runs default workflow with explicit TUI model export
+    Then the Rust workflow TUI model records the committed file
+    And the Rust preferences remember the workflow screen
+
   Scenario: Rust list-models shows supported default models
     Given an empty runtime configuration home
     When the Rust kcmt command lists models

--- a/tests/test_rust_workflow_parity_bdd.py
+++ b/tests/test_rust_workflow_parity_bdd.py
@@ -2337,6 +2337,7 @@ def rust_preferences_file_contains_default_selector_preferences(
     assert preferences["provider_rules"]["xai"]["preset"] == "none"
     assert preferences["provider_rules"]["github"]["preset"] == "none"
 
+
 @then("the keychain save response does not print the API key")
 def keychain_save_response_does_not_print_api_key(
     workflow_context: dict[str, Any],
@@ -2357,6 +2358,7 @@ def no_saved_configuration_file_contains_api_key(
     for path in config_home.rglob("*"):
         if path.is_file():
             assert workflow_context["secret"] not in path.read_text(errors="ignore")
+
 
 @then("the Rust preferences remember the workflow screen")
 def rust_preferences_remember_the_workflow_screen(

--- a/tests/test_rust_workflow_parity_bdd.py
+++ b/tests/test_rust_workflow_parity_bdd.py
@@ -822,6 +822,26 @@ def rust_kcmt_command_runs_in_default_workflow_mode(
     workflow_context["output"] = output
 
 
+@when("the Rust kcmt command runs default workflow with explicit TUI model export")
+def rust_kcmt_command_runs_default_workflow_with_explicit_tui_model_export(
+    workflow_context: dict[str, Any],
+) -> None:
+    env = _clean_env(workflow_context["config_home"])
+    env["KCMT_TUI_MODEL_EXPORT"] = "1"
+    output = _run(
+        [
+            str(_rust_bin("kcmt")),
+            "--tui",
+            "--no-auto-push",
+            "--repo-path",
+            str(workflow_context["repo"]),
+        ],
+        REPO_ROOT,
+        env=env,
+    )
+    workflow_context["output"] = output
+
+
 @when("the Rust kcmt command runs in default workflow mode with two workers")
 def rust_kcmt_command_runs_in_default_workflow_mode_with_two_workers(
     workflow_context: dict[str, Any],
@@ -1837,6 +1857,28 @@ def compact_workflow_output_includes_profile_timings(
     assert "[kcmt-profile] snapshot:" in output
 
 
+@then("the Rust workflow TUI model records the committed file")
+def rust_workflow_tui_model_records_the_committed_file(
+    workflow_context: dict[str, Any],
+) -> None:
+    output = workflow_context["output"]
+    model_line = next(
+        line.removeprefix("[kcmt-tui-model] ")
+        for line in output.splitlines()
+        if line.startswith("[kcmt-tui-model] ")
+    )
+    model = json.loads(model_line)
+    assert model["screen"] == "workflow"
+    assert model["provider"] == "openai"
+    assert model["mode"] == "direct"
+    assert model["current_phase"] == "complete"
+    assert model["total_files"] == 1
+    assert model["committed"] == 1
+    assert model["failed"] == 0
+    assert model["files"]["tracked.py"]["status"] == "committed"
+    assert model["files"]["tracked.py"]["subject"] == "chore(repo): update tracked"
+
+
 @then("the raw status snapshot records the config overrides")
 def raw_status_snapshot_records_the_config_overrides(
     workflow_context: dict[str, Any],
@@ -2295,7 +2337,6 @@ def rust_preferences_file_contains_default_selector_preferences(
     assert preferences["provider_rules"]["xai"]["preset"] == "none"
     assert preferences["provider_rules"]["github"]["preset"] == "none"
 
-
 @then("the keychain save response does not print the API key")
 def keychain_save_response_does_not_print_api_key(
     workflow_context: dict[str, Any],
@@ -2316,6 +2357,15 @@ def no_saved_configuration_file_contains_api_key(
     for path in config_home.rglob("*"):
         if path.is_file():
             assert workflow_context["secret"] not in path.read_text(errors="ignore")
+
+@then("the Rust preferences remember the workflow screen")
+def rust_preferences_remember_the_workflow_screen(
+    workflow_context: dict[str, Any],
+) -> None:
+    preferences = json.loads(
+        (workflow_context["config_home"] / "preferences.json").read_text()
+    )
+    assert preferences["tui"]["last_screen"] == "workflow"
 
 
 @then("the Anthropic provider receives the latest Haiku model")


### PR DESCRIPTION
## Summary
- Adds a Rust workflow TUI state model for explicit workflow `--tui` runs, tracking provider/model visibility, per-file progress, commit/failure state, push state, and persisted `tui.last_screen`.
- Preserves PR #37 configure `--tui` behavior while making workflow `--tui` an explicit opt-in path that rejects non-TTY use before committing.
- Adds deterministic TUI model export for executable tests and avoids macOS keychain probes during runtime benchmark mode.

## Conventional Commit Breakdown
| Commit | Type | Scope | Summary | Version Impact |
| --- | --- | --- | --- | --- |
| `22a86b7` | feat | rust | add workflow TUI state model | minor |

## Release Notes Draft
- Rust workflow runs now have a testable TUI state model behind explicit `--tui`, including per-file progress and failure state.
- Non-interactive CLI behavior is unchanged unless `--tui` is explicitly requested.

## Behaviour Changes
- `kcmt --tui ...` for workflow commands now requires an interactive terminal unless `KCMT_TUI_MODEL_EXPORT=1` is set for tests.
- In non-TTY workflow use, explicit `--tui` exits with a clear error before writing commits.
- Configure `--tui` remains on the existing PR #37 configure path.

## API / Schema / Contract Changes
- Adds serialized Rust workflow TUI model fields for repo path, provider, model, mode, phase, counters, push state, and file states.
- Adds BDD coverage for explicit Rust workflow TUI model export.
- No external API or storage schema migration required.

## Testing Evidence
- `cargo test --manifest-path rust/Cargo.toml -p kcmt-tui workflow_model`
- `cargo test --manifest-path rust/Cargo.toml -p kcmt-cli explicit_tui_workflow --test workflow_modes`
- `uv run pytest -q tests/test_rust_workflow_parity_bdd.py -k "tui and state" --no-cov`
- `cargo test --manifest-path rust/Cargo.toml -p kcmt-cli --test benchmark_contracts runtime_benchmark_fast_snapshot_keeps_python_compatible_keys`
- `cargo test --manifest-path rust/Cargo.toml -p kcmt-cli --test benchmark_contracts runtime_benchmark_rust_ingests_snapshot_stage_timings_json`

## Coverage Evidence
- `make check` reported Python coverage total 93.88%, above the 80% threshold.
- `make quality-gates` completed successfully after the focused Rust and BDD tests.

## Quality Gate Evidence
- `git diff --check` passed.
- `make check` passed.
- `make quality-gates` passed.

## Demo Evidence
- Model-export tests cover successful workflow export, non-TTY rejection before committing, and single-file prepare-failure export.

## Versioning / SemVer Impact
- Minor: adds a new Rust workflow TUI capability behind explicit opt-in.

## Risk and Rollback
- Risk: the actual full-screen workflow renderer is still a minimal state-backed slice, not a complete interactive Ink replacement.
- Risk: hidden test export is intentionally gated by `KCMT_TUI_MODEL_EXPORT=1`.
- Rollback: revert `22a86b7` to remove the workflow TUI model and restore prior workflow `--tui` behavior.

## Operational Notes
- Runtime benchmark mode now avoids credential/keychain probing when building provider availability, preventing local macOS keychain stalls during benchmark contracts.
- No deployment steps required.

## Linked Work
- Builds on merged PR #37 configure TUI/model preference behavior.

## Reviewer Checklist
- [ ] Confirm workflow `--tui` non-TTY rejection is acceptable as the explicit contract.
- [ ] Confirm model export shape is sufficient for the next workflow TUI rendering slice.
- [ ] Confirm runtime benchmark keychain bypass is scoped to `KCMT_RUNTIME_BENCHMARK`.

## Adversarial Review Result
- Subagent review found a single-file failure export gap; this PR addresses it with stderr model export plus a focused integration test.
