### PR TITLE
docs(readme): add rust-only homebrew install

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,15 @@ as the primary surface.
 
 ## Install
 
+Install the Rust CLI with Homebrew:
+
+```sh
+brew tap djh00t/kcmt-homebrew
+brew install kcmt
+```
+
+Homebrew installs the Rust CLI binaries without the legacy Python package.
+
 Install the Rust CLI from the repo root:
 
 ```sh

--- a/tests/features/homebrew_release.feature
+++ b/tests/features/homebrew_release.feature
@@ -7,3 +7,9 @@ Feature: Homebrew release sync
     When the Homebrew sync helper updates the formula for version 0.3.2
     Then the formula version is updated to 0.3.2
     And the formula checksum is updated from the release checksums
+
+  Scenario: README install section documents Rust-only Homebrew install
+    Given the README install section
+    Then the install section includes the kcmt Homebrew tap
+    And the install section installs kcmt from Homebrew
+    And the install section states Homebrew installs the Rust CLI without the legacy Python package

--- a/tests/test_homebrew_release_bdd.py
+++ b/tests/test_homebrew_release_bdd.py
@@ -19,6 +19,7 @@ scenarios("features/homebrew_release.feature")
 
 RELEASE_VERSION = "0.3.2"
 RELEASE_CHECKSUM = "1fa8338b016e839e3c1f1a02805e186986bba75c0dcb535b06137be0c71d205a"
+README_PATH = Path(__file__).resolve().parents[1] / "README.md"
 
 
 @given("a placeholder kcmt-homebrew formula", target_fixture="homebrew_context")
@@ -73,3 +74,30 @@ def formula_version_is_updated(homebrew_context: dict[str, Any]) -> None:
 def formula_checksum_is_updated(homebrew_context: dict[str, Any]) -> None:
     formula_text = Path(homebrew_context["formula_path"]).read_text(encoding="utf-8")
     assert f'sha256 "{RELEASE_CHECKSUM}"' in formula_text
+
+
+@given("the README install section", target_fixture="readme_install_section")
+def readme_install_section() -> str:
+    readme_text = README_PATH.read_text(encoding="utf-8")
+    start = readme_text.index("## Install")
+    end = readme_text.index("## Quick start")
+    return readme_text[start:end]
+
+
+@then("the install section includes the kcmt Homebrew tap")
+def install_section_includes_homebrew_tap(readme_install_section: str) -> None:
+    assert "brew tap djh00t/kcmt-homebrew" in readme_install_section
+
+
+@then("the install section installs kcmt from Homebrew")
+def install_section_installs_kcmt_from_homebrew(readme_install_section: str) -> None:
+    assert "brew install kcmt" in readme_install_section
+
+
+@then(
+    "the install section states Homebrew installs the Rust CLI without the legacy "
+    "Python package"
+)
+def install_section_states_homebrew_is_rust_only(readme_install_section: str) -> None:
+    assert "Homebrew installs the Rust CLI" in readme_install_section
+    assert "without the legacy Python package" in readme_install_section


### PR DESCRIPTION
## Summary

Adds Homebrew install guidance to the README install section and covers it with executable BDD documentation checks.

## Conventional Commit Breakdown

| Commit | Type | Scope | Summary |
| --- | --- | --- | --- |
| `3d09e36` | `test` | `homebrew` | describe rust-only install contract |
| `e9bd9a7` | `test` | `homebrew` | assert rust-only install docs |
| `d75576a` | `docs` | `readme` | add rust-only homebrew install |

## Release Notes Draft

- Documented the Homebrew tap install path for kcmt.
- Clarified that Homebrew installs the Rust CLI binaries without the legacy Python package.

## Behaviour Changes

- README users now see `brew tap djh00t/kcmt-homebrew` and `brew install kcmt` directly in the install section.
- Legacy Python installation remains documented as a separate compatibility-only path.

## API / Schema / Contract Changes

- No API or schema changes.
- Added BDD coverage for the README Homebrew install contract.

## Testing Evidence

- `rtk uv run pytest -q --no-cov tests/test_homebrew_release_bdd.py`
  - Red phase failed before the README update because the install section did not include `brew tap djh00t/kcmt-homebrew`.
  - Green phase passed after the README update: `2 passed`.
- `rtk git fetch origin && rtk git rebase origin/main`
  - Branch was up to date with `origin/main`.
- `rtk make check`
  - Exited `0`.
  - Noted existing Black Python-version warnings and Cargo stderr line `fatal: mixed reset is not allowed in a bare repository`.
- `rtk make quality-gates`
  - Exited `0`.
  - Noted coverage warnings plus the same formatter/Cargo stderr noise.

## Risk and Rollback

- Risk is low: docs-only README change plus BDD assertions.
- Rollback by reverting the three commits in this branch.

## Operational Notes

- Homebrew install path depends on the existing `djh00t/kcmt-homebrew` tap.
- GitHub reported one low vulnerability on the default branch during push; this PR does not modify dependencies.

## Linked Work

- Not provided.

## Reviewer Checklist

- [ ] Confirm the README install ordering matches the desired user-facing install path.
- [ ] Confirm the Rust-only wording is explicit enough to distinguish Homebrew from legacy Python compatibility installs.
- [ ] Confirm BDD coverage is sufficient for this docs contract.
