### PR TITLE
test(kcmt-core): expand rust git workflow coverage

### DIFF
--- a/rust/crates/kcmt-core/src/git/commit_file.rs
+++ b/rust/crates/kcmt-core/src/git/commit_file.rs
@@ -796,7 +796,9 @@ fn valid_hash(value: &str) -> Option<&str> {
 
 #[cfg(test)]
 mod tests {
-    use super::{commit_file_with_gix, recent_commit_hash, CommitStaging, GixCommitSession};
+    use super::{
+        commit_file, commit_file_with_gix, recent_commit_hash, CommitStaging, GixCommitSession,
+    };
     use std::fs;
     use std::path::{Path, PathBuf};
     use std::process::Command;
@@ -1174,5 +1176,56 @@ mod tests {
             git_output(&repo, &["log", "-1", "--pretty=%s"]),
             "chore(repo): add first file"
         );
+    }
+
+    #[test]
+    fn commit_file_returns_default_outcome_on_dry_run() {
+        let repo = unique_temp_dir("cli-dry-run");
+
+        let outcome = commit_file(&repo, "tracked.py", "chore(repo): skip dry run", true)
+            .expect("dry run should succeed");
+
+        assert_eq!(outcome.stage_path_ms, 0.0);
+        assert!(!outcome.stage_path_invoked);
+        assert_eq!(outcome.create_commit_ms, 0.0);
+        assert!(outcome.commit_hash.is_none());
+    }
+
+    #[test]
+    fn reads_recent_commit_hash_from_packed_refs() {
+        let repo = unique_temp_dir("recent-packed-refs");
+        git(&repo, &["init", "-q"]);
+        fs::write(repo.join("tracked.py"), "print('seed')\n").expect("tracked file");
+        git(&repo, &["add", "tracked.py"]);
+        git(&repo, &["commit", "-m", "chore(repo): seed"]);
+        let expected = git_output(&repo, &["rev-parse", "HEAD"]);
+        let branch = git_output(&repo, &["symbolic-ref", "--quiet", "HEAD"]);
+        git(&repo, &["pack-refs", "--all"]);
+        let loose_ref = repo.join(".git").join(&branch);
+        if loose_ref.exists() {
+            fs::remove_file(&loose_ref).expect("loose ref removed");
+        }
+        let packed_refs = fs::read_to_string(repo.join(".git").join("packed-refs"))
+            .expect("packed refs should exist");
+        assert!(packed_refs.lines().any(|line| line.ends_with(&branch)));
+
+        let actual = recent_commit_hash(&repo).expect("packed refs should be readable");
+
+        assert_eq!(actual.as_deref(), Some(expected.as_str()));
+    }
+
+    #[test]
+    fn reads_recent_commit_hash_from_detached_head() {
+        let repo = unique_temp_dir("recent-detached-head");
+        git(&repo, &["init", "-q"]);
+        fs::write(repo.join("tracked.py"), "print('seed')\n").expect("tracked file");
+        git(&repo, &["add", "tracked.py"]);
+        git(&repo, &["commit", "-m", "chore(repo): seed"]);
+        let expected = git_output(&repo, &["rev-parse", "HEAD"]);
+        git(&repo, &["checkout", "--detach", "HEAD"]);
+
+        let actual = recent_commit_hash(&repo).expect("detached head hash should be read");
+
+        assert_eq!(actual.as_deref(), Some(expected.as_str()));
     }
 }

--- a/rust/crates/kcmt-core/src/git/repo.rs
+++ b/rust/crates/kcmt-core/src/git/repo.rs
@@ -622,8 +622,8 @@ mod tests {
 
     #[test]
     fn render_porcelain_lines_uses_destination_path_for_rename_records() {
-        let rendered = render_porcelain_lines("R  old.py\0new.py\0C  src.py\0dst.py\0");
+        let rendered = render_porcelain_lines("R  new.py\0old.py\0C  dst.py\0src.py\0");
 
-        assert_eq!(rendered, "R  new.py -> old.py\nC  dst.py -> src.py\n");
+        assert_eq!(rendered, "R  old.py -> new.py\nC  src.py -> dst.py\n");
     }
 }

--- a/rust/crates/kcmt-core/src/git/repo.rs
+++ b/rust/crates/kcmt-core/src/git/repo.rs
@@ -619,4 +619,11 @@ mod tests {
 
         assert_eq!(status, "MM tracked.py\n");
     }
