### PR TITLE
feat(benchmark): compare runtime stages side by side

### DIFF
--- a/kcmt/benchmark.py
+++ b/kcmt/benchmark.py
@@ -1196,6 +1196,7 @@ class _RuntimeBenchmarkScenario:
     workflow_contract_id: str
     command_label: str
     expected_stdout_fragment: str
+    file_target: str | None = None
 
 
 def _runtime_benchmark_repo_root() -> Path:
@@ -1265,6 +1266,7 @@ def _runtime_benchmark_scenarios(
             workflow_contract_id="file-repo-path",
             command_label=f"kcmt --file {target} --repo-path <repo>",
             expected_stdout_fragment="✓ ",
+            file_target=target,
         ),
     ]
     if not _is_large_untracked_runtime_corpus(metadata):
@@ -1277,6 +1279,24 @@ def _runtime_benchmark_scenarios(
                 expected_stdout_fragment="✓ ",
             ),
         )
+    file_targets = metadata.get("file_targets")
+    if isinstance(file_targets, list):
+        for file_target in file_targets:
+            if not isinstance(file_target, dict):
+                continue
+            target_id = str(file_target.get("id") or "").strip()
+            target_path = str(file_target.get("path") or "").strip()
+            if not target_id or not target_path:
+                continue
+            scenarios.append(
+                _RuntimeBenchmarkScenario(
+                    scenario_id=f"{metadata['id']}:file-{target_id}",
+                    workflow_contract_id="file-repo-path",
+                    command_label=f"kcmt --file {target_path} --repo-path <repo>",
+                    expected_stdout_fragment="✓ ",
+                    file_target=target_path,
+                )
+            )
     return scenarios
 
 
