### PR TITLE
build(homebrew): wire tap sync into release flow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install install-python install-dev format ruff-fix lint test test-ink test-rust test-llm-matrix test-verbose test-strict coverage check quality-gates typecheck clean clean-build clean-cache clean-pyc clean-test build version bump-patch bump-minor bump-major release release-test publish dev-setup dev-check quick-patch quick-minor quick-major
+.PHONY: help install install-python install-dev format ruff-fix lint test test-ink test-rust test-llm-matrix test-verbose test-strict coverage check quality-gates typecheck clean clean-build clean-cache clean-pyc clean-test build version bump-patch bump-minor bump-major release release-test homebrew-sync publish dev-setup dev-check quick-patch quick-minor quick-major
 # Default target
 help:
 	@echo "Available targets:"
@@ -27,6 +27,7 @@ help:
 	@echo "  bump-major    Bump major version (X.0.0)"
 	@echo "  release-test  Build release artifacts locally"
 	@echo "  release       Tag and push a semver release"
+	@echo "  homebrew-sync Update the kcmt-homebrew formula from release checksums"
 	@echo "  publish       Alias for release"
 
 # Variables
@@ -37,6 +38,8 @@ UV = uv
 RUST_MANIFEST = rust/Cargo.toml
 RUST_BIN_DIR = rust/target/release
 RUST_DIST_DIR = dist
+HOMEBREW_TAP_REPO ?= ../kcmt-homebrew
+HOMEBREW_FORMULA = Formula/kcmt.rb
 PYTEST = $(UV) run pytest
 TEST_ENV = KCMT_DISABLE_KEYCHAIN=1
 PYPI_TOKEN ?=
@@ -174,6 +177,8 @@ build: clean
 	[ -f README.md ] && cp README.md "$$archive_dir"/ || true; \
 	[ -f LICENSE ] && cp LICENSE "$$archive_dir"/ || true; \
 	tar -C $(RUST_DIST_DIR) -czf "$(RUST_DIST_DIR)/kcmt-$(VERSION)-$$(uname -s | tr '[:upper:]' '[:lower:]')-$$(uname -m).tar.gz" "kcmt-$(VERSION)-$$(uname -s | tr '[:upper:]' '[:lower:]')-$$(uname -m)"; \
+	git archive --format=tar.gz --prefix="kcmt-$(VERSION)/" HEAD -o "$(RUST_DIST_DIR)/kcmt-$(VERSION)-source.tar.gz"; \
+	sha256sum "$(RUST_DIST_DIR)/kcmt-$(VERSION)-$$(uname -s | tr '[:upper:]' '[:lower:]')-$$(uname -m).tar.gz" "$(RUST_DIST_DIR)/kcmt-$(VERSION)-source.tar.gz" > "$(RUST_DIST_DIR)/SHA256SUMS"; \
 	rm -rf "$$archive_dir"
 
 # Release
@@ -185,6 +190,20 @@ release: build
 	@git tag -a v$(VERSION) -m "Release v$(VERSION)"
 	@git push origin v$(VERSION)
 	@echo "Pushed release tag v$(VERSION)"
+	@$(MAKE) homebrew-sync
+
+homebrew-sync:
+	@test -f "$(RUST_DIST_DIR)/SHA256SUMS" || (echo "Run make build or make release-test first." && exit 1)
+	@test -d "$(HOMEBREW_TAP_REPO)/.git" || (echo "Set HOMEBREW_TAP_REPO to a cloned kcmt-homebrew repo." && exit 1)
+	@echo "Syncing kcmt-homebrew formula from $(RUST_DIST_DIR)/SHA256SUMS..."
+	$(PYTHON) scripts/sync_homebrew_formula.py --tap-repo "$(HOMEBREW_TAP_REPO)" --version "$(VERSION)" --sums-file "$(RUST_DIST_DIR)/SHA256SUMS"
+	@if git -C "$(HOMEBREW_TAP_REPO)" diff --quiet -- "$(HOMEBREW_FORMULA)"; then \
+		echo "kcmt-homebrew formula already up to date."; \
+	else \
+		git -C "$(HOMEBREW_TAP_REPO)" add "$(HOMEBREW_FORMULA)"; \
+		git -C "$(HOMEBREW_TAP_REPO)" commit -m "build(homebrew): update kcmt formula for v$(VERSION)"; \
+		git -C "$(HOMEBREW_TAP_REPO)" push origin HEAD; \
+	fi
 
 publish: release
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Snapshots are saved under
 ## Homebrew
 
 See [docs/homebrew.md](docs/homebrew.md) for the current Homebrew packaging
