### PR TITLE
build(homebrew): pin kcmt release archive checksum

### DIFF
--- a/kcmt-homebrew/Formula/kcmt.rb
+++ b/kcmt-homebrew/Formula/kcmt.rb
@@ -3,7 +3,7 @@ class Kcmt < Formula
   homepage "https://github.com/djh00t/kcmt"
   version "0.3.2"
   url "https://github.com/djh00t/kcmt/archive/refs/tags/v#{version}.tar.gz"
-  sha256 "REPLACE_WITH_RELEASE_TARBALL_SHA256"
+  sha256 "1fa8338b016e839e3c1f1a02805e186986bba75c0dcb535b06137be0c71d205a"
   license "MIT"
 
   depends_on "rust" => :build


### PR DESCRIPTION
## Summary

Pins the `kcmt-homebrew` formula to the actual `v0.3.2` release archive checksum so the tap scaffold is publishable instead of containing a placeholder value.

## Conventional Commit Breakdown

| Commit | Scope | What changed | Why |
|---|---|---|---|
| `build(homebrew): pin kcmt release archive checksum` | `homebrew` | Replaced the placeholder SHA256 in `kcmt-homebrew/Formula/kcmt.rb` with the `v0.3.2` release archive checksum. | Makes the Homebrew tap scaffold auditable and ready for release publication. |

## Release Notes Draft

- The `kcmt-homebrew` tap scaffold now points at the real `v0.3.2` source archive checksum.
- The formula remains source-built from Cargo and installs the Rust binaries `kcmt`, `commit`, and `kc`.
- This keeps the Homebrew packaging flow aligned with the Rust release process already documented in the repo.

## Behaviour Changes

- Homebrew installs now validate against the actual archive checksum for `v0.3.2`.
- No CLI runtime behaviour changes.

## API / Schema / Contract Changes

- None.

## Testing Evidence

- `make check`
- `ruby -c kcmt-homebrew/Formula/kcmt.rb`
- `brew audit --new --strict --tap djh00t/kcmt-homebrew kcmt`

## Coverage Evidence

- Included in `make check`.
- Rust unit and integration coverage passed.
- Python test suite passed.
- Ink UI tests passed.

## Quality Gate Evidence

- `make check` passed cleanly.
- `brew audit` passed when run against the tap-qualified formula name.

## Demo Evidence

- Not provided.

## Versioning / SemVer Impact

- None.
- This is release packaging for an existing Rust tag, not a new product version.

## Risk and Rollback

- Low risk: the change is limited to a single formula checksum.
- Rollback is straightforward: revert this commit and restore the placeholder or replace it with a corrected archive checksum if a release archive changes.

## Operational Notes

- The repo now carries a `kcmt-homebrew/` tap scaffold.
- The tap still needs repository publication and final release workflow wiring outside this PR.

## Linked Work

- `docs/homebrew.md`
- `kcmt-homebrew/Formula/kcmt.rb`
- `.github/workflows/release-notes.yml`

## Reviewer Checklist

- [ ] Confirm the checksum matches the intended `v0.3.2` release archive.
- [ ] Confirm the formula remains source-built from Cargo.
- [ ] Confirm the tap naming stays `kcmt-homebrew` end to end.
- [ ] Confirm the validation commands listed above are sufficient for merge.