+
+    #[test]
+    fn render_porcelain_lines_uses_destination_path_for_rename_records() {
+        let rendered = render_porcelain_lines("R  old.py\0new.py\0C  src.py\0dst.py\0");
+
+        assert_eq!(rendered, "R  new.py -> old.py\nC  dst.py -> src.py\n");
+    }
 }

--- a/rust/crates/kcmt-core/src/git/runner.rs
+++ b/rust/crates/kcmt-core/src/git/runner.rs
@@ -45,3 +45,80 @@ impl CommandRunner for GitCliRunner {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{CommandRunner, GitCliRunner};
+    use crate::error::KcmtError;
+    use std::fs;
+    use std::path::{Path, PathBuf};
+    use std::process::Command;
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn unique_temp_dir(label: &str) -> PathBuf {
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock should be after unix epoch")
+            .as_nanos();
+        let suffix = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let path = std::env::temp_dir().join(format!("kcmt-core-{label}-{nanos}-{suffix}"));
+        fs::create_dir_all(&path).expect("temp dir should be created");
+        path
+    }
+
+    fn git(repo: &Path, args: &[&str]) {
+        let output = Command::new("git")
+            .current_dir(repo)
+            .args(args)
+            .output()
+            .expect("git command should run");
+        assert!(
+            output.status.success(),
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    #[test]
+    fn git_cli_runner_returns_output_on_success() {
+        let repo = unique_temp_dir("runner-success");
+        git(&repo, &["init", "-q"]);
+
+        let output = GitCliRunner
+            .run(&repo, &["rev-parse", "--show-toplevel"])
+            .expect("git rev-parse should succeed");
+
+        assert!(output.stderr.is_empty());
+        assert!(output.status.is_some());
+        assert_eq!(
+            fs::canonicalize(output.stdout.trim()).expect("stdout path canonical"),
+            fs::canonicalize(&repo).expect("repo path canonical")
+        );
+    }
+
+    #[test]
+    fn git_cli_runner_wraps_nonzero_exit_as_command_failure() {
+        let repo = unique_temp_dir("runner-failure");
+        git(&repo, &["init", "-q"]);
+
+        let err = GitCliRunner
+            .run(&repo, &["definitely-not-a-command"])
+            .expect_err("invalid git command should fail");
+
+        match err {
+            KcmtError::CommandFailure {
+                command,
+                status,
+                stderr,
+            } => {
+                assert_eq!(command, "git definitely-not-a-command");
+                assert_ne!(status, Some(0));
+                assert!(!stderr.trim().is_empty());
+            }
+            other => panic!("expected command failure, got {other:?}"),
+        }
+    }
+}

--- a/rust/crates/kcmt-core/src/workflow/atomic_failure_recovery.rs
+++ b/rust/crates/kcmt-core/src/workflow/atomic_failure_recovery.rs
@@ -23,3 +23,69 @@ pub fn rollback_staged_file(repo_path: &Path, file_path: &str) -> Result<AtomicC
         Ok(AtomicCommitOutcome::Completed)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{rollback_staged_file, AtomicCommitOutcome};
+    use std::fs;
+    use std::path::{Path, PathBuf};
+    use std::process::Command;
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn unique_temp_dir(label: &str) -> PathBuf {
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock should be after unix epoch")
+            .as_nanos();
+        let suffix = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let path = std::env::temp_dir().join(format!("kcmt-core-{label}-{nanos}-{suffix}"));
+        fs::create_dir_all(&path).expect("temp dir should be created");
+        path
+    }
+
+    fn git(repo: &Path, args: &[&str]) -> String {
+        let output = Command::new("git")
+            .current_dir(repo)
+            .args(args)
+            .output()
+            .expect("git command should run");
+        assert!(
+            output.status.success(),
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&output.stderr)
+        );
+        String::from_utf8_lossy(&output.stdout).trim().to_string()
+    }
+
+    fn init_repo(repo: &Path) {
+        git(repo, &["init", "-q"]);
+        git(repo, &["config", "user.name", "kcmt test"]);
+        git(repo, &["config", "user.email", "kcmt-test@example.com"]);
+    }
+
+    #[test]
+    fn rollback_staged_file_returns_recovered_on_successful_git_reset() {
+        let repo = unique_temp_dir("rollback-recovered");
+        init_repo(&repo);
+        fs::write(repo.join("tracked.py"), "print('seed')\n").expect("tracked file");
+        git(&repo, &["add", "tracked.py"]);
+
+        let outcome = rollback_staged_file(&repo, "tracked.py").expect("rollback should succeed");
+
+        assert_eq!(outcome, AtomicCommitOutcome::Recovered);
+        assert_eq!(git(&repo, &["status", "--short"]), "?? tracked.py");
+    }
+
+    #[test]
+    fn rollback_staged_file_returns_completed_when_git_reset_fails() {
+        let repo = unique_temp_dir("rollback-completed");
+        git(&repo, &["init", "--bare", "-q"]);
+
+        let outcome = rollback_staged_file(&repo, "missing.py").expect("rollback should return");
+
+        assert_eq!(outcome, AtomicCommitOutcome::Completed);
+    }
+}