-shape, release requirements, and tap guidance.
+shape, release requirements, tap repo, and release sync flow.
 
 ## Release
 

--- a/docs/homebrew.md
+++ b/docs/homebrew.md
@@ -5,11 +5,11 @@ kcmt should be registered as a third-party Homebrew tap, not as a binary blob in
 
 ## Recommended shape
 
-- Create a dedicated tap repository, for example `kcmt-homebrew`.
-- Add a `Formula/kcmt.rb` formula named `kcmt`.
-- Point the formula at a tagged release source archive or GitHub release asset.
-- Keep releases semver-tagged as `vX.Y.Z`.
-- Publish release notes on the GitHub release so the tap points at a stable tag.
+- The dedicated tap repository is `djh00t/kcmt-homebrew`.
+- The tap exposes a `Formula/kcmt.rb` formula named `kcmt`.
+- The formula points at a tagged release source archive from `djh00t/kcmt`.
+- Releases stay semver-tagged as `vX.Y.Z`.
+- Release notes live on the GitHub release so the tap points at a stable tag.
 
 ## What this repo now provides
 
@@ -21,14 +21,14 @@ kcmt should be registered as a third-party Homebrew tap, not as a binary blob in
   - a compiled Rust binary archive for the runner platform
   - a source archive for formula builds or tap review
   - SHA256 checksums for the archives
+- `make homebrew-sync` updates and publishes the tap formula from the current
+  release checksums when a `kcmt-homebrew` checkout is present.
 
 ## What the tap still needs
 
-1. A Homebrew formula that builds the CLI from source with Cargo, or a bottle
-   strategy if prebuilt binaries are required later.
-2. A tap repository with `brew tap djh00t/kcmt-homebrew` style installation docs.
-3. `brew audit --new-formula` validation before publishing the tap.
-4. If bottles are introduced later, platform-specific checksums and bottle
+1. A bottle strategy if prebuilt binaries are required later.
+2. `brew audit --new --strict` validation before publishing formula changes.
+3. If bottles are introduced later, platform-specific checksums and bottle
    publication steps.
 
 ## Practical install path
@@ -50,4 +50,5 @@ This repository now carries a `kcmt-homebrew/` scaffold with:
 - `kcmt-homebrew/Formula/kcmt.rb`
 
 The scaffold is the starting point for the real tap repository and keeps the