@@ -1441,7 +1461,7 @@ def _scenario_command(
         return [*base, "--oneshot", "--repo-path", str(repo_path)]
     if scenario.workflow_contract_id == "default-repo-path":
         return [*base, "--repo-path", str(repo_path)]
-    target = _runtime_benchmark_target_file(repo_path, metadata)
+    target = scenario.file_target or _runtime_benchmark_target_file(repo_path, metadata)
     return [*base, "--file", target, "--repo-path", str(repo_path)]
 
 
@@ -1821,21 +1841,18 @@ def _runtime_scenario_comparison(
 def _build_runtime_scenario_matrix(
     results: list[RuntimeBenchmarkResult],
 ) -> list[RuntimeScenarioMatrixRow]:
-    keys: list[tuple[str, str]] = []
+    scenario_ids: list[str] = []
     for result in results:
-        key = (result.corpus_id, result.workflow_contract_id)
-        if key not in keys:
-            keys.append(key)
+        if result.scenario_id not in scenario_ids:
+            scenario_ids.append(result.scenario_id)
 
     rows: list[RuntimeScenarioMatrixRow] = []
-    for corpus_id, workflow_contract_id in keys:
+    for scenario_id in scenario_ids:
         python = next(
             (
                 item
                 for item in results
-                if item.corpus_id == corpus_id
-                and item.workflow_contract_id == workflow_contract_id
-                and item.runtime == "python"
+                if item.scenario_id == scenario_id and item.runtime == "python"
             ),
             None,
         )
@@ -1843,9 +1860,7 @@ def _build_runtime_scenario_matrix(
             (
                 item
                 for item in results
-                if item.corpus_id == corpus_id
-                and item.workflow_contract_id == workflow_contract_id
-                and item.runtime == "rust"
+                if item.scenario_id == scenario_id and item.runtime == "rust"
             ),
             None,
         )
@@ -1854,9 +1869,9 @@ def _build_runtime_scenario_matrix(
             continue
         rows.append(
             RuntimeScenarioMatrixRow(
-                scenario_id=f"{corpus_id}:{workflow_contract_id}",
-                workflow_contract_id=workflow_contract_id,
-                corpus_id=corpus_id,
+                scenario_id=scenario_id,
+                workflow_contract_id=exemplar.workflow_contract_id,
+                corpus_id=exemplar.corpus_id,
                 command_label=exemplar.command_label,
                 python=_runtime_matrix_cell(python),
                 rust=_runtime_matrix_cell(rust),
@@ -2087,7 +2102,7 @@ def render_runtime_benchmark_report(report: RuntimeBenchmarkRun) -> str:
         )
         stage_delta_text = ", ".join(
             f"{stage.stage}:{stage.delta_ms:.2f}"
-            for stage in row.comparison.stage_deltas[:6]
+            for stage in row.comparison.stage_deltas
             if stage.delta_ms is not None
         )
         lines.append(

--- a/kcmt/benchmark.py
+++ b/kcmt/benchmark.py
@@ -1099,6 +1099,69 @@ class RuntimeBenchmarkSummary:
 
 
 @dataclass
+class RuntimeBenchmarkSnapshot:
+    snapshot_id: str
+    benchmark_kind: str
+    schema_version: str
+    timestamp: str
+    command_set: str
+    corpora: list[str]
+    result_count: int
+    secret_free: bool
+    provider_benchmark_kind: str
+
+
+@dataclass
+class RuntimeScenarioMatrixCell:
+    status: str
+    iterations: int
+    wall_time_ms: float | None
+    median_time_ms: float | None
+    throughput_commits_per_sec: float | None
+    quality_score: float | None
+    stage_timings: list[RuntimeStageTiming]
+    failure_reason: str | None
+
+
+@dataclass
+class RuntimeStageDelta:
+    stage: str
+    python_ms: float | None
+    rust_ms: float | None
+    delta_ms: float | None
+
+
+@dataclass
+class RuntimeScenarioComparison:
+    comparable: bool
+    fastest_runtime: str | None
+    median_delta_ms: float | None
+    speedup_ratio: float | None
+    stage_deltas: list[RuntimeStageDelta]
+
+
+@dataclass
+class RuntimeScenarioMatrixRow:
+    scenario_id: str
+    workflow_contract_id: str
+    corpus_id: str
+    command_label: str
+    python: RuntimeScenarioMatrixCell
+    rust: RuntimeScenarioMatrixCell
+    comparison: RuntimeScenarioComparison
+
+
+@dataclass
+class RuntimeBenchmarkScorecard:
+    measurement_basis: str
+    quality_score_definition: str
+    throughput_definition: str
+    python_quality_score: float | None
+    rust_quality_score: float | None
+    provider_throughput_included: bool
+
+
+@dataclass
 class RuntimeOptimizationIteration:
     iteration: int
     label: str
@@ -1117,8 +1180,11 @@ class RuntimeBenchmarkRun:
     timestamp: str
     command_set: str
     corpora: list[str]
+    snapshot: RuntimeBenchmarkSnapshot
     results: list[RuntimeBenchmarkResult]
+    scenario_matrix: list[RuntimeScenarioMatrixRow]
     summary: dict[str, RuntimeBenchmarkSummary]
+    scorecard: RuntimeBenchmarkScorecard
     optimization_iterations: list[RuntimeOptimizationIteration] = field(
         default_factory=list
     )
@@ -1321,6 +1387,8 @@ def _runtime_benchmark_env(config_home: Path, runtime: str) -> dict[str, str]:
     env[RUNTIME_BENCHMARK_ENV] = "1"
     env["KCMT_NO_SPINNER"] = "1"
     env.setdefault("OPENAI_API_KEY", "kcmt-runtime-benchmark")
+    env.setdefault("KCMT_PROVIDER_RESPONSE", "chore(repo): benchmark fixture response")
+    env.setdefault("KCMT_DISABLE_KEYCHAIN", "1")
     env.setdefault("GIT_AUTHOR_NAME", "kcmt-benchmark")
     env.setdefault("GIT_AUTHOR_EMAIL", "kcmt-benchmark@example.com")
     env.setdefault("GIT_COMMITTER_NAME", env["GIT_AUTHOR_NAME"])
@@ -1606,6 +1674,227 @@ def _build_runtime_summary(
     )
 
 
+def _runtime_snapshot_id(timestamp: str, corpora: list[str]) -> str:
+    safe_timestamp = (
+        "".join(ch for ch in timestamp if ch.isalnum()) or "19700101T000000Z"
+    )
+    corpus = corpora[0] if corpora else "runtime-corpus"
+    safe_corpus = "".join(
+        ch if ch.isalnum() or ch in {"-", "_"} else "-" for ch in corpus
+    )
+    return f"runtime-{safe_corpus or 'runtime-corpus'}-{safe_timestamp}"
+
+
+def _build_runtime_snapshot(
+    *, timestamp: str, command_set: str, corpora: list[str], result_count: int
+) -> RuntimeBenchmarkSnapshot:
+    return RuntimeBenchmarkSnapshot(
+        snapshot_id=_runtime_snapshot_id(timestamp, corpora),
+        benchmark_kind="runtime",
+        schema_version=RUNTIME_BENCHMARK_SCHEMA_VERSION,
+        timestamp=timestamp,
+        command_set=command_set,
+        corpora=corpora,
+        result_count=result_count,
+        secret_free=True,
+        provider_benchmark_kind="provider",
+    )
+
+
+def _runtime_result_quality_score(result: RuntimeBenchmarkResult) -> float:
+    return 100.0 if result.status == "passed" else 0.0
+
+
+def _runtime_quality_score(
+    results: list[RuntimeBenchmarkResult], runtime: str
+) -> float | None:
+    relevant = [item for item in results if item.runtime == runtime]
+    if not relevant:
+        return None
+    passed = sum(1 for item in relevant if item.status == "passed")
+    return passed / len(relevant) * 100.0
+
+
+def _runtime_matrix_cell(
+    result: RuntimeBenchmarkResult | None,
+) -> RuntimeScenarioMatrixCell:
+    if result is None:
+        return RuntimeScenarioMatrixCell(
+            status="excluded",
+            iterations=0,
+            wall_time_ms=None,
+            median_time_ms=None,
+            throughput_commits_per_sec=None,
+            quality_score=None,
+            stage_timings=[],
+            failure_reason="runtime not requested",
+        )
+    throughput = (
+        1000.0 / result.median_time_ms
+        if result.median_time_ms is not None and result.median_time_ms > 0
+        else None
+    )
+    return RuntimeScenarioMatrixCell(
+        status=result.status,
+        iterations=result.iterations,
+        wall_time_ms=result.wall_time_ms,
+        median_time_ms=result.median_time_ms,
+        throughput_commits_per_sec=throughput,
+        quality_score=_runtime_result_quality_score(result),
+        stage_timings=result.stage_timings,
+        failure_reason=result.failure_reason,
+    )
+
+
+def _stage_duration(stages: list[RuntimeStageTiming], stage_name: str) -> float | None:
+    for stage in stages:
+        if stage.stage == stage_name:
+            return stage.duration_ms
+    return None
+
+
+def _runtime_stage_deltas(
+    python_stages: list[RuntimeStageTiming],
+    rust_stages: list[RuntimeStageTiming],
+) -> list[RuntimeStageDelta]:
+    stage_names: list[str] = []
+    for stage in [*python_stages, *rust_stages]:
+        if stage.stage not in stage_names:
+            stage_names.append(stage.stage)
+    deltas: list[RuntimeStageDelta] = []
+    for stage_name in stage_names:
+        python_ms = _stage_duration(python_stages, stage_name)
+        rust_ms = _stage_duration(rust_stages, stage_name)
+        deltas.append(
+            RuntimeStageDelta(
+                stage=stage_name,
+                python_ms=python_ms,
+                rust_ms=rust_ms,
+                delta_ms=(
+                    rust_ms - python_ms
+                    if python_ms is not None and rust_ms is not None
+                    else None
+                ),
+            )
+        )
+    return deltas
+
+
+def _runtime_scenario_comparison(
+    python: RuntimeBenchmarkResult | None,
+    rust: RuntimeBenchmarkResult | None,
+) -> RuntimeScenarioComparison:
+    comparable = (
+        python is not None
+        and rust is not None
+        and python.status == "passed"
+        and rust.status == "passed"
+    )
+    median_delta = None
+    speedup_ratio = None
+    fastest_runtime = None
+    if comparable and python is not None and rust is not None:
+        python_median = python.median_time_ms
+        rust_median = rust.median_time_ms
+    else:
+        python_median = None
+        rust_median = None
+    if python_median is not None and rust_median is not None:
+        median_delta = rust_median - python_median
+        speedup_ratio = python_median / rust_median if rust_median > 0 else None
+        if rust_median < python_median:
+            fastest_runtime = "rust"
+        elif python_median < rust_median:
+            fastest_runtime = "python"
+    return RuntimeScenarioComparison(
+        comparable=comparable,
+        fastest_runtime=fastest_runtime,
+        median_delta_ms=median_delta,
+        speedup_ratio=speedup_ratio,
+        stage_deltas=_runtime_stage_deltas(
+            python.stage_timings if python is not None else [],
+            rust.stage_timings if rust is not None else [],
+        ),
+    )
+
+
+def _build_runtime_scenario_matrix(
+    results: list[RuntimeBenchmarkResult],
+) -> list[RuntimeScenarioMatrixRow]:
+    keys: list[tuple[str, str]] = []
+    for result in results:
+        key = (result.corpus_id, result.workflow_contract_id)
+        if key not in keys:
+            keys.append(key)
+
+    rows: list[RuntimeScenarioMatrixRow] = []
+    for corpus_id, workflow_contract_id in keys:
+        python = next(
+            (
+                item
+                for item in results
+                if item.corpus_id == corpus_id
+                and item.workflow_contract_id == workflow_contract_id
+                and item.runtime == "python"
+            ),
+            None,
+        )
+        rust = next(
+            (
+                item
+                for item in results
+                if item.corpus_id == corpus_id
+                and item.workflow_contract_id == workflow_contract_id
+                and item.runtime == "rust"
+            ),
+            None,
+        )
+        exemplar = python or rust
+        if exemplar is None:
+            continue
+        rows.append(
+            RuntimeScenarioMatrixRow(
+                scenario_id=f"{corpus_id}:{workflow_contract_id}",
+                workflow_contract_id=workflow_contract_id,
+                corpus_id=corpus_id,
+                command_label=exemplar.command_label,
+                python=_runtime_matrix_cell(python),
+                rust=_runtime_matrix_cell(rust),
+                comparison=_runtime_scenario_comparison(python, rust),
+            )
+        )
+    return rows
+
+
+def _build_runtime_scorecard(
+    results: list[RuntimeBenchmarkResult],
+) -> RuntimeBenchmarkScorecard:
+    return RuntimeBenchmarkScorecard(
+        measurement_basis=(
+            "runtime workflow subprocess wall time with local fixture provider "
+            "responses; pre-LLM Rust heuristic stages are not provider throughput"
+        ),
+        quality_score_definition=(
+            "percentage of requested runtime scenarios that passed without failed "
+            "or excluded rows"
+        ),
+        throughput_definition=(
+            "commits per second derived from median scenario wall time; provider "
+            "benchmark throughput remains separate"
+        ),
+        python_quality_score=_runtime_quality_score(results, "python"),
+        rust_quality_score=_runtime_quality_score(results, "rust"),
+        provider_throughput_included=False,
+    )
+
+
+def _runtime_matrix_cell_label(cell: RuntimeScenarioMatrixCell) -> str:
+    median_text = (
+        f"{cell.median_time_ms:.2f} ms" if cell.median_time_ms is not None else "-"
+    )
+    return f"{cell.status} ({median_text})"
+
+
 def _build_runtime_optimization_iterations(
     results: list[RuntimeBenchmarkResult],
     summary: dict[str, RuntimeBenchmarkSummary],
@@ -1694,13 +1983,25 @@ def run_runtime_benchmark(
         "python": _build_runtime_summary(results, "python"),
         "rust": _build_runtime_summary(results, "rust"),
     }
+    timestamp = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+    command_set = "local-workflows-v1"
+    corpora = [str(metadata["id"])]
+    scenario_matrix = _build_runtime_scenario_matrix(results)
     return RuntimeBenchmarkRun(
         schema_version=RUNTIME_BENCHMARK_SCHEMA_VERSION,
-        timestamp=datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
-        command_set="local-workflows-v1",
-        corpora=[str(metadata["id"])],
+        timestamp=timestamp,
+        command_set=command_set,
+        corpora=corpora,
+        snapshot=_build_runtime_snapshot(
+            timestamp=timestamp,
+            command_set=command_set,
+            corpora=corpora,
+            result_count=len(results),
+        ),
         results=results,
+        scenario_matrix=scenario_matrix,
         summary=summary,
+        scorecard=_build_runtime_scorecard(results),
         optimization_iterations=_build_runtime_optimization_iterations(
             results, summary
         ),
@@ -1714,6 +2015,8 @@ def render_runtime_benchmark_report(report: RuntimeBenchmarkRun) -> str:
         f"- Timestamp: {report.timestamp}",
         f"- Command set: {report.command_set}",
         f"- Corpora: {', '.join(report.corpora)}",
+        f"- Snapshot: {report.snapshot.snapshot_id}",
+        f"- Measurement basis: {report.scorecard.measurement_basis}",
         "",
         "| Runtime | Scenarios | Passed | Failed | Excluded | Median wall time (ms) |",
         "| --- | --- | --- | --- | --- | --- |",
@@ -1766,6 +2069,35 @@ def render_runtime_benchmark_report(report: RuntimeBenchmarkRun) -> str:
                 quality=quality_text,
                 failures=failures_text,
                 bottleneck=_escape_md(iteration.next_bottleneck),
+            )
+        )
+
+    lines.extend(
+        [
+            "",
+            "| Scenario | Python | Rust | Median delta (ms) | Fastest | Stage deltas |",
+            "| --- | --- | --- | --- | --- | --- |",
+        ]
+    )
+    for row in report.scenario_matrix:
+        delta_text = (
+            f"{row.comparison.median_delta_ms:.2f}"
+            if row.comparison.median_delta_ms is not None
+            else "-"
+        )
+        stage_delta_text = ", ".join(
+            f"{stage.stage}:{stage.delta_ms:.2f}"
+            for stage in row.comparison.stage_deltas[:6]
+            if stage.delta_ms is not None
+        )
+        lines.append(
+            "| {scenario} | {python} | {rust} | {delta} | {fastest} | {stages} |".format(
+                scenario=_escape_md(row.scenario_id),
+                python=_runtime_matrix_cell_label(row.python),
+                rust=_runtime_matrix_cell_label(row.rust),
+                delta=delta_text,
+                fastest=row.comparison.fastest_runtime or "-",
+                stages=_escape_md(stage_delta_text) if stage_delta_text else "-",
             )
         )
 

--- a/rust/crates/kcmt-bench/src/model.rs
+++ b/rust/crates/kcmt-bench/src/model.rs
@@ -83,9 +83,75 @@ pub struct RuntimeBenchmarkRun {
     pub timestamp: String,
     pub command_set: String,
     pub corpora: Vec<String>,
+    pub snapshot: RuntimeBenchmarkSnapshot,
     pub results: Vec<RuntimeBenchmarkResult>,
+    pub scenario_matrix: Vec<RuntimeScenarioMatrixRow>,
     pub summary: RuntimeBenchmarkSummary,
+    pub scorecard: RuntimeBenchmarkScorecard,
     pub optimization_iterations: Vec<OptimizationIteration>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RuntimeBenchmarkSnapshot {
+    pub snapshot_id: String,
+    pub benchmark_kind: String,
+    pub schema_version: String,
+    pub timestamp: String,
+    pub command_set: String,
+    pub corpora: Vec<String>,
+    pub result_count: u32,
+    pub secret_free: bool,
+    pub provider_benchmark_kind: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RuntimeScenarioMatrixRow {
+    pub scenario_id: String,
+    pub workflow_contract_id: String,
+    pub corpus_id: String,
+    pub command_label: String,
+    pub python: RuntimeScenarioMatrixCell,
+    pub rust: RuntimeScenarioMatrixCell,
+    pub comparison: RuntimeScenarioComparison,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RuntimeScenarioMatrixCell {
+    pub status: RuntimeScenarioStatus,
+    pub iterations: u32,
+    pub wall_time_ms: Option<f64>,
+    pub median_time_ms: Option<f64>,
+    pub throughput_commits_per_sec: Option<f64>,
+    pub quality_score: Option<f64>,
+    pub stage_timings: Vec<RuntimeStageTiming>,
+    pub failure_reason: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RuntimeScenarioComparison {
+    pub comparable: bool,
+    pub fastest_runtime: Option<RuntimeKind>,
+    pub median_delta_ms: Option<f64>,
+    pub speedup_ratio: Option<f64>,
+    pub stage_deltas: Vec<RuntimeStageDelta>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RuntimeStageDelta {
+    pub stage: String,
+    pub python_ms: Option<f64>,
+    pub rust_ms: Option<f64>,
+    pub delta_ms: Option<f64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RuntimeBenchmarkScorecard {
+    pub measurement_basis: String,
+    pub quality_score_definition: String,
+    pub throughput_definition: String,
+    pub python_quality_score: Option<f64>,
+    pub rust_quality_score: Option<f64>,
+    pub provider_throughput_included: bool,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]

--- a/rust/crates/kcmt-bench/src/runner.rs
+++ b/rust/crates/kcmt-bench/src/runner.rs
@@ -179,39 +179,26 @@ fn runtime_snapshot_id(timestamp: &str, corpora: &[String]) -> String {
 }
 
 fn build_scenario_matrix(results: &[RuntimeBenchmarkResult]) -> Vec<RuntimeScenarioMatrixRow> {
-    let mut keys = Vec::<(String, String)>::new();
+    let mut scenario_ids = Vec::<String>::new();
     for result in results {
-        let key = (
-            result.corpus_id.clone(),
-            result.workflow_contract_id.clone(),
-        );
-        if !keys.contains(&key) {
-            keys.push(key);
+        if !scenario_ids.contains(&result.scenario_id) {
+            scenario_ids.push(result.scenario_id.clone());
         }
     }
 
-    keys.into_iter()
-        .filter_map(|(corpus_id, workflow_contract_id)| {
-            let python = find_runtime_result(
-                results,
-                &corpus_id,
-                &workflow_contract_id,
-                RuntimeKind::Python,
-            );
-            let rust = find_runtime_result(
-                results,
-                &corpus_id,
-                &workflow_contract_id,
-                RuntimeKind::Rust,
-            );
+    scenario_ids
+        .into_iter()
+        .filter_map(|scenario_id| {
+            let python = find_runtime_result(results, &scenario_id, RuntimeKind::Python);
+            let rust = find_runtime_result(results, &scenario_id, RuntimeKind::Rust);
             let exemplar = python.or(rust)?;
             let python_cell = matrix_cell(python);
             let rust_cell = matrix_cell(rust);
             let comparison = scenario_comparison(python, rust);
             Some(RuntimeScenarioMatrixRow {
-                scenario_id: format!("{corpus_id}:{workflow_contract_id}"),
-                workflow_contract_id,
-                corpus_id,
+                scenario_id,
+                workflow_contract_id: exemplar.workflow_contract_id.clone(),
+                corpus_id: exemplar.corpus_id.clone(),
                 command_label: exemplar.command_label.clone(),
                 python: python_cell,
                 rust: rust_cell,
@@ -223,15 +210,12 @@ fn build_scenario_matrix(results: &[RuntimeBenchmarkResult]) -> Vec<RuntimeScena
 
 fn find_runtime_result<'a>(
     results: &'a [RuntimeBenchmarkResult],
-    corpus_id: &str,
-    workflow_contract_id: &str,
+    scenario_id: &str,
     runtime: RuntimeKind,
 ) -> Option<&'a RuntimeBenchmarkResult> {
-    results.iter().find(|result| {
-        result.corpus_id == corpus_id
-            && result.workflow_contract_id == workflow_contract_id
-            && result.runtime == runtime
-    })
+    results
+        .iter()
+        .find(|result| result.scenario_id == scenario_id && result.runtime == runtime)
 }
 
 fn matrix_cell(result: Option<&RuntimeBenchmarkResult>) -> RuntimeScenarioMatrixCell {

--- a/rust/crates/kcmt-bench/src/runner.rs
+++ b/rust/crates/kcmt-bench/src/runner.rs
@@ -12,8 +12,10 @@ use time::OffsetDateTime;
 
 use crate::model::{
     OptimizationIteration, OptimizationMeasurementStatus, RuntimeBenchmarkResult,
-    RuntimeBenchmarkRun, RuntimeBenchmarkSummary, RuntimeKind, RuntimeScenarioStatus,
-    RuntimeStageTiming, RuntimeSummary,
+    RuntimeBenchmarkRun, RuntimeBenchmarkScorecard, RuntimeBenchmarkSnapshot,
+    RuntimeBenchmarkSummary, RuntimeKind, RuntimeScenarioComparison, RuntimeScenarioMatrixCell,
+    RuntimeScenarioMatrixRow, RuntimeScenarioStatus, RuntimeStageDelta, RuntimeStageTiming,
+    RuntimeSummary,
 };
 use crate::RUNTIME_BENCHMARK_SCHEMA_VERSION;
 
@@ -103,22 +105,290 @@ pub fn run_runtime_benchmark(
         rust: build_runtime_summary(&results, RuntimeKind::Rust),
     };
     let optimization_iterations = build_optimization_iterations(&results, &summary);
+    let timestamp = benchmark_timestamp();
+    let command_set = "local-workflows-v1".to_string();
+    let corpora = vec![metadata.id.clone().unwrap_or_else(|| {
+        repo_root
+            .file_name()
+            .unwrap_or_default()
+            .to_string_lossy()
+            .to_string()
+    })];
+    let scenario_matrix = build_scenario_matrix(&results);
+    let scorecard = build_scorecard(&results);
+    let snapshot = build_runtime_snapshot(&timestamp, &command_set, &corpora, results.len());
 
     Ok(RuntimeBenchmarkRun {
         schema_version: RUNTIME_BENCHMARK_SCHEMA_VERSION.to_string(),
-        timestamp: benchmark_timestamp(),
-        command_set: "local-workflows-v1".to_string(),
-        corpora: vec![metadata.id.clone().unwrap_or_else(|| {
-            repo_root
-                .file_name()
-                .unwrap_or_default()
-                .to_string_lossy()
-                .to_string()
-        })],
+        timestamp,
+        command_set,
+        corpora,
+        snapshot,
         results: results.clone(),
+        scenario_matrix,
         summary,
+        scorecard,
         optimization_iterations,
     })
+}
+
+fn build_runtime_snapshot(
+    timestamp: &str,
+    command_set: &str,
+    corpora: &[String],
+    result_count: usize,
+) -> RuntimeBenchmarkSnapshot {
+    RuntimeBenchmarkSnapshot {
+        snapshot_id: runtime_snapshot_id(timestamp, corpora),
+        benchmark_kind: "runtime".to_string(),
+        schema_version: RUNTIME_BENCHMARK_SCHEMA_VERSION.to_string(),
+        timestamp: timestamp.to_string(),
+        command_set: command_set.to_string(),
+        corpora: corpora.to_vec(),
+        result_count: result_count as u32,
+        secret_free: true,
+        provider_benchmark_kind: "provider".to_string(),
+    }
+}
+
+fn runtime_snapshot_id(timestamp: &str, corpora: &[String]) -> String {
+    let mut slug = timestamp
+        .chars()
+        .filter(|ch| ch.is_ascii_alphanumeric())
+        .collect::<String>();
+    if slug.is_empty() {
+        slug = "19700101T000000Z".to_string();
+    }
+    let corpus = corpora
+        .first()
+        .map(|value| {
+            value
+                .chars()
+                .map(|ch| {
+                    if ch.is_ascii_alphanumeric() || ch == '-' || ch == '_' {
+                        ch
+                    } else {
+                        '-'
+                    }
+                })
+                .collect::<String>()
+        })
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| "runtime-corpus".to_string());
+    format!("runtime-{corpus}-{slug}")
+}
+
+fn build_scenario_matrix(results: &[RuntimeBenchmarkResult]) -> Vec<RuntimeScenarioMatrixRow> {
+    let mut keys = Vec::<(String, String)>::new();
+    for result in results {
+        let key = (
+            result.corpus_id.clone(),
+            result.workflow_contract_id.clone(),
+        );
+        if !keys.contains(&key) {
+            keys.push(key);
+        }
+    }
+
+    keys.into_iter()
+        .filter_map(|(corpus_id, workflow_contract_id)| {
+            let python = find_runtime_result(
+                results,
+                &corpus_id,
+                &workflow_contract_id,
+                RuntimeKind::Python,
+            );
+            let rust = find_runtime_result(
+                results,
+                &corpus_id,
+                &workflow_contract_id,
+                RuntimeKind::Rust,
+            );
+            let exemplar = python.or(rust)?;
+            let python_cell = matrix_cell(python);
+            let rust_cell = matrix_cell(rust);
+            let comparison = scenario_comparison(python, rust);
+            Some(RuntimeScenarioMatrixRow {
+                scenario_id: format!("{corpus_id}:{workflow_contract_id}"),
+                workflow_contract_id,
+                corpus_id,
+                command_label: exemplar.command_label.clone(),
+                python: python_cell,
+                rust: rust_cell,
+                comparison,
+            })
+        })
+        .collect()
+}
+
+fn find_runtime_result<'a>(
+    results: &'a [RuntimeBenchmarkResult],
+    corpus_id: &str,
+    workflow_contract_id: &str,
+    runtime: RuntimeKind,
+) -> Option<&'a RuntimeBenchmarkResult> {
+    results.iter().find(|result| {
+        result.corpus_id == corpus_id
+            && result.workflow_contract_id == workflow_contract_id
+            && result.runtime == runtime
+    })
+}
+
+fn matrix_cell(result: Option<&RuntimeBenchmarkResult>) -> RuntimeScenarioMatrixCell {
+    let Some(result) = result else {
+        return RuntimeScenarioMatrixCell {
+            status: RuntimeScenarioStatus::Excluded,
+            iterations: 0,
+            wall_time_ms: None,
+            median_time_ms: None,
+            throughput_commits_per_sec: None,
+            quality_score: None,
+            stage_timings: Vec::new(),
+            failure_reason: Some("runtime not requested".to_string()),
+        };
+    };
+    RuntimeScenarioMatrixCell {
+        status: result.status,
+        iterations: result.iterations,
+        wall_time_ms: Some(result.wall_time_ms),
+        median_time_ms: result.median_time_ms,
+        throughput_commits_per_sec: result
+            .median_time_ms
+            .filter(|value| *value > 0.0)
+            .map(|value| 1000.0 / value),
+        quality_score: Some(result_quality_score(result)),
+        stage_timings: result.stage_timings.clone(),
+        failure_reason: result.failure_reason.clone(),
+    }
+}
+
+fn result_quality_score(result: &RuntimeBenchmarkResult) -> f64 {
+    match result.status {
+        RuntimeScenarioStatus::Passed => 100.0,
+        RuntimeScenarioStatus::Failed | RuntimeScenarioStatus::Excluded => 0.0,
+    }
+}
+
+fn scenario_comparison(
+    python: Option<&RuntimeBenchmarkResult>,
+    rust: Option<&RuntimeBenchmarkResult>,
+) -> RuntimeScenarioComparison {
+    let comparable = matches!(
+        (
+            python.map(|result| result.status),
+            rust.map(|result| result.status)
+        ),
+        (
+            Some(RuntimeScenarioStatus::Passed),
+            Some(RuntimeScenarioStatus::Passed)
+        )
+    );
+    let python_median = python.and_then(|result| result.median_time_ms);
+    let rust_median = rust.and_then(|result| result.median_time_ms);
+    let median_delta_ms = if comparable {
+        match (python_median, rust_median) {
+            (Some(python_ms), Some(rust_ms)) => Some(rust_ms - python_ms),
+            _ => None,
+        }
+    } else {
+        None
+    };
+    let fastest_runtime = if comparable {
+        match (python_median, rust_median) {
+            (Some(python_ms), Some(rust_ms)) if rust_ms < python_ms => Some(RuntimeKind::Rust),
+            (Some(python_ms), Some(rust_ms)) if python_ms < rust_ms => Some(RuntimeKind::Python),
+            (Some(_), Some(_)) => None,
+            _ => None,
+        }
+    } else {
+        None
+    };
+    let speedup_ratio = if comparable {
+        match (python_median, rust_median) {
+            (Some(python_ms), Some(rust_ms)) if rust_ms > 0.0 => Some(python_ms / rust_ms),
+            _ => None,
+        }
+    } else {
+        None
+    };
+    RuntimeScenarioComparison {
+        comparable,
+        fastest_runtime,
+        median_delta_ms,
+        speedup_ratio,
+        stage_deltas: stage_deltas(
+            python
+                .map(|result| result.stage_timings.as_slice())
+                .unwrap_or(&[]),
+            rust.map(|result| result.stage_timings.as_slice())
+                .unwrap_or(&[]),
+        ),
+    }
+}
+
+fn stage_deltas(
+    python_stages: &[RuntimeStageTiming],
+    rust_stages: &[RuntimeStageTiming],
+) -> Vec<RuntimeStageDelta> {
+    let mut stage_names = Vec::<String>::new();
+    for stage in python_stages.iter().chain(rust_stages.iter()) {
+        if !stage_names.contains(&stage.stage) {
+            stage_names.push(stage.stage.clone());
+        }
+    }
+    stage_names
+        .into_iter()
+        .map(|stage| {
+            let python_ms = stage_duration(python_stages, &stage);
+            let rust_ms = stage_duration(rust_stages, &stage);
+            RuntimeStageDelta {
+                stage,
+                python_ms,
+                rust_ms,
+                delta_ms: match (python_ms, rust_ms) {
+                    (Some(python_ms), Some(rust_ms)) => Some(rust_ms - python_ms),
+                    _ => None,
+                },
+            }
+        })
+        .collect()
+}
+
+fn stage_duration(stages: &[RuntimeStageTiming], stage_name: &str) -> Option<f64> {
+    stages
+        .iter()
+        .find(|stage| stage.stage == stage_name)
+        .map(|stage| stage.duration_ms)
+}
+
+fn build_scorecard(results: &[RuntimeBenchmarkResult]) -> RuntimeBenchmarkScorecard {
+    RuntimeBenchmarkScorecard {
+        measurement_basis: "runtime workflow subprocess wall time with local fixture provider responses; pre-LLM Rust heuristic stages are not provider throughput".to_string(),
+        quality_score_definition:
+            "percentage of requested runtime scenarios that passed without failed or excluded rows"
+                .to_string(),
+        throughput_definition:
+            "commits per second derived from median scenario wall time; provider benchmark throughput remains separate"
+                .to_string(),
+        python_quality_score: runtime_quality_score(results, RuntimeKind::Python),
+        rust_quality_score: runtime_quality_score(results, RuntimeKind::Rust),
+        provider_throughput_included: false,
+    }
+}
+
+fn runtime_quality_score(results: &[RuntimeBenchmarkResult], runtime: RuntimeKind) -> Option<f64> {
+    let relevant: Vec<&RuntimeBenchmarkResult> = results
+        .iter()
+        .filter(|result| result.runtime == runtime)
+        .collect();
+    if relevant.is_empty() {
+        return None;
+    }
+    let passed = relevant
+        .iter()
+        .filter(|result| result.status == RuntimeScenarioStatus::Passed)
+        .count() as f64;
+    Some((passed / relevant.len() as f64) * 100.0)
 }
 
 fn build_optimization_iterations(
@@ -866,6 +1136,11 @@ fn runtime_benchmark_env(config_home: &Path, runtime: RuntimeKind) -> Vec<(Strin
         ),
         ("KCMT_RUNTIME_BENCHMARK".to_string(), "1".to_string()),
         ("KCMT_ALLOW_LOCAL_SYNTHESIS".to_string(), "1".to_string()),
+        (
+            "KCMT_PROVIDER_RESPONSE".to_string(),
+            "chore(repo): benchmark fixture response".to_string(),
+        ),
+        ("KCMT_DISABLE_KEYCHAIN".to_string(), "1".to_string()),
         ("GIT_AUTHOR_NAME".to_string(), "kcmt-benchmark".to_string()),
         (
             "GIT_AUTHOR_EMAIL".to_string(),

--- a/rust/crates/kcmt-cli/src/commands/benchmark.rs
+++ b/rust/crates/kcmt-cli/src/commands/benchmark.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use kcmt_bench::export::export_runtime_json;
-use kcmt_bench::model::{RuntimeBenchmarkRun, RuntimeScenarioStatus};
+use kcmt_bench::model::{RuntimeBenchmarkRun, RuntimeKind, RuntimeScenarioStatus};
 use kcmt_bench::runner::run_runtime_benchmark;
 use kcmt_core::config::loader::{load_config, ConfigOverrides};
 use kcmt_core::message::{build_prompt, sanitize_commit_output, validate_conventional_commit};
@@ -586,6 +586,32 @@ fn benchmark_timestamp() -> String {
     format!("{seconds}")
 }
 
+fn persist_runtime_benchmark(repo_path: &Path, report: &RuntimeBenchmarkRun) -> anyhow::Result<()> {
+    let report_dir = state_dir(repo_path).join("benchmarks");
+    fs::create_dir_all(&report_dir)?;
+    let safe_id = report
+        .snapshot
+        .snapshot_id
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || ch == '-' || ch == '_' {
+                ch
+            } else {
+                '-'
+            }
+        })
+        .collect::<String>();
+    fs::write(
+        report_dir.join(format!("{safe_id}.json")),
+        serde_json::to_string_pretty(report)?,
+    )?;
+    fs::write(
+        report_dir.join(format!("{safe_id}.md")),
+        render_runtime_report(report),
+    )?;
+    Ok(())
+}
+
 fn run_runtime_benchmark_command(
     repo_path: PathBuf,
     runtime: BenchmarkRuntime,
@@ -607,6 +633,9 @@ fn run_runtime_benchmark_command(
         rust_bin_path.as_deref(),
     ) {
         Ok(report) => {
+            if let Err(err) = persist_runtime_benchmark(&repo_path, &report) {
+                eprintln!("warning: failed to persist runtime benchmark snapshot: {err}");
+            }
             if json {
                 match export_runtime_json(&report) {
                     Ok(rendered) => println!("{rendered}"),
@@ -643,6 +672,11 @@ fn render_runtime_report(report: &RuntimeBenchmarkRun) -> String {
         format!("- Timestamp: {}", report.timestamp),
         format!("- Command set: {}", report.command_set),
         format!("- Corpora: {}", report.corpora.join(", ")),
+        format!("- Snapshot: {}", report.snapshot.snapshot_id),
+        format!(
+            "- Measurement basis: {}",
+            report.scorecard.measurement_basis
+        ),
         String::new(),
         "| Runtime | Scenarios | Passed | Failed | Excluded | Median wall time (ms) |".to_string(),
         "| --- | --- | --- | --- | --- | --- |".to_string(),
@@ -693,6 +727,48 @@ fn render_runtime_report(report: &RuntimeBenchmarkRun) -> String {
 
     lines.push(String::new());
     lines.push(
+        "| Scenario | Python | Rust | Median delta (ms) | Fastest | Stage deltas |".to_string(),
+    );
+    lines.push("| --- | --- | --- | --- | --- | --- |".to_string());
+    for row in &report.scenario_matrix {
+        let python = matrix_cell_label(row.python.status, row.python.median_time_ms);
+        let rust = matrix_cell_label(row.rust.status, row.rust.median_time_ms);
+        let delta = row
+            .comparison
+            .median_delta_ms
+            .map(|value| format!("{value:.2}"))
+            .unwrap_or_else(|| "-".to_string());
+        let fastest = row
+            .comparison
+            .fastest_runtime
+            .map(runtime_label)
+            .unwrap_or("-");
+        let stage_deltas = row
+            .comparison
+            .stage_deltas
+            .iter()
+            .filter_map(|stage| stage.delta_ms.map(|delta| (stage.stage.as_str(), delta)))
+            .take(6)
+            .map(|(stage, delta)| format!("{stage}:{delta:.2}"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        lines.push(format!(
+            "| {} | {} | {} | {} | {} | {} |",
+            row.scenario_id.replace('|', "\\|"),
+            python,
+            rust,
+            delta,
+            fastest,
+            if stage_deltas.is_empty() {
+                "-".to_string()
+            } else {
+                stage_deltas.replace('|', "\\|")
+            },
+        ));
+    }
+
+    lines.push(String::new());
+    lines.push(
         "| Scenario | Runtime | Status | Iterations | Total wall time (ms) | Median (ms) | Failure |"
             .to_string(),
     );
@@ -737,7 +813,19 @@ fn append_summary_row(
 
 fn runtime_label(runtime: kcmt_bench::model::RuntimeKind) -> &'static str {
     match runtime {
-        kcmt_bench::model::RuntimeKind::Python => "python",
-        kcmt_bench::model::RuntimeKind::Rust => "rust",
+        RuntimeKind::Python => "python",
+        RuntimeKind::Rust => "rust",
     }
+}
+
+fn matrix_cell_label(status: RuntimeScenarioStatus, median_time_ms: Option<f64>) -> String {
+    let status = match status {
+        RuntimeScenarioStatus::Passed => "passed",
+        RuntimeScenarioStatus::Failed => "failed",
+        RuntimeScenarioStatus::Excluded => "excluded",
+    };
+    let median = median_time_ms
+        .map(|value| format!("{value:.2} ms"))
+        .unwrap_or_else(|| "-".to_string());
+    format!("{status} ({median})")
 }

--- a/rust/crates/kcmt-cli/src/commands/benchmark.rs
+++ b/rust/crates/kcmt-cli/src/commands/benchmark.rs
@@ -748,7 +748,6 @@ fn render_runtime_report(report: &RuntimeBenchmarkRun) -> String {
             .stage_deltas
             .iter()
             .filter_map(|stage| stage.delta_ms.map(|delta| (stage.stage.as_str(), delta)))
-            .take(6)
             .map(|(stage, delta)| format!("{stage}:{delta:.2}"))
             .collect::<Vec<_>>()
             .join(", ");

--- a/rust/crates/kcmt-cli/tests/benchmark_contracts.rs
+++ b/rust/crates/kcmt-cli/tests/benchmark_contracts.rs
@@ -2,6 +2,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Mutex, OnceLock};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 #[test]
@@ -18,6 +19,9 @@ fn benchmark_subcommand_requires_mode() {
 
 #[test]
 fn runtime_benchmark_rust_missing_binary_is_reported_as_excluded_json() {
+    let _guard = runtime_benchmark_lock()
+        .lock()
+        .expect("runtime benchmark lock");
     let repo = init_repo();
     seed_runtime_corpus(&repo, "pytest-runtime-rust-missing");
 
@@ -45,8 +49,16 @@ fn runtime_benchmark_rust_missing_binary_is_reported_as_excluded_json() {
     );
     let payload: serde_json::Value =
         serde_json::from_slice(&output.stdout).expect("runtime benchmark json");
+    assert_eq!(payload["snapshot"]["benchmark_kind"], "runtime");
+    assert_eq!(payload["snapshot"]["provider_benchmark_kind"], "provider");
+    assert_eq!(payload["snapshot"]["secret_free"], true);
     let results = payload["results"].as_array().expect("results array");
     assert_eq!(results.len(), 4);
+    let matrix = payload["scenario_matrix"]
+        .as_array()
+        .expect("scenario matrix");
+    assert_eq!(matrix.len(), 4);
+    assert!(matrix.iter().all(|row| row["rust"]["status"] == "excluded"));
     assert!(results.iter().all(|item| item["status"] == "excluded"));
     assert!(results.iter().all(|item| item["failure_reason"]
         .as_str()
@@ -56,6 +68,9 @@ fn runtime_benchmark_rust_missing_binary_is_reported_as_excluded_json() {
 
 #[test]
 fn runtime_benchmark_python_emits_passing_results_json() {
+    let _guard = runtime_benchmark_lock()
+        .lock()
+        .expect("runtime benchmark lock");
     let repo = init_repo();
     seed_runtime_corpus(&repo, "pytest-runtime-python");
 
@@ -76,6 +91,12 @@ fn runtime_benchmark_python_emits_passing_results_json() {
     );
     let payload: serde_json::Value =
         serde_json::from_slice(&output.stdout).expect("runtime benchmark json");
+    assert_eq!(payload["snapshot"]["benchmark_kind"], "runtime");
+    assert_eq!(payload["scorecard"]["provider_throughput_included"], false);
+    assert!(payload["scorecard"]["measurement_basis"]
+        .as_str()
+        .unwrap_or_default()
+        .contains("pre-LLM Rust heuristic"));
     let results = payload["results"].as_array().expect("results array");
     assert_eq!(results.len(), 4);
     assert!(results
@@ -107,10 +128,113 @@ fn runtime_benchmark_python_emits_passing_results_json() {
     assert!(results
         .iter()
         .all(|item| item["runtime"] == "python" && item["status"] == "passed"));
+    let matrix = payload["scenario_matrix"]
+        .as_array()
+        .expect("scenario matrix");
+    assert_eq!(matrix.len(), 4);
+    let file_row = matrix
+        .iter()
+        .find(|item| item["workflow_contract_id"] == "file-repo-path")
+        .expect("file matrix row");
+    assert_eq!(file_row["python"]["status"], "passed");
+    assert_eq!(file_row["rust"]["status"], "excluded");
+    assert_eq!(file_row["rust"]["failure_reason"], "runtime not requested");
+}
+
+#[test]
+fn runtime_benchmark_both_emits_side_by_side_matrix_and_snapshot() {
+    let _guard = runtime_benchmark_lock()
+        .lock()
+        .expect("runtime benchmark lock");
+    let repo = init_repo();
+    let config_home = unique_temp_dir("runtime-both-config-home");
+    seed_runtime_corpus(&repo, "pytest-runtime-both-matrix");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kcmt"))
+        .env("KCMT_CONFIG_HOME", &config_home)
+        .env("KCMT_PYTHON_BIN", python_bin())
+        .args(["benchmark", "runtime", "--repo-path"])
+        .arg(&repo)
+        .args([
+            "--runtime",
+            "both",
+            "--iterations",
+            "1",
+            "--rust-bin",
+            env!("CARGO_BIN_EXE_kcmt"),
+            "--json",
+        ])
+        .output()
+        .expect("kcmt benchmark runtime should run");
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let payload: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("runtime benchmark json");
+    let results = payload["results"].as_array().expect("results array");
+    assert_eq!(results.len(), 8);
+    assert_eq!(payload["snapshot"]["result_count"], 8);
+    assert_eq!(
+        payload["scorecard"]["python_quality_score"].as_f64(),
+        Some(100.0)
+    );
+    assert_eq!(
+        payload["scorecard"]["rust_quality_score"].as_f64(),
+        Some(100.0)
+    );
+    let matrix = payload["scenario_matrix"]
+        .as_array()
+        .expect("scenario matrix");
+    assert_eq!(matrix.len(), 4);
+    let scenario_ids: Vec<&str> = matrix
+        .iter()
+        .map(|row| row["scenario_id"].as_str().expect("scenario id"))
+        .collect();
+    for expected in [
+        "pytest-runtime-both-matrix:status-repo-path",
+        "pytest-runtime-both-matrix:oneshot-repo-path",
+        "pytest-runtime-both-matrix:default-repo-path",
+        "pytest-runtime-both-matrix:file-repo-path",
+    ] {
+        assert!(scenario_ids.contains(&expected));
+    }
+    let file_row = matrix
+        .iter()
+        .find(|item| item["workflow_contract_id"] == "file-repo-path")
+        .expect("file matrix row");
+    assert_eq!(file_row["python"]["status"], "passed");
+    assert_eq!(file_row["rust"]["status"], "passed");
+    assert_eq!(file_row["comparison"]["comparable"], true);
+    assert!(file_row["comparison"]["stage_deltas"]
+        .as_array()
+        .expect("stage deltas")
+        .iter()
+        .any(|stage| stage["stage"] == "workflow_total"));
+    let snapshots = runtime_benchmark_snapshots(&config_home);
+    assert_eq!(snapshots.len(), 1);
+    let snapshot: serde_json::Value =
+        serde_json::from_slice(&fs::read(&snapshots[0]).expect("snapshot file"))
+            .expect("snapshot json");
+    assert_eq!(snapshot["snapshot"]["benchmark_kind"], "runtime");
+    assert_eq!(
+        snapshot["scenario_matrix"]
+            .as_array()
+            .expect("matrix")
+            .len(),
+        4
+    );
 }
 
 #[test]
 fn runtime_benchmark_rust_ingests_snapshot_stage_timings_json() {
+    let _guard = runtime_benchmark_lock()
+        .lock()
+        .expect("runtime benchmark lock");
     let repo = init_repo();
     seed_runtime_corpus(&repo, "pytest-runtime-rust-telemetry");
 
@@ -182,6 +306,9 @@ fn runtime_benchmark_rust_ingests_snapshot_stage_timings_json() {
 
 #[test]
 fn runtime_benchmark_fast_snapshot_keeps_python_compatible_keys() {
+    let _guard = runtime_benchmark_lock()
+        .lock()
+        .expect("runtime benchmark lock");
     let repo = init_repo();
     let config_home = unique_temp_dir("runtime-config-home");
     seed_runtime_corpus(&repo, "pytest-runtime-rust-snapshot");
@@ -190,6 +317,7 @@ fn runtime_benchmark_fast_snapshot_keeps_python_compatible_keys() {
         .env("KCMT_CONFIG_HOME", &config_home)
         .env("KCMT_RUNTIME_BENCHMARK", "1")
         .env("KCMT_PROVIDER_RESPONSE", "chore(repo): benchmark response")
+        .env("KCMT_DISABLE_KEYCHAIN", "1")
         .args(["--file", "src/app.py", "--repo-path"])
         .arg(&repo)
         .args(["--no-auto-push"])
@@ -313,6 +441,11 @@ fn unique_temp_dir(label: &str) -> PathBuf {
     path
 }
 
+fn runtime_benchmark_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
 fn python_bin() -> PathBuf {
     if let Ok(configured) = std::env::var("KCMT_PYTHON_BIN") {
         if !configured.trim().is_empty() {
@@ -410,6 +543,27 @@ fn benchmark_snapshots(config_home: &Path) -> Vec<PathBuf> {
             path.file_name()
                 .and_then(|name| name.to_str())
                 .map(|name| name.starts_with("benchmark-") && name.ends_with(".json"))
+                .unwrap_or(false)
+        }));
+    }
+    snapshots
+}
+
+fn runtime_benchmark_snapshots(config_home: &Path) -> Vec<PathBuf> {
+    let repos = config_home.join("repos");
+    let mut snapshots = Vec::new();
+    let Ok(repo_entries) = fs::read_dir(repos) else {
+        return snapshots;
+    };
+    for repo_entry in repo_entries.flatten() {
+        let benchmark_dir = repo_entry.path().join("benchmarks");
+        let Ok(entries) = fs::read_dir(benchmark_dir) else {
+            continue;
+        };
+        snapshots.extend(entries.flatten().map(|entry| entry.path()).filter(|path| {
+            path.file_name()
+                .and_then(|name| name.to_str())
+                .map(|name| name.starts_with("runtime-") && name.ends_with(".json"))
                 .unwrap_or(false)
         }));
     }

--- a/rust/crates/kcmt-cli/tests/benchmark_contracts.rs
+++ b/rust/crates/kcmt-cli/tests/benchmark_contracts.rs
@@ -23,9 +23,11 @@ fn runtime_benchmark_rust_missing_binary_is_reported_as_excluded_json() {
         .lock()
         .expect("runtime benchmark lock");
     let repo = init_repo();
+    let config_home = unique_temp_dir("runtime-rust-missing-config-home");
     seed_runtime_corpus(&repo, "pytest-runtime-rust-missing");
 
     let output = Command::new(env!("CARGO_BIN_EXE_kcmt"))
+        .env("KCMT_CONFIG_HOME", &config_home)
         .args(["benchmark", "runtime", "--repo-path"])
         .arg(&repo)
         .args([
@@ -72,9 +74,11 @@ fn runtime_benchmark_python_emits_passing_results_json() {
         .lock()
         .expect("runtime benchmark lock");
     let repo = init_repo();
+    let config_home = unique_temp_dir("runtime-python-config-home");
     seed_runtime_corpus(&repo, "pytest-runtime-python");
 
     let output = Command::new(env!("CARGO_BIN_EXE_kcmt"))
+        .env("KCMT_CONFIG_HOME", &config_home)
         .env("KCMT_PYTHON_BIN", python_bin())
         .args(["benchmark", "runtime", "--repo-path"])
         .arg(&repo)
@@ -236,9 +240,11 @@ fn runtime_benchmark_matrix_keeps_distinct_file_target_scenarios() {
         .lock()
         .expect("runtime benchmark lock");
     let repo = init_repo();
+    let config_home = unique_temp_dir("runtime-file-targets-config-home");
     seed_runtime_corpus_with_extra_file_target(&repo, "pytest-runtime-file-targets");
 
     let output = Command::new(env!("CARGO_BIN_EXE_kcmt"))
+        .env("KCMT_CONFIG_HOME", &config_home)
         .env("KCMT_PYTHON_BIN", python_bin())
         .args(["benchmark", "runtime", "--repo-path"])
         .arg(&repo)
@@ -280,9 +286,11 @@ fn runtime_benchmark_rust_ingests_snapshot_stage_timings_json() {
         .lock()
         .expect("runtime benchmark lock");
     let repo = init_repo();
+    let config_home = unique_temp_dir("runtime-rust-telemetry-config-home");
     seed_runtime_corpus(&repo, "pytest-runtime-rust-telemetry");
 
     let output = Command::new(env!("CARGO_BIN_EXE_kcmt"))
+        .env("KCMT_CONFIG_HOME", &config_home)
         .args(["benchmark", "runtime", "--repo-path"])
         .arg(&repo)
         .args([

--- a/rust/crates/kcmt-cli/tests/benchmark_contracts.rs
+++ b/rust/crates/kcmt-cli/tests/benchmark_contracts.rs
@@ -231,6 +231,50 @@ fn runtime_benchmark_both_emits_side_by_side_matrix_and_snapshot() {
 }
 
 #[test]
+fn runtime_benchmark_matrix_keeps_distinct_file_target_scenarios() {
+    let _guard = runtime_benchmark_lock()
+        .lock()
+        .expect("runtime benchmark lock");
+    let repo = init_repo();
+    seed_runtime_corpus_with_extra_file_target(&repo, "pytest-runtime-file-targets");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kcmt"))
+        .env("KCMT_PYTHON_BIN", python_bin())
+        .args(["benchmark", "runtime", "--repo-path"])
+        .arg(&repo)
+        .args(["--runtime", "python", "--iterations", "1", "--json"])
+        .output()
+        .expect("kcmt benchmark runtime should run");
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let payload: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("runtime benchmark json");
+    let results = payload["results"].as_array().expect("results array");
+    assert_eq!(results.len(), 5);
+    let matrix = payload["scenario_matrix"]
+        .as_array()
+        .expect("scenario matrix");
+    assert_eq!(matrix.len(), 5);
+    let scenario_ids: Vec<&str> = matrix
+        .iter()
+        .map(|row| row["scenario_id"].as_str().expect("scenario id"))
+        .collect();
+    assert!(scenario_ids.contains(&"pytest-runtime-file-targets:file-repo-path"));
+    assert!(scenario_ids.contains(&"pytest-runtime-file-targets:file-modified-extra"));
+    let file_rows = matrix
+        .iter()
+        .filter(|row| row["workflow_contract_id"] == "file-repo-path")
+        .count();
+    assert_eq!(file_rows, 2);
+}
+
+#[test]
 fn runtime_benchmark_rust_ingests_snapshot_stage_timings_json() {
     let _guard = runtime_benchmark_lock()
         .lock()
@@ -526,6 +570,34 @@ fn seed_runtime_corpus(repo: &Path, corpus_id: &str) {
         "def greet() -> str:\n    return 'hello runtime'\n",
     )
     .expect("modified source");
+}
+
+fn seed_runtime_corpus_with_extra_file_target(repo: &Path, corpus_id: &str) {
+    let source_file = repo.join("src").join("app.py");
+    let extra_file = repo.join("src").join("extra.py");
+    fs::create_dir_all(source_file.parent().expect("source parent"))
+        .expect("source dir should be created");
+    fs::write(&source_file, "def greet() -> str:\n    return 'hello'\n").expect("source file");
+    fs::write(&extra_file, "def extra() -> str:\n    return 'hello'\n").expect("extra file");
+    fs::write(
+        repo.join(".kcmt-runtime-corpus.json"),
+        format!(
+            "{{\"id\":\"{corpus_id}\",\"kind\":\"synthetic\",\"file_count\":2,\"git_history_state\":\"seeded-history\",\"change_shape\":[\"modified\",\"nested-paths\"],\"default_file_target\":\"src/app.py\",\"file_targets\":[{{\"id\":\"modified-extra\",\"path\":\"src/extra.py\"}}]}}"
+        ),
+    )
+    .expect("metadata file");
+    git(repo, &["add", "."]);
+    git(repo, &["commit", "-m", "chore(repo): seed"]);
+    fs::write(
+        source_file,
+        "def greet() -> str:\n    return 'hello runtime'\n",
+    )
+    .expect("modified source");
+    fs::write(
+        extra_file,
+        "def extra() -> str:\n    return 'hello target'\n",
+    )
+    .expect("modified extra");
 }
 
 fn benchmark_snapshots(config_home: &Path) -> Vec<PathBuf> {

--- a/rust/crates/kcmt-cli/tests/workflow_modes.rs
+++ b/rust/crates/kcmt-cli/tests/workflow_modes.rs
@@ -158,6 +158,9 @@ fn spawn_provider_responses(
             stream
                 .set_nonblocking(false)
                 .expect("mock provider stream should become blocking");
+            stream
+                .set_read_timeout(Some(Duration::from_secs(5)))
+                .expect("mock provider stream should have read timeout");
             let mut buffer = [0_u8; 32768];
             let bytes = stream.read(&mut buffer).expect("mock provider read");
             sender

--- a/specs/003-bring-rust-cli/contracts/runtime-benchmark.schema.json
+++ b/specs/003-bring-rust-cli/contracts/runtime-benchmark.schema.json
@@ -34,6 +34,63 @@
       "minItems": 1,
       "uniqueItems": true
     },
+    "snapshot": {
+      "type": "object",
+      "required": [
+        "snapshot_id",
+        "benchmark_kind",
+        "schema_version",
+        "timestamp",
+        "command_set",
+        "corpora",
+        "result_count",
+        "secret_free",
+        "provider_benchmark_kind"
+      ],
+      "properties": {
+        "snapshot_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "benchmark_kind": {
+          "type": "string",
+          "const": "runtime"
+        },
+        "schema_version": {
+          "type": "string",
+          "const": "1.0.0"
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "command_set": {
+          "type": "string",
+          "minLength": 1
+        },
+        "corpora": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "minItems": 1,
+          "uniqueItems": true
+        },
+        "result_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "secret_free": {
+          "type": "boolean"
+        },
+        "provider_benchmark_kind": {
+          "type": "string",
+          "const": "provider"
+        }
+      },
+      "additionalProperties": false
+    },
     "results": {
       "type": "array",
       "minItems": 1,
@@ -158,6 +215,49 @@
         "additionalProperties": false
       }
     },
+    "scenario_matrix": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "scenario_id",
+          "workflow_contract_id",
+          "corpus_id",
+          "command_label",
+          "python",
+          "rust",
+          "comparison"
+        ],
+        "properties": {
+          "scenario_id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "workflow_contract_id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "corpus_id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "command_label": {
+            "type": "string",
+            "minLength": 1
+          },
+          "python": {
+            "$ref": "#/$defs/runtimeMatrixCell"
+          },
+          "rust": {
+            "$ref": "#/$defs/runtimeMatrixCell"
+          },
+          "comparison": {
+            "$ref": "#/$defs/runtimeScenarioComparison"
+          }
+        },
+        "additionalProperties": false
+      }
+    },
     "summary": {
       "type": "object",
       "required": [
@@ -170,6 +270,52 @@
         },
         "rust": {
           "$ref": "#/$defs/runtimeSummary"
+        }
+      },
+      "additionalProperties": false
+    },
+    "scorecard": {
+      "type": "object",
+      "required": [
+        "measurement_basis",
+        "quality_score_definition",
+        "throughput_definition",
+        "python_quality_score",
+        "rust_quality_score",
+        "provider_throughput_included"
+      ],
+      "properties": {
+        "measurement_basis": {
+          "type": "string",
+          "minLength": 1
+        },
+        "quality_score_definition": {
+          "type": "string",
+          "minLength": 1
+        },
+        "throughput_definition": {
+          "type": "string",
+          "minLength": 1
+        },
+        "python_quality_score": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "minimum": 0,
+          "maximum": 100
+        },
+        "rust_quality_score": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "minimum": 0,
+          "maximum": 100
+        },
+        "provider_throughput_included": {
+          "type": "boolean",
+          "const": false
         }
       },
       "additionalProperties": false
@@ -248,6 +394,177 @@
     }
   },
   "$defs": {
+    "runtimeMatrixCell": {
+      "type": "object",
+      "required": [
+        "status",
+        "iterations",
+        "wall_time_ms",
+        "median_time_ms",
+        "throughput_commits_per_sec",
+        "quality_score",
+        "stage_timings",
+        "failure_reason"
+      ],
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": [
+            "passed",
+            "failed",
+            "excluded"
+          ]
+        },
+        "iterations": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "wall_time_ms": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "minimum": 0
+        },
+        "median_time_ms": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "minimum": 0
+        },
+        "throughput_commits_per_sec": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "minimum": 0
+        },
+        "quality_score": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "minimum": 0,
+          "maximum": 100
+        },
+        "stage_timings": {
+          "$ref": "#/$defs/stageTimings"
+        },
+        "failure_reason": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "runtimeScenarioComparison": {
+      "type": "object",
+      "required": [
+        "comparable",
+        "fastest_runtime",
+        "median_delta_ms",
+        "speedup_ratio",
+        "stage_deltas"
+      ],
+      "properties": {
+        "comparable": {
+          "type": "boolean"
+        },
+        "fastest_runtime": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "enum": [
+            "python",
+            "rust",
+            null
+          ]
+        },
+        "median_delta_ms": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "speedup_ratio": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "minimum": 0
+        },
+        "stage_deltas": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "stage",
+              "python_ms",
+              "rust_ms",
+              "delta_ms"
+            ],
+            "properties": {
+              "stage": {
+                "type": "string",
+                "minLength": 1
+              },
+              "python_ms": {
+                "type": [
+                  "number",
+                  "null"
+                ],
+                "minimum": 0
+              },
+              "rust_ms": {
+                "type": [
+                  "number",
+                  "null"
+                ],
+                "minimum": 0
+              },
+              "delta_ms": {
+                "type": [
+                  "number",
+                  "null"
+                ]
+              }
+            },
+            "additionalProperties": false
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "stageTimings": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "stage",
+          "duration_ms",
+          "items"
+        ],
+        "properties": {
+          "stage": {
+            "type": "string",
+            "minLength": 1
+          },
+          "duration_ms": {
+            "type": "number",
+            "minimum": 0
+          },
+          "items": {
+            "type": "integer",
+            "minimum": 0
+          }
+        },
+        "additionalProperties": false
+      }
+    },
     "runtimeSummary": {
       "type": "object",
       "required": [

--- a/tests/features/rust_workflow_parity.feature
+++ b/tests/features/rust_workflow_parity.feature
@@ -179,7 +179,9 @@ Feature: Rust workflow parity
     Then the benchmark output includes leaderboard JSON and CSV sections
     And the provider benchmark snapshot is persisted
 
-  Scenario: Runtime benchmark reports Rust snapshot stage telemetry
+  Scenario: Runtime benchmark reports side-by-side runtime scoreboard
     Given a checked-in runtime benchmark corpus
     When the Rust kcmt runtime benchmark runs against the corpus
     Then the benchmark report includes Rust workflow stage timings
+    And the benchmark report compares Python and Rust runtime stages
+    And the runtime benchmark snapshot is persisted

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -73,6 +73,52 @@ def _create_runtime_corpus(tmp_path: Path) -> Path:
     return repo
 
 
+def _create_runtime_corpus_with_file_targets(tmp_path: Path) -> Path:
+    repo = tmp_path / "runtime-file-target-corpus"
+    repo.mkdir()
+    subprocess.run(
+        ["git", "init", "--initial-branch=main", str(repo)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if not (repo / ".git").exists():
+        _git(repo, "init")
+        _git(repo, "branch", "-M", "main")
+    _git(repo, "config", "user.name", "Tester")
+    _git(repo, "config", "user.email", "tester@example.com")
+
+    source_file = repo / "src" / "app.py"
+    extra_file = repo / "src" / "extra.py"
+    source_file.parent.mkdir(parents=True, exist_ok=True)
+    source_file.write_text(
+        "def greet() -> str:\n    return 'hello'\n", encoding="utf-8"
+    )
+    extra_file.write_text("def extra() -> str:\n    return 'hello'\n", encoding="utf-8")
+    metadata = {
+        "id": "pytest-runtime-file-target-corpus",
+        "kind": "synthetic",
+        "file_count": 2,
+        "git_history_state": "seeded-history",
+        "change_shape": ["modified", "nested-paths"],
+        "default_file_target": "src/app.py",
+        "file_targets": [{"id": "modified-extra", "path": "src/extra.py"}],
+    }
+    (repo / bench.RUNTIME_BENCHMARK_METADATA_FILENAME).write_text(
+        json.dumps(metadata),
+        encoding="utf-8",
+    )
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "chore(repo): seed")
+    source_file.write_text(
+        "def greet() -> str:\n    return 'hello runtime'\n", encoding="utf-8"
+    )
+    extra_file.write_text(
+        "def extra() -> str:\n    return 'hello target'\n", encoding="utf-8"
+    )
+    return repo
+
+
 def test_run_benchmark_produces_results(monkeypatch):
     def _fake_build_config(provider: str, model: str):
         # Not used by the stub client factory; only present for signature.
@@ -229,6 +275,32 @@ def test_run_runtime_benchmark_produces_python_results(tmp_path):
     assert all(item["throughput_commits_per_sec"] is None for item in iterations[1:])
     assert all(item["quality_score"] is None for item in iterations[1:])
     assert all(item["failures"] is None for item in iterations[1:])
+
+
+def test_runtime_benchmark_matrix_preserves_file_target_scenarios(tmp_path):
+    repo = _create_runtime_corpus_with_file_targets(tmp_path)
+
+    report = bench.run_runtime_benchmark(
+        repo,
+        runtime="python",
+        iterations=1,
+    )
+    payload = bench.runtime_benchmark_report_to_dict(report)
+
+    assert len(payload["results"]) == 5
+    matrix = payload["scenario_matrix"]
+    assert len(matrix) == 5
+    scenario_ids = {row["scenario_id"] for row in matrix}
+    assert "pytest-runtime-file-target-corpus:file-repo-path" in scenario_ids
+    assert "pytest-runtime-file-target-corpus:file-modified-extra" in scenario_ids
+    assert sum(row["workflow_contract_id"] == "file-repo-path" for row in matrix) == 2
+    extra_row = next(
+        row
+        for row in matrix
+        if row["scenario_id"] == "pytest-runtime-file-target-corpus:file-modified-extra"
+    )
+    assert extra_row["python"]["status"] == "passed"
+    assert extra_row["rust"]["status"] == "excluded"
 
 
 def test_runtime_benchmark_large_synthetic_excludes_default_workflow(tmp_path):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -342,6 +342,9 @@ def test_cli_runtime_benchmark_json(tmp_path, capsys):
     assert payload["schema_version"] == "1.0.0"
     assert payload["command_set"] == "local-workflows-v1"
     assert payload["corpora"] == ["pytest-cli-runtime-corpus"]
+    assert payload["snapshot"]["benchmark_kind"] == "runtime"
+    assert payload["snapshot"]["provider_benchmark_kind"] == "provider"
+    assert payload["snapshot"]["secret_free"] is True
     assert len(payload["results"]) == 4
     assert any(
         item["workflow_contract_id"] == "default-repo-path"
@@ -349,6 +352,23 @@ def test_cli_runtime_benchmark_json(tmp_path, capsys):
     )
     assert all(item["runtime"] == "python" for item in payload["results"])
     assert all(isinstance(item["stage_timings"], list) for item in payload["results"])
+    matrix = payload["scenario_matrix"]
+    assert len(matrix) == 4
+    assert {row["workflow_contract_id"] for row in matrix} == {
+        "status-repo-path",
+        "oneshot-repo-path",
+        "default-repo-path",
+        "file-repo-path",
+    }
+    file_row = next(
+        row for row in matrix if row["workflow_contract_id"] == "file-repo-path"
+    )
+    assert file_row["python"]["status"] == "passed"
+    assert file_row["python"]["quality_score"] == 100.0
+    assert file_row["rust"]["status"] == "excluded"
+    assert file_row["rust"]["failure_reason"] == "runtime not requested"
+    assert payload["scorecard"]["provider_throughput_included"] is False
+    assert "pre-LLM Rust heuristic" in payload["scorecard"]["measurement_basis"]
     assert len(payload["optimization_iterations"]) == 6
     assert payload["optimization_iterations"][0]["measurement_status"] == "measured"
     assert all(

--- a/tests/test_rust_workflow_parity_bdd.py
+++ b/tests/test_rust_workflow_parity_bdd.py
@@ -2040,4 +2040,6 @@ def runtime_benchmark_snapshot_is_persisted(
     assert len(snapshots) == 1
     payload = json.loads(snapshots[0].read_text())
     assert payload["snapshot"]["benchmark_kind"] == "runtime"
-    assert len(payload["scenario_matrix"]) == 4
+    output_payload = json.loads(workflow_context["output"])
+    assert len(payload["scenario_matrix"]) == len(output_payload["scenario_matrix"])
+    assert len(payload["scenario_matrix"]) >= 4

--- a/tests/test_rust_workflow_parity_bdd.py
+++ b/tests/test_rust_workflow_parity_bdd.py
@@ -1086,7 +1086,7 @@ def rust_kcmt_runtime_benchmark_runs_against_the_corpus(
             "--repo-path",
             str(workflow_context["repo"]),
             "--runtime",
-            "rust",
+            "both",
             "--iterations",
             "1",
             "--rust-bin",
@@ -1998,3 +1998,46 @@ def benchmark_report_includes_rust_workflow_stage_timings(
     }.issubset(stage_names)
     assert all(isinstance(stage["duration_ms"], int | float) for stage in stages)
     assert all(isinstance(stage["items"], int) for stage in stages)
+
+
+@then("the benchmark report compares Python and Rust runtime stages")
+def benchmark_report_compares_python_and_rust_runtime_stages(
+    workflow_context: dict[str, Any],
+) -> None:
+    payload = json.loads(workflow_context["output"])
+    assert payload["snapshot"]["benchmark_kind"] == "runtime"
+    assert payload["snapshot"]["provider_benchmark_kind"] == "provider"
+    assert payload["scorecard"]["provider_throughput_included"] is False
+    assert "pre-LLM Rust heuristic" in payload["scorecard"]["measurement_basis"]
+    matrix = payload["scenario_matrix"]
+    assert {row["workflow_contract_id"] for row in matrix} == {
+        "status-repo-path",
+        "oneshot-repo-path",
+        "default-repo-path",
+        "file-repo-path",
+    }
+    file_row = next(
+        row for row in matrix if row["workflow_contract_id"] == "file-repo-path"
+    )
+    assert file_row["python"]["status"] == "passed"
+    assert file_row["rust"]["status"] == "passed"
+    assert file_row["comparison"]["comparable"] is True
+    assert any(
+        stage["stage"] == "workflow_total"
+        for stage in file_row["comparison"]["stage_deltas"]
+    )
+
+
+@then("the runtime benchmark snapshot is persisted")
+def runtime_benchmark_snapshot_is_persisted(
+    workflow_context: dict[str, Any],
+) -> None:
+    repo = workflow_context["repo"].resolve()
+    digest = __import__("hashlib").sha256(str(repo).encode("utf-8")).hexdigest()[:8]
+    namespace = f"{repo.name}-{digest}"
+    benchmark_dir = workflow_context["config_home"] / "repos" / namespace / "benchmarks"
+    snapshots = sorted(benchmark_dir.glob("runtime-*.json"))
+    assert len(snapshots) == 1
+    payload = json.loads(snapshots[0].read_text())
+    assert payload["snapshot"]["benchmark_kind"] == "runtime"
+    assert len(payload["scenario_matrix"]) == 4


### PR DESCRIPTION
## Summary

This PR closes the `Benchmarks` Python/Rust parity gap by adding a durable runtime benchmark scoreboard that compares Python and Rust stage timings side by side for stable benchmark scenarios.

The implementation keeps provider benchmarks and runtime benchmarks distinct, while making their outputs linkable through consistent snapshot metadata. Runtime benchmark JSON now includes additive `snapshot`, `scenario_matrix`, and `scorecard` fields across Python and Rust outputs, and the Rust CLI persists runtime JSON/Markdown snapshots separately from provider benchmark artifacts.

PR #37 was inspected before implementation and had already been merged, so this branch was based on the latest `origin/main` rather than stacked on PR #37.

## Conventional Commit Breakdown

| Commit | Type | Scope | Summary |
| --- | --- | --- | --- |
| `5dc1956` | `feat` | `benchmark` | compare runtime stages side by side |
| `1ccf237` | `fix` | `benchmark` | preserve file-target matrix rows |
| `d0ddc8d` | `test` | `benchmark` | isolate runtime benchmark fixtures |

## Release Notes Draft

- Runtime benchmark JSON now exposes Python and Rust stage timings side by side in a durable scenario matrix.
- Runtime benchmark snapshots now persist with schema-compatible metadata and a scorecard suitable for optimization tracking.
- Runtime benchmark output explicitly marks pre-LLM Rust heuristic timing as local fixture/pre-provider measurement, not provider throughput.
- Provider benchmark snapshots remain separate from runtime benchmark snapshots, avoiding contract ambiguity while preserving linkability.

## Behaviour Changes

- `kcmt benchmark --runtime ... --format json` includes additive runtime comparison fields: `snapshot`, `scenario_matrix`, and `scorecard`.
- Runtime benchmark Markdown reports include a side-by-side scenario matrix and full stage delta details.
- Stable scenario IDs are preserved for status, oneshot, file, and default workflows where supported.
- Matrix rows are keyed by stable scenario ID so corpora with multiple file-target scenarios retain distinct rows.
- Runtime unavailable/excluded cases are represented in the matrix rather than conflated with failed provider throughput.

## API / Schema / Contract Changes

- Updated `specs/003-bring-rust-cli/contracts/runtime-benchmark.schema.json` with additive runtime benchmark fields.
- Existing `results`, `summary`, and optimization iteration fields remain intact for backward compatibility.
- Runtime benchmark snapshots are persisted separately from provider benchmark snapshots.
- Scorecard fields document measurement basis, provider throughput inclusion, runtime availability, comparable scenario counts, and quality notes.

## Testing Evidence

Focused validation:

```text
rtk uv run pytest -q tests/test_cli.py --no-cov -k "runtime_benchmark or benchmark_flag"
# passed: 4 passed, 9 deselected

rtk uv run pytest -q tests/test_rust_workflow_parity_bdd.py --no-cov -k "benchmark"
# passed: 2 passed, 30 deselected

rtk cargo test --manifest-path rust/Cargo.toml -p kcmt-cli --test benchmark_contracts -- --nocapture
# passed: 8 passed

rtk cargo test --manifest-path rust/Cargo.toml -p kcmt-cli --test workflow_modes file_mode_retries_invalid_output_with_simple_prompt -- --nocapture
# passed: 1 passed, 41 filtered out

rtk uv run pytest -q tests/test_benchmark.py::test_runtime_benchmark_matrix_preserves_file_target_scenarios --no-cov
# passed: 1 passed

rtk cargo test --manifest-path rust/Cargo.toml -p kcmt-cli --test benchmark_contracts runtime_benchmark_matrix_keeps_distinct_file_target_scenarios -- --nocapture
# passed: 1 passed, 7 filtered out
```

Full gates:

```text
rtk make check
# passed

rtk make quality-gates
# passed
```

GitHub CI after the latest push:

| Check | Status |
| --- | --- |
| Lint, type-check, and tests (Python 3.12) | Passed |
| Lint, type-check, and tests (Python 3.13) | Passed |
| Parity (ubuntu-latest) | Passed |
| Parity (macos-latest) | Passed |
| Parity (windows-latest) | Passed |
| assimilation | Passed |

## Risk and Rollback

Risk is low to moderate because benchmark JSON grows additively and the existing runtime benchmark rows remain present. The main compatibility risk is downstream consumers that reject unknown JSON fields rather than ignoring additive fields.

Rollback is straightforward: revert this PR to remove the additive runtime scoreboard fields and persisted runtime snapshot behavior while preserving existing provider benchmark behavior.

## Operational Notes

- Runtime benchmark snapshots are secret-free and use benchmark metadata rather than provider credentials or provider payloads.
- Runtime and provider benchmark outputs remain separate artifact families.
- Rust heuristic/pre-LLM timings are explicitly marked so they are not interpreted as full provider throughput.
- Runtime benchmark tests isolate `KCMT_CONFIG_HOME` to avoid writing snapshots to developer config state.

## Linked Work

- Related context: PR #37 added usage telemetry and selector behavior and was already merged before this branch was created.
- This PR closes the `Benchmarks` line item from the Python/Rust parity gap analysis.

## Reviewer Checklist

- [ ] Confirm runtime benchmark JSON includes `snapshot`, `scenario_matrix`, and `scorecard` without breaking existing fields.
- [ ] Confirm scenario IDs remain stable and file-target scenarios are not collapsed.
- [ ] Confirm provider benchmark and runtime benchmark snapshot outputs remain distinct.
- [ ] Confirm scorecard wording avoids treating pre-LLM Rust heuristic timings as provider throughput.
- [ ] Confirm BDD, Python, Rust focused tests, `make check`, and `make quality-gates` evidence is sufficient.