--- a/rust/crates/kcmt-core/src/workflow/changeset.rs
+++ b/rust/crates/kcmt-core/src/workflow/changeset.rs
@@ -48,34 +48,50 @@ fn parse_porcelain_path(raw_path: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::collect_changes;
-    use crate::error::Result;
+    use crate::error::{KcmtError, Result};
     use crate::git::repo::GitRepository;
 
-    struct StaticRepo {
-        status: &'static str,
+    struct StubRepo {
+        status: Result<String>,
     }
 
-    impl GitRepository for StaticRepo {
+    impl GitRepository for StubRepo {
         fn staged_files(&self) -> Result<Vec<String>> {
             Ok(Vec::new())
         }
 
         fn status_porcelain(&self) -> Result<String> {
-            Ok(self.status.to_string())
+            match &self.status {
+                Ok(value) => Ok(value.clone()),
+                Err(KcmtError::Io(err)) => Err(KcmtError::Io(std::io::Error::new(
+                    err.kind(),
+                    err.to_string(),
+                ))),
+                Err(KcmtError::CommandFailure {
+                    command,
+                    status,
+                    stderr,
+                }) => Err(KcmtError::CommandFailure {
+                    command: command.clone(),
+                    status: *status,
+                    stderr: stderr.clone(),
+                }),
+                Err(KcmtError::Message(message)) => Err(KcmtError::Message(message.clone())),
+            }
         }
 
         fn status_porcelain_for_path(&self, _file_path: &str) -> Result<String> {
-            Ok(self.status.to_string())
+            Ok(String::new())
         }
     }
 
     #[test]
     fn collect_changes_skips_ignored_rows_and_uses_worktree_status() {
-        let repo = StaticRepo {
-            status: " M tracked.py\n!! ignored.log\n?? new.py\n",
+        let repo = StubRepo {
+            status: Ok(" M tracked.py\n!! ignored.log\n?? new.py\n".to_string()),
         };
 
-        let changes = collect_changes(&repo).expect("changes");
+        let changes = collect_changes(&repo).expect("changes should collect");
 
         assert_eq!(changes.len(), 2);
         assert_eq!(changes[0].file_path, "tracked.py");
@@ -87,11 +103,11 @@ mod tests {
 
     #[test]
     fn collect_changes_uses_rename_and_copy_destination_paths() {
-        let repo = StaticRepo {
-            status: "R  old.py -> new.py\n C template.py -> copied.py\n",
+        let repo = StubRepo {
+            status: Ok("R  old.py -> new.py\n C template.py -> copied.py\n".to_string()),
         };
 
-        let changes = collect_changes(&repo).expect("changes");
+        let changes = collect_changes(&repo).expect("changes should collect");
 
         assert_eq!(changes.len(), 2);
         assert_eq!(changes[0].file_path, "new.py");
@@ -100,5 +116,30 @@ mod tests {
         assert_eq!(changes[1].file_path, "copied.py");
         assert_eq!(changes[1].change_type, "C");
         assert!(!changes[1].staged);
+    }
+
+    #[test]
+    fn collect_changes_skips_short_and_blank_status_lines() {
+        let repo = StubRepo {
+            status: Ok("M\n?? \n".to_string()),
+        };
+
+        let changes = collect_changes(&repo).expect("changes should collect");
+
+        assert!(changes.is_empty());
+    }
+
+    #[test]
+    fn collect_changes_propagates_status_errors() {
+        let repo = StubRepo {
+            status: Err(KcmtError::Message("status failed".to_string())),
+        };
+
+        let err = collect_changes(&repo).expect_err("status error should propagate");
+
+        match err {
+            KcmtError::Message(message) => assert_eq!(message, "status failed"),
+            other => panic!("expected message error, got {other:?}"),
+        }
     }
 }

--- a/rust/crates/kcmt-core/src/workflow/commit_flow.rs
+++ b/rust/crates/kcmt-core/src/workflow/commit_flow.rs
@@ -23,3 +23,84 @@ pub fn recommend_commit(repo: &dyn GitRepository) -> Result<CommitRecommendation
         error: None,
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::recommend_commit;
+    use crate::error::{KcmtError, Result};
+    use crate::git::repo::GitRepository;
+
+    struct StubRepo {
+        status: Result<String>,
+    }
+
+    impl GitRepository for StubRepo {
+        fn staged_files(&self) -> Result<Vec<String>> {
+            Ok(Vec::new())
+        }
+
+        fn status_porcelain(&self) -> Result<String> {
+            match &self.status {
+                Ok(value) => Ok(value.clone()),
+                Err(KcmtError::Io(err)) => Err(KcmtError::Io(std::io::Error::new(
+                    err.kind(),
+                    err.to_string(),
+                ))),
+                Err(KcmtError::CommandFailure {
+                    command,
+                    status,
+                    stderr,
+                }) => Err(KcmtError::CommandFailure {
+                    command: command.clone(),
+                    status: *status,
+                    stderr: stderr.clone(),
+                }),
+                Err(KcmtError::Message(message)) => Err(KcmtError::Message(message.clone())),
+            }
+        }
+
+        fn status_porcelain_for_path(&self, _file_path: &str) -> Result<String> {
+            Ok(String::new())
+        }
+    }
+
+    #[test]
+    fn recommend_commit_returns_no_relevant_changes_for_empty_status() {
+        let recommendation = recommend_commit(&StubRepo {
+            status: Ok(String::new()),
+        })
+        .expect("recommendation should succeed");
+
+        assert_eq!(recommendation.subject, "chore: no relevant changes");
+        assert_eq!(recommendation.raw_message, recommendation.subject);
+        assert_eq!(recommendation.provider_id, "none");
+        assert_eq!(recommendation.model, "heuristic");
+        assert!(recommendation.success);
+        assert!(recommendation.body.is_none());
+        assert!(recommendation.error.is_none());
+    }
+
+    #[test]
+    fn recommend_commit_returns_update_message_for_non_empty_status() {
+        let recommendation = recommend_commit(&StubRepo {
+            status: Ok(" M tracked.py\n".to_string()),
+        })
+        .expect("recommendation should succeed");
+
+        assert_eq!(recommendation.subject, "chore: update repository changes");
+        assert_eq!(recommendation.raw_message, recommendation.subject);
+    }
+
+    #[test]
+    fn recommend_commit_propagates_status_error() {
+        let err = recommend_commit(&StubRepo {
+            status: Err(KcmtError::Message("status failed".to_string())),
+        })
+        .expect_err("status failure should propagate");
+
+        match err {
+            KcmtError::Message(message) => assert_eq!(message, "status failed"),
+            other => panic!("expected message error, got {other:?}"),
+        }
+    }
+}

--- a/rust/crates/kcmt-core/src/workflow/provider_dispatch.rs
+++ b/rust/crates/kcmt-core/src/workflow/provider_dispatch.rs
@@ -25,3 +25,38 @@ pub fn select_provider(preferred: Option<&str>, fallback: &[(&str, &str)]) -> Pr
         model: model.to_string(),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::select_provider;
+
+    #[test]
+    fn select_provider_returns_preferred_match() {
+        let selection = select_provider(
+            Some("anthropic"),
+            &[("openai", "gpt-4o-mini"), ("anthropic", "claude-sonnet")],
+        );
+
+        assert_eq!(selection.provider_id, "anthropic");
+        assert_eq!(selection.model, "claude-sonnet");
+    }
+
+    #[test]
+    fn select_provider_falls_back_when_preferred_missing() {
+        let selection = select_provider(
+            Some("xai"),
+            &[("openai", "gpt-4o-mini"), ("anthropic", "claude-sonnet")],
+        );
+
+        assert_eq!(selection.provider_id, "openai");
+        assert_eq!(selection.model, "gpt-4o-mini");
+    }
+
+    #[test]
+    fn select_provider_uses_default_when_fallback_empty() {
+        let selection = select_provider(None, &[]);
+
+        assert_eq!(selection.provider_id, "openai");
+        assert_eq!(selection.model, "gpt-4o-mini");
+    }
+}

--- a/rust/crates/kcmt-core/src/workflow/scheduler.rs
+++ b/rust/crates/kcmt-core/src/workflow/scheduler.rs
@@ -13,3 +13,58 @@ pub fn chunk_work(items: Vec<WorkItem>, workers: usize) -> Vec<Vec<WorkItem>> {
     }
     buckets
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{chunk_work, WorkItem};
+
+    fn ids(buckets: &[Vec<WorkItem>]) -> Vec<Vec<String>> {
+        buckets
+            .iter()
+            .map(|bucket| bucket.iter().map(|item| item.id.clone()).collect())
+            .collect()
+    }
+
+    #[test]
+    fn chunk_work_uses_one_bucket_when_workers_zero() {
+        let buckets = chunk_work(
+            vec![WorkItem { id: "a".into() }, WorkItem { id: "b".into() }],
+            0,
+        );
+
+        assert_eq!(ids(&buckets), vec![vec!["a".to_string(), "b".to_string()]]);
+    }
+
+    #[test]
+    fn chunk_work_distributes_round_robin_across_workers() {
+        let buckets = chunk_work(
+            vec![
+                WorkItem { id: "a".into() },
+                WorkItem { id: "b".into() },
+                WorkItem { id: "c".into() },
+                WorkItem { id: "d".into() },
+                WorkItem { id: "e".into() },
+            ],
+            3,
+        );
+
+        assert_eq!(
+            ids(&buckets),
+            vec![
+                vec!["a".to_string(), "d".to_string()],
+                vec!["b".to_string(), "e".to_string()],
+                vec!["c".to_string()],
+            ]
+        );
+    }
+
+    #[test]
+    fn chunk_work_preserves_empty_extra_buckets() {
+        let buckets = chunk_work(vec![WorkItem { id: "only".into() }], 3);
+
+        assert_eq!(
+            ids(&buckets),
+            vec![vec!["only".to_string()], vec![], vec![]]
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- add focused Rust unit coverage for `kcmt-core` git primitives in `commit_file.rs`, `repo.rs`, and `runner.rs`
- add focused Rust unit coverage for `kcmt-core` workflow primitives in `atomic_failure_recovery.rs`, `changeset.rs`, `commit_flow.rs`, `provider_dispatch.rs`, and `scheduler.rs`
- keep scope on no-intended-behavior-change coverage work in core git/workflow paths only

## Conventional Commit Breakdown
| Type | Scope | Summary |
| --- | --- | --- |
| `test` | `kcmt-core` | expand rust git workflow coverage |

## Release Notes Draft
- Increase Rust-side regression coverage for `kcmt-core` git and workflow helpers without changing intended runtime behavior.

## Behaviour Changes
- No intended user-visible behavior changes.
- Added regression coverage around git porcelain parsing, commit metadata lookup, runner failures, scheduling, provider fallback, and rollback handling.

## API / Schema / Contract Changes
- None.

## Testing Evidence
- `cargo test --manifest-path rust/Cargo.toml -p kcmt-core --lib -- --nocapture`
- `make quality-gates`
- `uv run coverage report` -> `TOTAL 147 10 93%`

## Risk and Rollback
- Risk is low because the diff is test-only in the targeted `kcmt-core` modules.
- Rollback is a straight revert of commit `d86309b`.

## Operational Notes
- `make quality-gates` emits existing Black parser warnings on Python 3.12 vs Python 3.14-formatted code, but the gate completed successfully.
- Rust test output includes `fatal: mixed reset is not allowed in a bare repository` from the negative rollback coverage case; the test expects the command failure path and still passes.

## Linked Work
- Not provided.

## Reviewer Checklist
- Confirm scope is limited to `rust/crates/kcmt-core/src/git/*` and `rust/crates/kcmt-core/src/workflow/*` test coverage.
- Confirm no production behavior changes were introduced.
- Confirm `make quality-gates` evidence is sufficient for merge.
