### PR TITLE
feat(rust): close configure ux parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,9 @@ Dependencies
 
 Run `kcmt --configure` inside a repository to write or refresh global config.
 Use `kcmt --configure --tui` to open the terminal menu shell when stdin/stdout
-are attached to a terminal.
+are attached to a terminal. In the Rust path, the TUI shows the resolved
+provider/model/credential summary and saves on `s` or Enter; `q`/Esc exits
+without changing files. Non-TTY configure runs stay non-blocking and scriptable.
 
 - Detects available API keys (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `XAI_API_KEY`, `GITHUB_TOKEN`).
 - Lets you choose the provider, tweak model/endpoint, and pick the env var to use.
@@ -129,7 +131,7 @@ First-use model selection
 
 Configure API keys for multiple providers
 
-- `kcmt --configure-all` lets you pick which providers to configure and select which environment variable holds each API key. This updates both the legacy `provider_env_overrides` and the new `providers[prov].api_key_env` entries.
+- `kcmt --configure-all` lets you pick which providers to configure and select which environment variable holds each API key. Non-interactive Rust runs with `--provider`, `--model`, `--endpoint`, or `--api-key-env` update the target `providers[prov]` entry without clobbering an existing primary provider/model priority.
 - `kcmt --verify-keys` prints a concise table of providers, the env var in use, whether it’s set, and any detected alternatives in your environment.
 
 OpenAI batch mode

--- a/kcmt/main.py
+++ b/kcmt/main.py
@@ -66,7 +66,7 @@ def _is_rust_covered_invocation(args: list[str] | None = None) -> bool:
     if "--oneshot" in arg_list or "--file" in arg_list:
         return True
     is_configure = "--configure" in arg_list or "--configure-all" in arg_list