-Homebrew packaging contract aligned with the Rust release flow.
+Homebrew packaging contract aligned with the Rust release flow. The published
+tap lives at `https://github.com/djh00t/kcmt-homebrew`.

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Helper scripts used by release and validation workflows."""

--- a/scripts/sync_homebrew_formula.py
+++ b/scripts/sync_homebrew_formula.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Sync the kcmt Homebrew formula from release checksums."
+    )
+    parser.add_argument("--tap-repo", required=True, help="Path to the kcmt-homebrew repo")
+    parser.add_argument("--version", required=True, help="Release version without the v prefix")
+    parser.add_argument("--sums-file", required=True, help="Path to dist/SHA256SUMS")
+    return parser.parse_args()
+
+
+def _load_source_checksum(sums_file: Path, version: str) -> str:
+    target_name = f"kcmt-{version}-source.tar.gz"
+    for line in sums_file.read_text(encoding="utf-8").splitlines():
+        parts = line.split()
+        if len(parts) >= 2 and parts[1].endswith(target_name):
+            return parts[0]
+    raise SystemExit(f"Could not find checksum for {target_name} in {sums_file}")
+
+
+def _replace(pattern: str, replacement: str, text: str, label: str) -> str:
+    updated, count = re.subn(pattern, replacement, text, count=1, flags=re.MULTILINE)
+    if count != 1:
+        raise SystemExit(f"Could not update {label} in kcmt formula")
+    return updated
+
+
+def sync_formula(tap_repo: Path, version: str, sums_file: Path) -> Path:
+    formula_path = tap_repo / "Formula" / "kcmt.rb"
+
+    if not formula_path.exists():
+        raise SystemExit(f"Missing formula file: {formula_path}")
+    if not sums_file.exists():
+        raise SystemExit(f"Missing checksum file: {sums_file}")
+
+    source_sha256 = _load_source_checksum(sums_file, version)
+    formula = formula_path.read_text(encoding="utf-8")
+
+    formula = _replace(
+        r'^  version "([^"]+)"$',
+        f'  version "{version}"',
+        formula,
+        "version",
+    )
+    formula = _replace(
+        r'^  sha256 "([^"]+)"$',
+        f'  sha256 "{source_sha256}"',
+        formula,
+        "sha256",
+    )
+
+    formula_path.write_text(formula, encoding="utf-8")
+    return formula_path
+
+
+def main() -> int:
+    args = _parse_args()
+    tap_repo = Path(args.tap_repo)
+    sums_file = Path(args.sums_file)
+    formula_path = sync_formula(tap_repo, args.version, sums_file)
+    source_sha256 = _load_source_checksum(sums_file, args.version)
+    print(f"Updated {formula_path} for v{args.version} ({source_sha256})")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/features/homebrew_release.feature
+++ b/tests/features/homebrew_release.feature
@@ -1,0 +1,9 @@
+Feature: Homebrew release sync
+  The release helper refreshes the tap formula from the latest release checksum.
+
+  Scenario: Syncing the tap formula updates the version and checksum
+    Given a placeholder kcmt-homebrew formula
+    And a release checksum file for version 0.3.2
+    When the Homebrew sync helper updates the formula for version 0.3.2
+    Then the formula version is updated to 0.3.2
+    And the formula checksum is updated from the release checksums

--- a/tests/test_homebrew_release_bdd.py
+++ b/tests/test_homebrew_release_bdd.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+from typing import Any
+
+from pytest_bdd import given, scenarios, then, when
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[1] / "scripts" / "sync_homebrew_formula.py"
+)
+SCRIPT_SPEC = spec_from_file_location("sync_homebrew_formula", SCRIPT_PATH)
+assert SCRIPT_SPEC is not None and SCRIPT_SPEC.loader is not None
+SCRIPT_MODULE = module_from_spec(SCRIPT_SPEC)
+SCRIPT_SPEC.loader.exec_module(SCRIPT_MODULE)
+sync_formula = SCRIPT_MODULE.sync_formula
+
+scenarios("features/homebrew_release.feature")
+
+RELEASE_VERSION = "0.3.2"
+RELEASE_CHECKSUM = "1fa8338b016e839e3c1f1a02805e186986bba75c0dcb535b06137be0c71d205a"
+
+
+@given("a placeholder kcmt-homebrew formula", target_fixture="homebrew_context")
+def placeholder_homebrew_formula(tmp_path: Path) -> dict[str, Path]:
+    tap_repo = tmp_path / "kcmt-homebrew"
+    formula_dir = tap_repo / "Formula"
+    formula_dir.mkdir(parents=True)
+    (formula_dir / "kcmt.rb").write_text(
+        """class Kcmt < Formula
+  desc "Rust CLI for generating conventional commits"
+  homepage "https://github.com/djh00t/kcmt"
+  version "0.3.1"
+  url "https://github.com/djh00t/kcmt/archive/refs/tags/v#{version}.tar.gz"
+  sha256 "placeholder"
+  license "MIT"
+end
+""",
+        encoding="utf-8",
+    )
+    return {"tap_repo": tap_repo, "sums_file": tmp_path / "dist" / "SHA256SUMS"}
+
+
+@given("a release checksum file for version 0.3.2")
+def release_checksum_file(homebrew_context: dict[str, Path]) -> dict[str, Path]:
+    sums_file = homebrew_context["sums_file"]
+    sums_file.parent.mkdir(parents=True, exist_ok=True)
+    sums_file.write_text(
+        f"{RELEASE_CHECKSUM}  dist/kcmt-{RELEASE_VERSION}-source.tar.gz\n",
+        encoding="utf-8",
+    )
+    return homebrew_context
+
+
+@when("the Homebrew sync helper updates the formula for version 0.3.2")
+def sync_homebrew_formula(homebrew_context: dict[str, Path]) -> dict[str, Any]:
+    formula_path = sync_formula(
+        homebrew_context["tap_repo"],
+        RELEASE_VERSION,
+        homebrew_context["sums_file"],
+    )
+    homebrew_context["formula_path"] = formula_path
+    return homebrew_context
+
+
+@then("the formula version is updated to 0.3.2")
+def formula_version_is_updated(homebrew_context: dict[str, Any]) -> None:
+    formula_text = Path(homebrew_context["formula_path"]).read_text(encoding="utf-8")
+    assert f'version "{RELEASE_VERSION}"' in formula_text
+
+
+@then("the formula checksum is updated from the release checksums")
+def formula_checksum_is_updated(homebrew_context: dict[str, Any]) -> None:
+    formula_text = Path(homebrew_context["formula_path"]).read_text(encoding="utf-8")
+    assert f'sha256 "{RELEASE_CHECKSUM}"' in formula_text


### PR DESCRIPTION
## Summary

Wires the Rust release flow to produce the source checksum required by Homebrew, updates the tap formula from those release artifacts, and documents the published `kcmt-homebrew` install path.

## Conventional Commit Breakdown

| Commit | Scope | What changed | Why |
|---|---|---|---|
| `build(homebrew): wire tap sync into release flow` | `homebrew` | Added release artifact generation for source archives and checksums, a tap sync helper, BDD coverage, and docs updates. | Makes `make release` and the Homebrew tap refresh use the same release evidence. |

## Release Notes Draft

- The Rust release build now emits the source archive and `SHA256SUMS` needed by the Homebrew tap.
- `make release` now syncs the `kcmt-homebrew` formula from the generated release checksum file.
- The published tap lives at `djh00t/kcmt-homebrew` and installs with `brew tap djh00t/kcmt-homebrew && brew install kcmt`.

## Behaviour Changes

- `make build` now emits `dist/kcmt-<version>-source.tar.gz` and `dist/SHA256SUMS` alongside the binary archive.
- `make release` now updates and publishes the formula in the sibling `kcmt-homebrew` checkout.
- Homebrew publishing now uses the same release checksum file that GitHub release notes generation uses.

## API / Schema / Contract Changes

- None.

## Testing Evidence

- `make check`
- `make release-test`
- `make homebrew-sync`
- `ruby -c Formula/kcmt.rb` in the published `kcmt-homebrew` repo
- `brew audit --new --strict --tap djh00t/kcmt-homebrew kcmt` in the published `kcmt-homebrew` repo

## Coverage Evidence

- Included in `make check`.
- The new BDD scenario `tests/features/homebrew_release.feature` passed.
- The existing Rust parity and Python test suites passed.

## Quality Gate Evidence

- `make check` passed cleanly on the final file set.
- `brew audit --new --strict --tap djh00t/kcmt-homebrew kcmt` passed on the published tap repo.

## Demo Evidence

- Not provided.

## Versioning / SemVer Impact

- None.
- This change affects release plumbing and tap publishing, not the CLI contract.

## Risk and Rollback

- Low risk: the commit is limited to release packaging, tap sync automation, docs, and tests.
- Rollback is straightforward: revert this commit and revert the tap repo commit `734cf30` if needed.

## Operational Notes

- The tap repo has been published separately as `https://github.com/djh00t/kcmt-homebrew`.
- Release operators should keep a sibling clone of that repo available when running `make release` so the sync step can publish the checksum update.
- The formula remains source-built from the tagged Rust release archive.

## Linked Work

- `docs/homebrew.md`
- `scripts/sync_homebrew_formula.py`
- `tests/test_homebrew_release_bdd.py`
- `https://github.com/djh00t/kcmt-homebrew`

## Reviewer Checklist

- [ ] Confirm `make build` now produces the source archive and checksum file.
- [ ] Confirm `make release` updates the tap formula from `dist/SHA256SUMS`.
- [ ] Confirm the published `kcmt-homebrew` repo still audits cleanly.
- [ ] Confirm the new BDD coverage matches the release-sync helper behavior.
