### PR TITLE
docs(homebrew): add kcmt-homebrew tap scaffold

### DIFF
--- a/docs/homebrew.md
+++ b/docs/homebrew.md
@@ -5,7 +5,7 @@ kcmt should be registered as a third-party Homebrew tap, not as a binary blob in
 
 ## Recommended shape
 
-- Create a dedicated tap repository, for example `homebrew-kcmt`.
+- Create a dedicated tap repository, for example `kcmt-homebrew`.
 - Add a `Formula/kcmt.rb` formula named `kcmt`.
 - Point the formula at a tagged release source archive or GitHub release asset.
 - Keep releases semver-tagged as `vX.Y.Z`.
@@ -26,7 +26,7 @@ kcmt should be registered as a third-party Homebrew tap, not as a binary blob in
 
 1. A Homebrew formula that builds the CLI from source with Cargo, or a bottle
    strategy if prebuilt binaries are required later.
-2. A tap repository with `brew tap djh00t/kcmt` style installation docs.
+2. A tap repository with `brew tap djh00t/kcmt-homebrew` style installation docs.
 3. `brew audit --new-formula` validation before publishing the tap.
 4. If bottles are introduced later, platform-specific checksums and bottle
    publication steps.
@@ -36,9 +36,18 @@ kcmt should be registered as a third-party Homebrew tap, not as a binary blob in
 For a CLI tool, the normal user-facing path is:
 
 ```sh
-brew tap djh00t/kcmt
+brew tap djh00t/kcmt-homebrew
 brew install kcmt
 ```
 
 That keeps the release flow conventional and avoids trying to force a binary-only
 package into `homebrew/core`.
+
+## Tap scaffold in this repo
+
+This repository now carries a `kcmt-homebrew/` scaffold with:
+
+- `kcmt-homebrew/Formula/kcmt.rb`
+
+The scaffold is the starting point for the real tap repository and keeps the
+Homebrew packaging contract aligned with the Rust release flow.

--- a/kcmt-homebrew/Formula/kcmt.rb
+++ b/kcmt-homebrew/Formula/kcmt.rb
@@ -1,0 +1,24 @@
+class Kcmt < Formula
+  desc "Rust CLI for generating conventional commits"
+  homepage "https://github.com/djh00t/kcmt"
+  version "0.3.2"
+  url "https://github.com/djh00t/kcmt/archive/refs/tags/v#{version}.tar.gz"
+  sha256 "REPLACE_WITH_RELEASE_TARBALL_SHA256"
+  license "MIT"
+
+  depends_on "rust" => :build
+
+  def install
+    system(
+      "cargo", "build", "--locked", "--release",
+      "--manifest-path", "rust/Cargo.toml", "-p", "kcmt-cli"
+    )
+    bin.install "rust/target/release/kcmt"
+    bin.install "rust/target/release/commit"
+    bin.install "rust/target/release/kc"
+  end
+
+  test do
+    assert_match "Usage:", shell_output("#{bin}/kcmt --help")
+  end
+end


### PR DESCRIPTION
## Summary

Add a `kcmt-homebrew` tap scaffold and update the packaging guidance so the repo points at the correct tap name.

## Conventional Commit Breakdown

| Commit | Scope | Summary |
|---|---|---|
| `docs(homebrew): rename tap guidance to kcmt-homebrew` | `homebrew` | Update the packaging guide to use the `kcmt-homebrew` tap name and installation path. |
| `build(homebrew): add kcmt formula scaffold` | `homebrew` | Add a Homebrew formula skeleton that builds the Rust CLI from the tagged release source tree. |

## Release Notes Draft

- Homebrew packaging docs now point at `kcmt-homebrew`.
- A `kcmt-homebrew/Formula/kcmt.rb` scaffold exists in the repo.
- The formula builds the Rust CLI binaries from the release source tree.

## Behaviour Changes

- None at runtime.
- This is packaging and documentation only.

## API / Schema / Contract Changes

- None.

## Testing Evidence

- `ruby -c kcmt-homebrew/Formula/kcmt.rb`
- `git diff --check`

## Risk and Rollback

- Low risk: the changes are doc and packaging scaffold only.
- Roll back by reverting the two Homebrew-related commits.

## Operational Notes

- The formula still needs a real release tarball checksum from a tagged Rust release before it can be published.
- `brew audit --new-formula` remains a required step before tap publication.

## Linked Work

- Follows the Rust-first README update and the merged migration/release work.

## Reviewer Checklist

- [x] Tap name uses `kcmt-homebrew`
- [x] Formula scaffold builds the Rust CLI binaries
- [x] Documentation matches the tap name and install path
- [x] Syntax and diff hygiene checks passed