-    if is_configure and any(flag in arg_list for flag in _CONFIG_OVERRIDE_FLAGS):
+    if is_configure:
         return True
     if (
         "--list-models" in arg_list

--- a/rust/crates/kcmt-cli/src/commands/configure.rs
+++ b/rust/crates/kcmt-cli/src/commands/configure.rs
@@ -2,15 +2,26 @@ use std::collections::HashMap;
 use std::fs;
 use std::path::PathBuf;
 
+use anyhow::{bail, Result};
 use kcmt_core::config::loader::{config_file_path, load_config, ConfigOverrides};
 use kcmt_core::model::{ModelPreference, ProviderConfigEntry};
-use kcmt_core::preferences::{load_preferences, save_preferences};
+use kcmt_core::preferences::{
+    default_keychain_account, load_preferences, preferences_path, Preferences, ProviderRule,
+};
 use serde_json::json;
 
-use super::model_discovery::{default_provider_definitions, discover_model_catalog};
+use super::model_discovery::{
+    default_provider_definitions, discover_model_catalog, ProviderDefinition,
+};
 
-pub fn run_configure(repo_path: PathBuf, overrides: ConfigOverrides) -> i32 {
-    match write_config(repo_path, overrides) {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConfigureMode {
+    Single,
+    All,
+}
+
+pub fn run_configure(repo_path: PathBuf, overrides: ConfigOverrides, mode: ConfigureMode) -> i32 {
+    match write_config(repo_path, overrides, mode) {
         Ok(path) => {
             println!("Configuration saved to {}", path.display());
             0
@@ -67,35 +78,113 @@ pub fn run_verify_keys() -> i32 {
     0
 }
 
-fn write_config(repo_path: PathBuf, overrides: ConfigOverrides) -> anyhow::Result<PathBuf> {
-    let cfg = load_config(&repo_path, &overrides)?;
+fn write_config(
+    repo_path: PathBuf,
+    overrides: ConfigOverrides,
+    mode: ConfigureMode,
+) -> Result<PathBuf> {
+    let definitions = default_provider_definitions();
+    validate_overrides(&overrides, &definitions)?;
+    let path = config_file_path(&repo_path);
+    let persisted_config_exists = path.exists();
+    let target_provider = overrides.provider.clone();
+    let mut resolved_overrides = overrides.clone();
+    if mode == ConfigureMode::All && persisted_config_exists {
+        resolved_overrides.provider = None;
+        resolved_overrides.model = None;
+        resolved_overrides.endpoint = None;
+        resolved_overrides.api_key_env = None;
+    }
+
+    let cfg = load_config(&repo_path, &resolved_overrides)?;
+    let target_provider = target_provider.unwrap_or_else(|| cfg.provider.clone());
+    let Some(target_definition) = provider_definition(&definitions, &target_provider) else {
+        bail!("unsupported provider '{target_provider}' for configure");
+    };
+
     let mut providers: HashMap<String, ProviderConfigEntry> = cfg.providers.clone();
-    for definition in default_provider_definitions() {
+    for definition in &definitions {
         providers
-            .entry(definition.provider.to_string())
+            .entry(definition.provider.clone())
             .and_modify(|entry| {
                 entry
                     .name
-                    .get_or_insert_with(|| definition.display_name.to_string());
+                    .get_or_insert_with(|| definition.display_name.clone());
                 entry
                     .endpoint
-                    .get_or_insert_with(|| definition.endpoint.to_string());
+                    .get_or_insert_with(|| definition.endpoint.clone());
                 entry
                     .api_key_env
-                    .get_or_insert_with(|| definition.api_key_env.to_string());
+                    .get_or_insert_with(|| definition.api_key_env.clone());
                 entry
                     .keychain_account
-                    .get_or_insert_with(|| format!("provider/{}/default", definition.provider));
+                    .get_or_insert_with(|| default_keychain_account(&definition.provider));
                 entry
                     .preferred_model
-                    .get_or_insert_with(|| definition.default_model.to_string());
+                    .get_or_insert_with(|| definition.default_model.clone());
             })
             .or_insert_with(|| ProviderConfigEntry {
-                name: Some(definition.display_name.to_string()),
-                endpoint: Some(definition.endpoint.to_string()),
-                api_key_env: Some(definition.api_key_env.to_string()),
-                keychain_account: Some(format!("provider/{}/default", definition.provider)),
-                preferred_model: Some(definition.default_model.to_string()),
+                name: Some(definition.display_name.clone()),
+                endpoint: Some(definition.endpoint.clone()),
+                api_key_env: Some(definition.api_key_env.clone()),
+                keychain_account: Some(default_keychain_account(&definition.provider)),
+                preferred_model: Some(definition.default_model.clone()),
+            });
+    }
+
+    if mode == ConfigureMode::All {
+        providers
+            .entry(target_provider.clone())
+            .and_modify(|entry| {
+                entry
+                    .name
+                    .get_or_insert_with(|| target_definition.display_name.clone());
+                if let Some(endpoint) = overrides.endpoint.clone() {
+                    entry.endpoint = Some(endpoint);
+                } else {
+                    entry
+                        .endpoint
+                        .get_or_insert_with(|| target_definition.endpoint.clone());
+                }
+                if let Some(api_key_env) = overrides.api_key_env.clone() {
+                    entry.api_key_env = Some(api_key_env);
+                } else {
+                    entry
+                        .api_key_env
+                        .get_or_insert_with(|| target_definition.api_key_env.clone());
+                }
+                entry
+                    .keychain_account
+                    .get_or_insert_with(|| default_keychain_account(&target_provider));
+                if let Some(model) = overrides.model.clone() {
+                    entry.preferred_model = Some(model);
+                } else {
+                    entry
+                        .preferred_model
+                        .get_or_insert_with(|| target_definition.default_model.clone());
+                }
+            })
+            .or_insert_with(|| ProviderConfigEntry {
+                name: Some(target_definition.display_name.clone()),
+                endpoint: Some(
+                    overrides
+                        .endpoint
+                        .clone()
+                        .unwrap_or_else(|| target_definition.endpoint.clone()),
+                ),
+                api_key_env: Some(
+                    overrides
+                        .api_key_env
+                        .clone()
+                        .unwrap_or_else(|| target_definition.api_key_env.clone()),
+                ),
+                keychain_account: Some(default_keychain_account(&target_provider)),
+                preferred_model: Some(
+                    overrides
+                        .model
+                        .clone()
+                        .unwrap_or_else(|| target_definition.default_model.clone()),
+                ),
             });
     }
 
@@ -104,24 +193,46 @@ fn write_config(repo_path: PathBuf, overrides: ConfigOverrides) -> anyhow::Resul
         primary.api_key_env = Some(cfg.api_key_env.clone());
         primary
             .keychain_account
-            .get_or_insert_with(|| format!("provider/{}/default", cfg.provider));
+            .get_or_insert_with(|| default_keychain_account(&cfg.provider));
         primary.preferred_model = Some(cfg.model.clone());
+    }
+
+    let mut provider = cfg.provider.clone();
+    let mut model = cfg.model.clone();
+    let mut llm_endpoint = cfg.llm_endpoint.clone();
+    let mut api_key_env = cfg.api_key_env.clone();
+    if mode == ConfigureMode::All && target_provider == cfg.provider && persisted_config_exists {
+        if let Some(value) = overrides.model.clone() {
+            model = value;
+        }
+        if let Some(value) = overrides.endpoint.clone() {
+            llm_endpoint = value;
+        }
+        if let Some(value) = overrides.api_key_env.clone() {
+            api_key_env = value;
+        }
+        provider = target_provider.clone();
+        if let Some(primary) = providers.get_mut(&provider) {
+            primary.endpoint = Some(llm_endpoint.clone());
+            primary.api_key_env = Some(api_key_env.clone());
+            primary.preferred_model = Some(model.clone());
+        }
     }
 
     let model_priority = if cfg.model_priority.is_empty() {
         vec![ModelPreference {
-            provider: cfg.provider.clone(),
-            model: cfg.model.clone(),
+            provider: provider.clone(),
+            model: model.clone(),
         }]
     } else {
         cfg.model_priority.clone()
     };
 
     let payload = json!({
-        "provider": cfg.provider,
-        "model": cfg.model,
-        "llm_endpoint": cfg.llm_endpoint,
-        "api_key_env": cfg.api_key_env,
+        "provider": provider,
+        "model": model,
+        "llm_endpoint": llm_endpoint,
+        "api_key_env": api_key_env,
         "git_repo_path": cfg.git_repo_path,
         "max_commit_length": cfg.max_commit_length,
         "auto_push": cfg.auto_push,
@@ -131,12 +242,122 @@ fn write_config(repo_path: PathBuf, overrides: ConfigOverrides) -> anyhow::Resul
         "batch_model": cfg.batch_model,
         "batch_timeout_seconds": cfg.batch_timeout_seconds
     });
-    let path = config_file_path(&repo_path);
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)?;
     }
     fs::write(&path, serde_json::to_string_pretty(&payload)?)?;
-    let preferences = load_preferences().unwrap_or_default();
-    save_preferences(&preferences)?;
+    initialize_preferences(&definitions)?;
     Ok(path)
+}
+
+fn initialize_preferences(definitions: &[ProviderDefinition]) -> Result<PathBuf> {
+    let path = preferences_path();
+    let defaults = serde_json::to_value(Preferences::default())?;
+    let mut preferences = if path.exists() {
+        fs::read_to_string(&path)
+            .ok()
+            .and_then(|raw| serde_json::from_str::<serde_json::Value>(&raw).ok())
+            .filter(|value| value.is_object())
+            .unwrap_or_else(|| defaults.clone())
+    } else {
+        defaults.clone()
+    };
+    let object = preferences
+        .as_object_mut()
+        .expect("preferences value is object");
+    if let Some(default_object) = defaults.as_object() {
+        for (key, value) in default_object {
+            object.entry(key.clone()).or_insert_with(|| value.clone());
+        }
+    }
+    if object
+        .get("prompt_profiles")
+        .and_then(|value| value.as_array())
+        .map(|profiles| profiles.is_empty())
+        .unwrap_or(true)
+    {
+        object["prompt_profiles"] = defaults["prompt_profiles"].clone();
+    }
+    if object
+        .get("default_prompt_profile")
+        .and_then(|value| value.as_str())
+        .map(|value| value.trim().is_empty())
+        .unwrap_or(true)
+    {
+        object["default_prompt_profile"] = defaults["default_prompt_profile"].clone();
+    }
+    let provider_rules = object
+        .entry("provider_rules".to_string())
+        .or_insert_with(|| serde_json::json!({}));
+    if !provider_rules.is_object() {
+        *provider_rules = serde_json::json!({});
+    }
+    let provider_rules = provider_rules
+        .as_object_mut()
+        .expect("provider_rules value is object");
+    let default_rule = serde_json::to_value(ProviderRule::default())?;
+    for definition in definitions {
+        provider_rules
+            .entry(definition.provider.clone())
+            .or_insert_with(|| default_rule.clone());
+    }
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    fs::write(&path, serde_json::to_string_pretty(&preferences)?)?;
+    Ok(path)
+}
+
+fn provider_definition<'a>(
+    definitions: &'a [ProviderDefinition],
+    provider: &str,
+) -> Option<&'a ProviderDefinition> {
+    definitions
+        .iter()
+        .find(|definition| definition.provider == provider)
+}
+
+fn validate_overrides(
+    overrides: &ConfigOverrides,
+    definitions: &[ProviderDefinition],
+) -> Result<()> {
+    if let Some(provider) = overrides.provider.as_deref() {
+        if provider_definition(definitions, provider).is_none() {
+            let expected = definitions
+                .iter()
+                .map(|definition| definition.provider.as_str())
+                .collect::<Vec<_>>()
+                .join(", ");
+            bail!("unsupported provider '{provider}'; expected one of: {expected}");
+        }
+    }
+    if let Some(model) = overrides.model.as_deref() {
+        let trimmed = model.trim();
+        if trimmed.is_empty() || trimmed.chars().any(char::is_whitespace) {
+            bail!("model must be a non-empty provider model id without whitespace");
+        }
+    }
+    if let Some(endpoint) = overrides.endpoint.as_deref() {
+        let trimmed = endpoint.trim();
+        if !(trimmed.starts_with("https://") || trimmed.starts_with("http://")) {
+            bail!(
+                "endpoint must be an http(s) URL; use --api-key-env for environment variable names"
+            );
+        }
+    }
+    if let Some(api_key_env) = overrides.api_key_env.as_deref() {
+        if api_key_env.starts_with("http://") || api_key_env.starts_with("https://") {
+            bail!("api key env must be an environment variable name, not a URL");
+        }
+        let mut chars = api_key_env.chars();
+        let Some(first) = chars.next() else {
+            bail!("api key env must be a non-empty environment variable name");
+        };
+        if !(first == '_' || first.is_ascii_alphabetic())
+            || !chars.all(|ch| ch == '_' || ch.is_ascii_alphanumeric())
+        {
+            bail!("api key env must match [A-Za-z_][A-Za-z0-9_]*");
+        }
+    }
+    Ok(())
 }

--- a/rust/crates/kcmt-cli/src/lib.rs
+++ b/rust/crates/kcmt-cli/src/lib.rs
@@ -13,6 +13,7 @@ use kcmt_core::git::repo::find_git_repo_root;
 use kcmt_core::preferences::{default_keychain_account, OsKeychainStore, SecretStore};
 
 use args::{CliArgs, CliCommand, StatusArgs};
+use commands::configure::ConfigureMode;
 use commands::workflow::WorkflowOutputOptions;
 
 #[derive(Debug, Clone)]
@@ -98,6 +99,32 @@ fn dispatch(_entrypoint: &str, args: CliArgs, arg_parse_ms: f64) -> i32 {
     let repo_path = repo_discovery.repo_path.clone();
 
     if args.configure || args.configure_all {
+        let overrides = config_overrides(&args, repo_path.clone());
+        if args.tui && kcmt_tui::should_enable_tui(false) {
+            let state = kcmt_tui::ConfigureTuiState {
+                provider: args
+                    .provider
+                    .clone()
+                    .unwrap_or_else(|| "auto/default".to_string()),
+                model: args
+                    .model
+                    .clone()
+                    .unwrap_or_else(|| "auto/default".to_string()),
+                rule: "provider presets enabled".to_string(),
+                credential_status: "keychain first, environment fallback".to_string(),
+            };
+            match kcmt_tui::run_configure_tui(state) {
+                Ok(kcmt_tui::ConfigureTuiOutcome::Save) => {}
+                Ok(kcmt_tui::ConfigureTuiOutcome::Cancel) => {
+                    println!("Configuration unchanged");
+                    return 0;
+                }
+                Err(err) => {
+                    eprintln!("{err}");
+                    return 1;
+                }
+            }
+        }
         if args.save_api_key {
             let Some(api_key) = explicit_api_key
                 .as_deref()
@@ -114,26 +141,12 @@ fn dispatch(_entrypoint: &str, args: CliArgs, arg_parse_ms: f64) -> i32 {
             }
             println!("Saved {provider} credentials to OS keychain account {account}");
         }
-        let overrides = config_overrides(&args, repo_path.clone());
-        if args.tui && kcmt_tui::should_enable_tui(false) {
-            let state = kcmt_tui::ConfigureTuiState {
-                provider: args
-                    .provider
-                    .clone()
-                    .unwrap_or_else(|| "auto/default".to_string()),
-                model: args
-                    .model
-                    .clone()
-                    .unwrap_or_else(|| "auto/default".to_string()),
-                rule: "provider presets enabled".to_string(),
-                credential_status: "keychain first, environment fallback".to_string(),
-            };
-            if let Err(err) = kcmt_tui::run_configure_tui(state) {
-                eprintln!("{err}");
-                return 1;
-            }
-        }
-        return commands::configure::run_configure(repo_path, overrides);
+        let mode = if args.configure_all {
+            ConfigureMode::All
+        } else {
+            ConfigureMode::Single
+        };
+        return commands::configure::run_configure(repo_path, overrides, mode);
     }
 
     if args.benchmark {

--- a/rust/crates/kcmt-cli/tests/configure_contracts.rs
+++ b/rust/crates/kcmt-cli/tests/configure_contracts.rs
@@ -112,6 +112,107 @@ fn configure_all_accepts_noninteractive_overrides() {
         config["providers"]["openai"]["api_key_env"],
         "OPENAI_TEST_KEY"
     );
+    assert_eq!(
+        config["providers"]["openai"]["keychain_account"],
+        "provider/openai/default"
+    );
+    assert!(config["providers"]["openai"].get("api_key").is_none());
+}
+
+#[test]
+fn configure_all_updates_target_provider_without_clobbering_primary() {
+    let config_home = unique_temp_dir("home");
+    let repo = unique_temp_dir("repo");
+    let config_path = config_home.join("config.json");
+    fs::write(
+        &config_path,
+        serde_json::json!({
+            "provider": "openai",
+            "model": "gpt-existing",
+            "llm_endpoint": "https://openai.existing/v1",
+            "api_key_env": "OPENAI_EXISTING_KEY",
+            "git_repo_path": repo.to_string_lossy(),
+            "max_commit_length": 72,
+            "auto_push": false,
+            "use_batch": false,
+            "batch_model": "gpt-existing",
+            "batch_timeout_seconds": 900,
+            "providers": {
+                "openai": {
+                    "name": "OpenAI",
+                    "endpoint": "https://openai.existing/v1",
+                    "api_key_env": "OPENAI_EXISTING_KEY",
+                    "keychain_account": "provider/openai/existing",
+                    "preferred_model": "gpt-existing"
+                },
+                "anthropic": {
+                    "name": "Anthropic",
+                    "endpoint": "https://anthropic.existing",
+                    "api_key_env": "ANTHROPIC_EXISTING_KEY",
+                    "preferred_model": "claude-existing"
+                }
+            },
+            "model_priority": [
+                {"provider": "openai", "model": "gpt-existing"},
+                {"provider": "anthropic", "model": "claude-existing"}
+            ]
+        })
+        .to_string(),
+    )
+    .expect("seed config");
+
+    let output = kcmt_command()
+        .env("KCMT_CONFIG_HOME", &config_home)
+        .args([
+            "--configure-all",
+            "--provider",
+            "anthropic",
+            "--model",
+            "claude-new",
+            "--endpoint",
+            "https://anthropic.new",
+            "--api-key-env",
+            "ANTHROPIC_NEW_KEY",
+            "--repo-path",
+        ])
+        .arg(&repo)
+        .output()
+        .expect("kcmt configure-all should run");
+
+    assert!(
+        output.status.success(),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let config: serde_json::Value =
+        serde_json::from_slice(&fs::read(&config_path).expect("config file")).expect("config json");
+    assert_eq!(config["provider"], "openai");
+    assert_eq!(config["model"], "gpt-existing");
+    assert_eq!(config["llm_endpoint"], "https://openai.existing/v1");
+    assert_eq!(config["api_key_env"], "OPENAI_EXISTING_KEY");
+    assert_eq!(config["model_priority"][0]["provider"], "openai");
+    assert_eq!(config["model_priority"][1]["provider"], "anthropic");
+    assert_eq!(
+        config["providers"]["openai"]["keychain_account"],
+        "provider/openai/existing"
+    );
+    assert_eq!(
+        config["providers"]["anthropic"]["endpoint"],
+        "https://anthropic.new"
+    );
+    assert_eq!(
+        config["providers"]["anthropic"]["api_key_env"],
+        "ANTHROPIC_NEW_KEY"
+    );
+    assert_eq!(
+        config["providers"]["anthropic"]["preferred_model"],
+        "claude-new"
+    );
+    assert_eq!(
+        config["providers"]["anthropic"]["keychain_account"],
+        "provider/anthropic/default"
+    );
 }
 
 #[test]
@@ -158,6 +259,110 @@ fn configure_writes_default_preferences_file() {
     assert_eq!(preferences["selection_policy"], "fastest_cheap");
     assert_eq!(preferences["default_prompt_profile"], "conventional");
     assert_eq!(preferences["prompt_profiles"][0]["id"], "conventional");
+    assert!(preferences["provider_rules"]["openai"].is_object());
+    assert!(preferences["provider_rules"]["anthropic"].is_object());
+    assert!(preferences["provider_rules"]["xai"].is_object());
+    assert!(preferences["provider_rules"]["github"].is_object());
+}
+
+#[test]
+fn configure_preserves_existing_preferences_while_initializing_provider_rules() {
+    let config_home = unique_temp_dir("home");
+    let repo = unique_temp_dir("repo");
+    fs::write(
+        config_home.join("preferences.json"),
+        serde_json::json!({
+            "schema_version": 1,
+            "selection_policy": "best_quality",
+            "provider_rules": {
+                "openai": {
+                    "preset": "pin_exact_model",
+                    "value": "gpt-existing",
+                    "strict": true
+                }
+            },
+            "prompt_profiles": [
+                {
+                    "id": "custom",
+                    "name": "Custom",
+                    "system_instruction": "Use the custom profile.",
+                    "user_instruction": "Only output a commit."
+                }
+            ],
+            "default_prompt_profile": "custom",
+            "tui": {"last_screen": "providers"},
+            "model_cache": {"ttl_seconds": 123},
+            "skip_commitizen_install_prompt": true
+        })
+        .to_string(),
+    )
+    .expect("seed preferences");
+
+    let output = kcmt_command()
+        .env("KCMT_CONFIG_HOME", &config_home)
+        .args([
+            "--configure",
+            "--provider",
+            "openai",
+            "--model",
+            "gpt-test",
+            "--api-key-env",
+            "OPENAI_TEST_KEY",
+            "--repo-path",
+        ])
+        .arg(&repo)
+        .output()
+        .expect("kcmt configure should run");
+
+    assert!(
+        output.status.success(),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let preferences: serde_json::Value =
+        serde_json::from_slice(&fs::read(config_home.join("preferences.json")).expect("prefs"))
+            .expect("preferences json");
+    assert_eq!(preferences["selection_policy"], "best_quality");
+    assert_eq!(preferences["default_prompt_profile"], "custom");
+    assert_eq!(preferences["tui"]["last_screen"], "providers");
+    assert_eq!(preferences["model_cache"]["ttl_seconds"], 123);
+    assert_eq!(preferences["skip_commitizen_install_prompt"], true);
+    assert_eq!(
+        preferences["provider_rules"]["openai"]["preset"],
+        "pin_exact_model"
+    );
+    assert_eq!(preferences["provider_rules"]["openai"]["strict"], true);
+    assert!(preferences["provider_rules"]["anthropic"].is_object());
+    assert!(preferences["provider_rules"]["xai"].is_object());
+    assert!(preferences["provider_rules"]["github"].is_object());
+}
+
+#[test]
+fn configure_rejects_invalid_credential_combination() {
+    let config_home = unique_temp_dir("home");
+    let repo = unique_temp_dir("repo");
+
+    let output = kcmt_command()
+        .env("KCMT_CONFIG_HOME", &config_home)
+        .args([
+            "--configure",
+            "--provider",
+            "anthropic",
+            "--endpoint",
+            "ANTHROPIC_API_KEY",
+            "--api-key-env",
+            "https://anthropic.test",
+            "--repo-path",
+        ])
+        .arg(&repo)
+        .output()
+        .expect("kcmt configure should reject invalid inputs");
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("endpoint must be an http(s) URL"));
+    assert!(!config_home.join("config.json").exists());
 }
 
 #[test]

--- a/rust/crates/kcmt-tui/src/lib.rs
+++ b/rust/crates/kcmt-tui/src/lib.rs
@@ -39,7 +39,13 @@ pub struct ConfigureTuiState {
     pub credential_status: String,
 }
 
-pub fn run_configure_tui(state: ConfigureTuiState) -> anyhow::Result<()> {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConfigureTuiOutcome {
+    Save,
+    Cancel,
+}
+
+pub fn run_configure_tui(state: ConfigureTuiState) -> anyhow::Result<ConfigureTuiOutcome> {
     enable_raw_mode()?;
     let mut stdout = io::stdout();
     if let Err(err) = execute!(stdout, EnterAlternateScreen) {
@@ -68,7 +74,7 @@ pub fn run_configure_tui(state: ConfigureTuiState) -> anyhow::Result<()> {
 fn run_loop(
     terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
     state: &ConfigureTuiState,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<ConfigureTuiOutcome> {
     let items = [
         "Providers and credentials",
         "Provider model rules",
@@ -81,30 +87,66 @@ fn run_loop(
         terminal.draw(|frame| {
             let chunks = Layout::default()
                 .direction(Direction::Vertical)
-                .constraints([Constraint::Length(5), Constraint::Min(8), Constraint::Length(3)])
+                .constraints([
+                    Constraint::Length(5),
+                    Constraint::Min(8),
+                    Constraint::Length(3),
+                ])
                 .split(frame.area());
             let summary = Paragraph::new(format!(
                 "Provider: {}\nModel: {}\nRule: {}\nCredentials: {}",
                 state.provider, state.model, state.rule, state.credential_status
             ))
-            .block(Block::default().title("kcmt configure").borders(Borders::ALL));
+            .block(
+                Block::default()
+                    .title("kcmt configure")
+                    .borders(Borders::ALL),
+            );
             frame.render_widget(summary, chunks[0]);
-            let list = List::new(items.iter().map(|item| ListItem::new(*item)).collect::<Vec<_>>())
-                .block(Block::default().title("Menu").borders(Borders::ALL))
-                .style(Style::default())
-                .highlight_style(Style::default().add_modifier(Modifier::BOLD));
+            let list = List::new(
+                items
+                    .iter()
+                    .map(|item| ListItem::new(*item))
+                    .collect::<Vec<_>>(),
+            )
+            .block(Block::default().title("Menu").borders(Borders::ALL))
+            .style(Style::default())
+            .highlight_style(Style::default().add_modifier(Modifier::BOLD));
             frame.render_widget(list, chunks[1]);
-            let footer = Paragraph::new("This v1 configure TUI is read-oriented. Press q or Esc to exit; use CLI flags to save until editable TUI forms land.")
+            let footer = Paragraph::new("Press s to save this configuration, or q/Esc to cancel.")
                 .block(Block::default().borders(Borders::ALL));
             frame.render_widget(footer, chunks[2]);
         })?;
         if event::poll(Duration::from_millis(250))? {
             if let Event::Key(key) = event::read()? {
+                if matches!(key.code, KeyCode::Char('s') | KeyCode::Enter) {
+                    return Ok(ConfigureTuiOutcome::Save);
+                }
                 if matches!(key.code, KeyCode::Char('q') | KeyCode::Esc) {
-                    break;
+                    return Ok(ConfigureTuiOutcome::Cancel);
                 }
             }
         }
     }
-    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ConfigureTuiOutcome, ConfigureTuiState};
+
+    #[test]
+    fn configure_tui_state_names_save_and_cancel_outcomes() {
+        let state = ConfigureTuiState {
+            provider: "anthropic".to_string(),
+            model: "claude-test".to_string(),
+            rule: "provider presets enabled".to_string(),
+            credential_status: "keychain first, environment fallback".to_string(),
+        };
+
+        let outcome = ConfigureTuiOutcome::Save;
+
+        assert_eq!(state.provider, "anthropic");
+        assert!(matches!(outcome, ConfigureTuiOutcome::Save));
+        assert_ne!(outcome, ConfigureTuiOutcome::Cancel);
+    }
 }

--- a/tests/features/rust_workflow_parity.feature
+++ b/tests/features/rust_workflow_parity.feature
@@ -147,6 +147,35 @@ Feature: Rust workflow parity
     Then the Rust configuration file contains the Anthropic provider settings
     And the Rust preferences file contains default selector preferences
 
+  Scenario: Python entrypoint dispatches non-interactive configure to Rust
+    Given an empty runtime configuration home
+    When the Python kcmt entrypoint configures Anthropic in auto runtime mode
+    Then the Python entrypoint configure run is handled by Rust
+    And the Rust configuration file contains the Anthropic provider settings
+    And the Rust preferences file contains default selector preferences
+
+  Scenario: Python entrypoint dispatches bare configure to Rust without prompting
+    Given an empty runtime configuration home
+    When the Python kcmt entrypoint runs bare configure in auto runtime mode
+    Then the Python entrypoint configure run is handled by Rust
+    And the Rust configuration file contains the default OpenAI provider settings
+    And the Rust preferences file contains default selector preferences
+
+  Scenario: Python entrypoint dispatches configure-all to Rust
+    Given an existing OpenAI runtime configuration
+    When the Python kcmt entrypoint configures all providers in auto runtime mode
+    Then the Python entrypoint configure run is handled by Rust
+    And the Rust configuration keeps the OpenAI primary provider
+    And the Rust configuration file contains the Anthropic configure-all provider settings
+    And the Rust preferences file contains default selector preferences
+
+  Scenario: Rust configure-all updates provider entries without clobbering primary config
+    Given an existing OpenAI runtime configuration
+    When the Rust kcmt command configures all providers with Anthropic overrides
+    Then the Rust configuration keeps the OpenAI primary provider
+    And the Rust configuration file contains the Anthropic configure-all provider settings
+    And the Rust preferences file contains default selector preferences
+
   Scenario: Anthropic latest Haiku rule selects the Haiku model
     Given a git repository with one changed tracked file and Anthropic latest Haiku preferences
     When the Rust kcmt command commits the file with Anthropic preferences

--- a/tests/test_main_entrypoint.py
+++ b/tests/test_main_entrypoint.py
@@ -66,14 +66,14 @@ def test_covered_rust_runtime_invocations(monkeypatch):
     assert main_mod._is_rust_covered_invocation(["--file", "tracked.py"]) is True
     assert main_mod._is_rust_covered_invocation(["status", "--raw"]) is True
     assert main_mod._is_rust_covered_invocation(["benchmark", "runtime"]) is True
-    assert main_mod._is_rust_covered_invocation(["--configure"]) is False
+    assert main_mod._is_rust_covered_invocation(["--configure"]) is True
     assert (
         main_mod._is_rust_covered_invocation(["--configure", "--provider", "anthropic"])
         is True
     )
     assert main_mod._is_rust_covered_invocation(["--list-models"]) is True
     assert main_mod._is_rust_covered_invocation(["--verify-keys"]) is True
-    assert main_mod._is_rust_covered_invocation(["--configure-all"]) is False
+    assert main_mod._is_rust_covered_invocation(["--configure-all"]) is True
     assert (
         main_mod._is_rust_covered_invocation(
             ["--configure-all", "--api-key-env", "OPENAI_TEST_KEY"]
@@ -187,6 +187,70 @@ def test_run_rust_runtime_preserves_status_raw_args(monkeypatch):
 
     assert main_mod._run_rust_runtime() == 0
     assert called == [["/tmp/kcmt-rust", "status", "--repo-path", "/tmp/repo", "--raw"]]
+
+
+def test_run_rust_runtime_preserves_configure_all_args(monkeypatch):
+    called: list[list[str]] = []
+
+    def _fake_run(args: list[str], check: bool):
+        called.append(args)
+        assert check is False
+        return type("CompletedProcessStub", (), {"returncode": 0})()
+
+    monkeypatch.setattr(main_mod, "_should_use_rust_runtime", lambda _args: True)
+    monkeypatch.setattr(main_mod, "_resolve_rust_binary", lambda: "/tmp/kcmt-rust")
+    monkeypatch.setattr(main_mod.os.path, "exists", lambda _: True)
+    monkeypatch.setattr(
+        main_mod.sys,
+        "argv",
+        [
+            "kcmt",
+            "--configure-all",
+            "--provider",
+            "anthropic",
+            "--api-key-env",
+            "ANTHROPIC_TEST_KEY",
+            "--repo-path",
+            "/tmp/repo",
+        ],
+    )
+    monkeypatch.setattr(main_mod.subprocess, "run", _fake_run)
+
+    assert main_mod._run_rust_runtime() == 0
+    assert called == [
+        [
+            "/tmp/kcmt-rust",
+            "--configure-all",
+            "--provider",
+            "anthropic",
+            "--api-key-env",
+            "ANTHROPIC_TEST_KEY",
+            "--repo-path",
+            "/tmp/repo",
+        ]
+    ]
+
+
+def test_run_rust_runtime_preserves_bare_configure_args(monkeypatch):
+    called: list[list[str]] = []
+
+    def _fake_run(args: list[str], check: bool):
+        called.append(args)
+        assert check is False
+        return type("CompletedProcessStub", (), {"returncode": 0})()
+
+    monkeypatch.setattr(main_mod, "_should_use_rust_runtime", lambda _args: True)
+    monkeypatch.setattr(main_mod, "_resolve_rust_binary", lambda: "/tmp/kcmt-rust")
+    monkeypatch.setattr(main_mod.os.path, "exists", lambda _: True)
+    monkeypatch.setattr(
+        main_mod.sys,
+        "argv",
+        ["kcmt", "--configure", "--repo-path", "/tmp/repo"],
+    )
+    monkeypatch.setattr(main_mod.subprocess, "run", _fake_run)
+
+    assert main_mod._run_rust_runtime() == 0
+    assert called == [["/tmp/kcmt-rust", "--configure", "--repo-path", "/tmp/repo"]]
 
 
 def test_emit_runtime_trace_enabled_writes_json(monkeypatch, capsys):

--- a/tests/test_rust_workflow_parity_bdd.py
+++ b/tests/test_rust_workflow_parity_bdd.py
@@ -566,6 +566,50 @@ def empty_runtime_configuration_home(tmp_path: Path) -> dict[str, Any]:
     return {"repo": repo, "config_home": config_home}
 
 
+@given("an existing OpenAI runtime configuration", target_fixture="workflow_context")
+def existing_openai_runtime_configuration(tmp_path: Path) -> dict[str, Any]:
+    config_home = tmp_path / "config-home"
+    config_home.mkdir()
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (config_home / "config.json").write_text(
+        json.dumps(
+            {
+                "provider": "openai",
+                "model": "gpt-existing",
+                "llm_endpoint": "https://openai.existing/v1",
+                "api_key_env": "OPENAI_EXISTING_KEY",
+                "git_repo_path": str(repo),
+                "max_commit_length": 72,
+                "auto_push": False,
+                "use_batch": False,
+                "batch_model": "gpt-existing",
+                "batch_timeout_seconds": 900,
+                "providers": {
+                    "openai": {
+                        "name": "OpenAI",
+                        "endpoint": "https://openai.existing/v1",
+                        "api_key_env": "OPENAI_EXISTING_KEY",
+                        "keychain_account": "provider/openai/existing",
+                        "preferred_model": "gpt-existing",
+                    },
+                    "anthropic": {
+                        "name": "Anthropic",
+                        "endpoint": "https://anthropic.existing",
+                        "api_key_env": "ANTHROPIC_EXISTING_KEY",
+                        "preferred_model": "claude-existing",
+                    },
+                },
+                "model_priority": [
+                    {"provider": "openai", "model": "gpt-existing"},
+                    {"provider": "anthropic", "model": "claude-existing"},
+                ],
+            }
+        )
+    )
+    return {"repo": repo, "config_home": config_home}
+
+
 @given("a checked-in runtime benchmark corpus", target_fixture="workflow_context")
 def checked_in_runtime_benchmark_corpus(tmp_path: Path) -> dict[str, Any]:
     return {
@@ -985,6 +1029,133 @@ def rust_kcmt_configures_anthropic_non_interactively(
             "--api-key-env",
             "ANTHROPIC_TEST_KEY",
             "--no-auto-push",
+            "--repo-path",
+            str(workflow_context["repo"]),
+        ],
+        REPO_ROOT,
+        env=env,
+    )
+    workflow_context["output"] = output
+
+
+@when("the Python kcmt entrypoint configures Anthropic in auto runtime mode")
+def python_kcmt_entrypoint_configures_anthropic_in_auto_runtime_mode(
+    workflow_context: dict[str, Any],
+) -> None:
+    rust_bin = _rust_bin("kcmt")
+    env = _clean_env(workflow_context["config_home"])
+    env["KCMT_RUST_BIN"] = str(rust_bin)
+    env["KCMT_RUNTIME_TRACE"] = "1"
+    result = subprocess.run(
+        [
+            os.environ.get("PYTHON", "python"),
+            "-m",
+            "kcmt.main",
+            "--configure",
+            "--provider",
+            "anthropic",
+            "--model",
+            "claude-test",
+            "--endpoint",
+            "https://anthropic.test",
+            "--api-key-env",
+            "ANTHROPIC_TEST_KEY",
+            "--no-auto-push",
+            "--repo-path",
+            str(workflow_context["repo"]),
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+    workflow_context["output"] = result.stdout
+    workflow_context["stderr"] = result.stderr
+
+
+@when("the Python kcmt entrypoint runs bare configure in auto runtime mode")
+def python_kcmt_entrypoint_runs_bare_configure_in_auto_runtime_mode(
+    workflow_context: dict[str, Any],
+) -> None:
+    rust_bin = _rust_bin("kcmt")
+    env = _clean_env(workflow_context["config_home"])
+    env["KCMT_RUST_BIN"] = str(rust_bin)
+    env["KCMT_RUNTIME_TRACE"] = "1"
+    result = subprocess.run(
+        [
+            os.environ.get("PYTHON", "python"),
+            "-m",
+            "kcmt.main",
+            "--configure",
+            "--repo-path",
+            str(workflow_context["repo"]),
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+    workflow_context["output"] = result.stdout
+    workflow_context["stderr"] = result.stderr
+
+
+@when("the Python kcmt entrypoint configures all providers in auto runtime mode")
+def python_kcmt_entrypoint_configures_all_providers_in_auto_runtime_mode(
+    workflow_context: dict[str, Any],
+) -> None:
+    rust_bin = _rust_bin("kcmt")
+    env = _clean_env(workflow_context["config_home"])
+    env["KCMT_RUST_BIN"] = str(rust_bin)
+    env["KCMT_RUNTIME_TRACE"] = "1"
+    result = subprocess.run(
+        [
+            os.environ.get("PYTHON", "python"),
+            "-m",
+            "kcmt.main",
+            "--configure-all",
+            "--provider",
+            "anthropic",
+            "--model",
+            "claude-new",
+            "--endpoint",
+            "https://anthropic.new",
+            "--api-key-env",
+            "ANTHROPIC_NEW_KEY",
+            "--repo-path",
+            str(workflow_context["repo"]),
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+    workflow_context["output"] = result.stdout
+    workflow_context["stderr"] = result.stderr
+
+
+@when("the Rust kcmt command configures all providers with Anthropic overrides")
+def rust_kcmt_configures_all_providers_with_anthropic_overrides(
+    workflow_context: dict[str, Any],
+) -> None:
+    env = _clean_env(workflow_context["config_home"])
+    output = _run(
+        [
+            str(_rust_bin("kcmt")),
+            "--configure-all",
+            "--provider",
+            "anthropic",
+            "--model",
+            "claude-new",
+            "--endpoint",
+            "https://anthropic.new",
+            "--api-key-env",
+            "ANTHROPIC_NEW_KEY",
             "--repo-path",
             str(workflow_context["repo"]),
         ],
@@ -1849,6 +2020,64 @@ def rust_configuration_file_contains_anthropic_provider_settings(
     assert config["llm_endpoint"] == "https://anthropic.test"
     assert config["api_key_env"] == "ANTHROPIC_TEST_KEY"
     assert config["providers"]["anthropic"]["api_key_env"] == "ANTHROPIC_TEST_KEY"
+    assert config["providers"]["anthropic"]["keychain_account"] == (
+        "provider/anthropic/default"
+    )
+    assert "api_key" not in config["providers"]["anthropic"]
+
+
+@then("the Rust configuration file contains the default OpenAI provider settings")
+def rust_configuration_file_contains_default_openai_provider_settings(
+    workflow_context: dict[str, Any],
+) -> None:
+    config = json.loads((workflow_context["config_home"] / "config.json").read_text())
+    assert config["provider"] == "openai"
+    assert config["model"] == "gpt-5-mini-2025-08-07"
+    assert config["llm_endpoint"] == "https://api.openai.com/v1"
+    assert config["api_key_env"] == "OPENAI_API_KEY"
+    assert config["providers"]["openai"]["api_key_env"] == "OPENAI_API_KEY"
+    assert (
+        config["providers"]["openai"]["keychain_account"] == "provider/openai/default"
+    )
+    assert "api_key" not in config["providers"]["openai"]
+
+
+@then("the Python entrypoint configure run is handled by Rust")
+def python_entrypoint_configure_run_is_handled_by_rust(
+    workflow_context: dict[str, Any],
+) -> None:
+    assert "auto_covered_workflow" in workflow_context["stderr"]
+
+
+@then("the Rust configuration keeps the OpenAI primary provider")
+def rust_configuration_keeps_openai_primary_provider(
+    workflow_context: dict[str, Any],
+) -> None:
+    config = json.loads((workflow_context["config_home"] / "config.json").read_text())
+    assert config["provider"] == "openai"
+    assert config["model"] == "gpt-existing"
+    assert config["llm_endpoint"] == "https://openai.existing/v1"
+    assert config["api_key_env"] == "OPENAI_EXISTING_KEY"
+    assert config["providers"]["openai"]["keychain_account"] == (
+        "provider/openai/existing"
+    )
+    assert config["model_priority"][0]["provider"] == "openai"
+    assert config["model_priority"][1]["provider"] == "anthropic"
+
+
+@then(
+    "the Rust configuration file contains the Anthropic configure-all provider settings"
+)
+def rust_configuration_file_contains_anthropic_configure_all_provider_settings(
+    workflow_context: dict[str, Any],
+) -> None:
+    config = json.loads((workflow_context["config_home"] / "config.json").read_text())
+    provider = config["providers"]["anthropic"]
+    assert provider["endpoint"] == "https://anthropic.new"
+    assert provider["api_key_env"] == "ANTHROPIC_NEW_KEY"
+    assert provider["preferred_model"] == "claude-new"
+    assert provider["keychain_account"] == "provider/anthropic/default"
+    assert "api_key" not in provider
 
 
 @then("the Rust preferences file contains default selector preferences")
@@ -1861,6 +2090,10 @@ def rust_preferences_file_contains_default_selector_preferences(
     assert preferences["selection_policy"] == "fastest_cheap"
     assert preferences["default_prompt_profile"] == "conventional"
     assert preferences["prompt_profiles"][0]["id"] == "conventional"
+    assert preferences["provider_rules"]["openai"]["preset"] == "none"
+    assert preferences["provider_rules"]["anthropic"]["preset"] == "none"
+    assert preferences["provider_rules"]["xai"]["preset"] == "none"
+    assert preferences["provider_rules"]["github"]["preset"] == "none"
 
 
 @then("the Anthropic provider receives the latest Haiku model")


### PR DESCRIPTION
## Summary

- Route `--configure` and `--configure-all` through the Rust runtime in auto mode so configure remains non-blocking and scriptable.
- Strengthen Rust configure persistence for all provider entries, keychain account references, provider rules, and existing preferences.
- Make `--configure-all` update a target provider without clobbering the current primary provider/model priority.
- Add a minimal usable configure TUI outcome: save with `s`/Enter, cancel with `q`/Esc.

## Conventional Commit Breakdown

| Commit | Type | Scope | Summary |
| --- | --- | --- | --- |
| `6153291` | feat | rust | close configure ux parity |

## Release Notes Draft

Rust configure now covers the non-blocking configure UX path, including bare configure invocations, configure-all provider updates, default provider rule initialization, and keychain account reference persistence without storing secrets.

## Behaviour Changes

- `kcmt --configure` and `kcmt --configure-all` are Rust-covered in auto runtime mode.
- Non-TTY configure remains non-blocking and writes config/preferences directly.
- `--configure-all` updates the requested provider entry while preserving an existing primary provider, endpoint, env var, and model priority when applicable.
- Explicit invalid provider/model/endpoint/api-key-env combinations fail before writing config.
- `--configure --tui` in a real terminal now saves on `s`/Enter or exits unchanged on `q`/Esc.

## API / Schema / Contract Changes

- No schema version bump.
- `config.json` remains Python-compatible and stores env var names plus `keychain_account` references, not raw API keys.
- `preferences.json` now backfills provider rule defaults while preserving existing typed and unknown keys such as Python preferences.

## Testing Evidence

- `rtk cargo test --manifest-path rust/Cargo.toml -p kcmt-cli --test configure_contracts` - passed, 9 tests.
- `rtk cargo test --manifest-path rust/Cargo.toml -p kcmt-tui` - passed, 1 test.
- `rtk uv run pytest -q --no-cov tests/test_main_entrypoint.py` - passed, 22 tests.
- `rtk uv run pytest -q --no-cov tests/test_rust_workflow_parity_bdd.py -k "configure"` - passed, 6 tests, 30 deselected.
- `rtk make check` - passed after rebasing onto `origin/main`.
- `rtk make quality-gates` - passed after rebasing onto `origin/main`.

## Risk and Rollback

- Risk: routing bare configure through Rust changes the default auto-runtime path. This is intentional to preserve the PR #37 non-blocking configure contract.
- Risk: configure TUI is still a small save/cancel slice, not the full legacy wizard. Bare interactive fallback remains available with `KCMT_RUNTIME=python`.
- Rollback: revert this commit to restore the prior Python fallback and Rust read-only TUI behavior.

## Operational Notes

- PR #37 is merged into `origin/main`; this branch is based on the latest `origin/main` and is not stacked.
- No secrets are written to config or preferences; tests assert no `api_key` field is persisted in provider entries.

## Linked Work

- Builds on merged PR #37 semantics for non-blocking Rust configure, preferences, provider rules, and keychain account references.

## Reviewer Checklist

- [ ] Confirm bare `--configure` should now auto-route to Rust.
- [ ] Confirm configure-all provider updates preserve primary provider settings.
- [ ] Confirm preference merge behavior preserves unknown Python preference keys.
- [ ] Confirm TUI save/cancel behavior is an acceptable smallest usable slice.
