### PR TITLE
ci(workflow): add dependency advisor scan

### DIFF
--- a/.github/workflows/dependency-advisor.yml
+++ b/.github/workflows/dependency-advisor.yml
@@ -1,0 +1,50 @@
+name: Dependency Advisor Scan
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  scan:
+    if: github.event_name != 'push' || !contains(github.event.head_commit.message, '[skip ci]')
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - id: depadvisor
+        name: Run Dependency Advisor scan
+        uses: djh00t/dependency-advisor-action@v0.0.2-action-test
+        with:
+          path: ${{ github.workspace }}
+          policy: standard
+          fail-on-findings: "false"
+          json-output: ${{ runner.temp }}/dependency-advisor/dependency-advisor.json
+          sarif-output: ${{ runner.temp }}/dependency-advisor/dependency-advisor.sarif
+          markdown-output: ${{ runner.temp }}/dependency-advisor/dependency-advisor.md
+
+      - name: Upload SARIF to code scanning
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && !github.event.repository.private
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: ${{ steps.depadvisor.outputs.sarif_output }}
+
+      - name: Upload dependency advisor reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: dependency-advisor-reports
+          path: |
+            ${{ steps.depadvisor.outputs.json_output }}
+            ${{ steps.depadvisor.outputs.sarif_output }}
+            ${{ steps.depadvisor.outputs.markdown_output }}
+          if-no-files-found: error

--- a/tests/features/dependency_advisor_workflow.feature
+++ b/tests/features/dependency_advisor_workflow.feature
@@ -1,0 +1,9 @@
+Feature: Dependency Advisor workflow
+  The repo installs the Dependency Advisor scan as a CI signal.
+
+  Scenario: The workflow uses the published dependency advisor action
+    Given the dependency advisor workflow file
+    When I inspect the workflow configuration
+    Then it uses the published dependency advisor action
+    And it scans the repository root
+    And it uploads dependency advisor reports

--- a/tests/test_dependency_advisor_workflow_bdd.py
+++ b/tests/test_dependency_advisor_workflow_bdd.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from pytest_bdd import given, scenarios, then, when
+
+WORKFLOW_PATH = (
+    Path(__file__).resolve().parents[1] / ".github/workflows/dependency-advisor.yml"
+)
+
+scenarios("features/dependency_advisor_workflow.feature")
+
+
+@given("the dependency advisor workflow file", target_fixture="workflow_text")
+def dependency_advisor_workflow_file() -> str:
+    return WORKFLOW_PATH.read_text(encoding="utf-8")
+
+
+@when("I inspect the workflow configuration", target_fixture="workflow_text")
+def inspect_workflow(workflow_text: str) -> str:
+    return workflow_text
+
+
+@then("it uses the published dependency advisor action")
+def uses_published_dependency_advisor_action(workflow_text: str) -> None:
+    assert "uses: djh00t/dependency-advisor-action@v0.0.2-action-test" in workflow_text
+
+
+@then("it scans the repository root")
+def scans_repository_root(workflow_text: str) -> None:
+    assert "path: ${{ github.workspace }}" in workflow_text
+    assert 'fail-on-findings: "false"' in workflow_text
+
+
+@then("it uploads dependency advisor reports")
+def uploads_dependency_advisor_reports(workflow_text: str) -> None:
+    assert "Upload SARIF to code scanning" in workflow_text
+    assert "Upload dependency advisor reports" in workflow_text


### PR DESCRIPTION
## Summary
Install a Dependency Advisor GitHub Actions workflow directly in `kcmt` so pull requests and main-branch pushes can publish scan reports from the repository root.

## Conventional Commit Breakdown
| Commit | Scope | Summary |
| --- | --- | --- |
| `ci(workflow): add dependency advisor scan` | workflow | Adds the repo-local Dependency Advisor workflow plus BDD coverage for the workflow contract. |

## Release Notes Draft
- `kcmt` now includes a Dependency Advisor scan workflow.
- The workflow scans the repository root and uploads JSON, SARIF, and Markdown reports.
- The workflow is report-only for findings for now, so it can be introduced without blocking existing CI.

## Behaviour Changes
- Pull requests and pushes to `main` now trigger the Dependency Advisor scan workflow.
- The workflow publishes scan outputs and code-scanning artifacts.

## API / Schema / Contract Changes
- None.

## Testing Evidence
- `make check`
- `make quality-gates`

## Risk and Rollback
- Low risk: this adds a new workflow and a small BDD contract check.
- Roll back by reverting the workflow and test files.

## Operational Notes
- The workflow pins the published `djh00t/dependency-advisor-action` release tag currently available in the action repo.
- SARIF upload runs on public main-branch pushes.

## Linked Work
- Published action repo: `djh00t/dependency-advisor-action`
- This repository: `djh00t/kcmt`

## Reviewer Checklist
- [ ] The workflow targets the repo root.
- [ ] The workflow uses the published dependency-advisor action.
- [ ] The BDD scenario covers the workflow contract.
- [ ] Local checks and quality gates passed.
